### PR TITLE
Rename 'args' in lambda structs to 'params'

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -48,7 +48,7 @@ pub struct IfElse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lambda {
     pub span: Span,
-    pub args: Vec<Pattern>,
+    pub params: Vec<Pattern>,
     pub body: Box<Expr>,
     pub is_async: bool,
     pub return_type: Option<TypeAnn>,

--- a/src/codegen/d_ts.rs
+++ b/src/codegen/d_ts.rs
@@ -214,18 +214,18 @@ pub fn build_type(
         }
         // This is used to copy the names of args from the expression
         // over to the lambda's type.
-        Type::Lam(types::LamType { args, ret, .. }) => {
+        Type::Lam(types::LamType { params, ret, .. }) => {
             match expr {
                 // TODO: handle is_async
                 Some(ast::Expr::Lambda(ast::Lambda {
-                    args: expr_args, ..
+                    params: expr_params, ..
                 })) => {
-                    if args.len() != expr_args.len() {
+                    if params.len() != expr_params.len() {
                         panic!("number of args don't match")
                     } else {
-                        let params: Vec<TsFnParam> = args
+                        let params: Vec<TsFnParam> = params
                             .iter()
-                            .zip(expr_args)
+                            .zip(expr_params)
                             .map(|(inferred_type, pattern)| {
                                 let type_ann = Some(TsTypeAnn {
                                     span: DUMMY_SP,
@@ -275,7 +275,7 @@ pub fn build_type(
                     _ => panic!("mismatch"),
                 },
                 None => {
-                    let params: Vec<TsFnParam> = args
+                    let params: Vec<TsFnParam> = params
                         .iter()
                         .enumerate()
                         .map(|(i, arg)| {

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -151,7 +151,7 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
             optional: false,
         }),
         ast::Expr::Lambda(ast::Lambda {
-            args,
+            params: args,
             body,
             is_async,
             ..

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -115,11 +115,11 @@ fn unify_lams(t1: &LamType, t2: &LamType, ctx: &Context) -> Subst {
     // - subtyping
 
     // Partial application
-    if t1.args.len() < t2.args.len() {
-        let partial_args = t2.args[..t1.args.len()].to_vec();
-        let partial_ret = ctx.lam(t2.args[t1.args.len()..].to_vec(), t2.ret.clone());
+    if t1.params.len() < t2.params.len() {
+        let partial_args = t2.params[..t1.params.len()].to_vec();
+        let partial_ret = ctx.lam(t2.params[t1.params.len()..].to_vec(), t2.ret.clone());
         let mut cs: Vec<_> = t1
-            .args
+            .params
             .iter()
             .zip(&partial_args)
             .map(|(a, b)| Constraint {
@@ -130,13 +130,13 @@ fn unify_lams(t1: &LamType, t2: &LamType, ctx: &Context) -> Subst {
             types: (*t1.ret.clone(), partial_ret),
         });
         unify_many(&cs, ctx)
-    } else if t1.args.len() != t2.args.len() {
+    } else if t1.params.len() != t2.params.len() {
         panic!("Unification mismatch: arity mismatch");
     } else {
         let mut cs: Vec<_> = t1
-            .args
+            .params
             .iter()
-            .zip(&t2.args)
+            .zip(&t2.params)
             .map(|(a, b)| Constraint {
                 types: (a.clone(), b.clone()),
             })

--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -73,11 +73,11 @@ impl Context {
             frozen: false,
         })
     }
-    pub fn lam(&self, args: Vec<Type>, ret: Box<Type>) -> Type {
+    pub fn lam(&self, params: Vec<Type>, ret: Box<Type>) -> Type {
         Type::Lam(types::LamType {
             id: self.fresh_id(),
             frozen: false,
-            args,
+            params,
             ret,
         })
     }

--- a/src/infer/substitutable.rs
+++ b/src/infer/substitutable.rs
@@ -36,14 +36,14 @@ impl Substitutable for Type {
             Type::Lam(LamType {
                 id,
                 frozen,
-                args,
+                params,
                 ret,
             }) => match sub.get(id) {
                 Some(replacement) => replacement.to_owned(),
                 None => Type::Lam(LamType {
                     id: id.to_owned(),
                     frozen: frozen.to_owned(),
-                    args: args.iter().map(|arg| arg.apply(sub)).collect(),
+                    params: params.iter().map(|param| param.apply(sub)).collect(),
                     ret: Box::from(ret.apply(sub)),
                 }),
             },
@@ -92,8 +92,8 @@ impl Substitutable for Type {
     fn ftv(&self) -> HashSet<i32> {
         match self {
             Type::Var(VarType { id, .. }) => HashSet::from([id.to_owned()]),
-            Type::Lam(LamType { args, ret, .. }) => {
-                let mut result: HashSet<_> = args.iter().flat_map(|a| a.ftv()).collect();
+            Type::Lam(LamType { params, ret, .. }) => {
+                let mut result: HashSet<_> = params.iter().flat_map(|param| param.ftv()).collect();
                 result.extend(ret.ftv());
                 result
             }

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -31,7 +31,7 @@ pub fn decl_parser() -> impl Parser<char, Statement, Error = Simple<char>> {
                             span: init.span(),
                             expr: Box::from(Expr::Lambda(Lambda {
                                 span: init.span(),
-                                args: vec![pattern.clone()],
+                                params: vec![pattern.clone()],
                                 body: Box::from(init),
                                 is_async: false,
                                 return_type: None,

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -199,7 +199,7 @@ pub fn expr_parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .map_with_span(|(((is_async, args), return_type), body), span: Span| {
                 Expr::Lambda(Lambda {
                     span,
-                    args,
+                    params: args,
                     body: Box::new(body),
                     is_async: is_async.is_some(),
                     return_type,

--- a/src/parser/snapshots/crochet__parser__tests__async_await-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__async_await-2.snap
@@ -20,7 +20,7 @@ Program {
                 Lambda(
                     Lambda {
                         span: 10..34,
-                        args: [],
+                        params: [],
                         body: Await(
                             Await {
                                 span: 24..32,

--- a/src/parser/snapshots/crochet__parser__tests__async_await-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__async_await-3.snap
@@ -20,7 +20,7 @@ Program {
                 Lambda(
                     Lambda {
                         span: 10..39,
-                        args: [],
+                        params: [],
                         body: Op(
                             Op {
                                 span: 22..39,

--- a/src/parser/snapshots/crochet__parser__tests__async_await-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__async_await-4.snap
@@ -20,7 +20,7 @@ Program {
                 Lambda(
                     Lambda {
                         span: 10..33,
-                        args: [],
+                        params: [],
                         body: Await(
                             Await {
                                 span: 22..33,

--- a/src/parser/snapshots/crochet__parser__tests__async_await.snap
+++ b/src/parser/snapshots/crochet__parser__tests__async_await.snap
@@ -9,7 +9,7 @@ Program {
             expr: Lambda(
                 Lambda {
                     span: 0..14,
-                    args: [],
+                    params: [],
                     body: Lit(
                         Num(
                             Num {

--- a/src/parser/snapshots/crochet__parser__tests__declarations-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__declarations-2.snap
@@ -20,7 +20,7 @@ Program {
                 Lambda(
                     Lambda {
                         span: 8..23,
-                        args: [
+                        params: [
                             Ident(
                                 BindingIdent {
                                     span: 9..10,

--- a/src/parser/snapshots/crochet__parser__tests__declarations-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__declarations-4.snap
@@ -23,7 +23,7 @@ Program {
                         expr: Lambda(
                             Lambda {
                                 span: 12..21,
-                                args: [
+                                params: [
                                     Ident(
                                         BindingIdent {
                                             span: 8..9,
@@ -38,7 +38,7 @@ Program {
                                 body: Lambda(
                                     Lambda {
                                         span: 12..21,
-                                        args: [],
+                                        params: [],
                                         body: App(
                                             App {
                                                 span: 18..21,

--- a/src/parser/snapshots/crochet__parser__tests__function_definition-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__function_definition-2.snap
@@ -9,7 +9,7 @@ Program {
             expr: Lambda(
                 Lambda {
                     span: 0..8,
-                    args: [],
+                    params: [],
                     body: Lit(
                         Num(
                             Num {

--- a/src/parser/snapshots/crochet__parser__tests__function_definition-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__function_definition-3.snap
@@ -9,7 +9,7 @@ Program {
             expr: Lambda(
                 Lambda {
                     span: 0..14,
-                    args: [
+                    params: [
                         Ident(
                             BindingIdent {
                                 span: 1..2,

--- a/src/parser/snapshots/crochet__parser__tests__function_definition.snap
+++ b/src/parser/snapshots/crochet__parser__tests__function_definition.snap
@@ -9,7 +9,7 @@ Program {
             expr: Lambda(
                 Lambda {
                     span: 0..11,
-                    args: [
+                    params: [
                         Ident(
                             BindingIdent {
                                 span: 1..2,

--- a/src/parser/snapshots/crochet__parser__tests__type_annotations-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__type_annotations-3.snap
@@ -20,7 +20,7 @@ Program {
                 Lambda(
                     Lambda {
                         span: 10..41,
-                        args: [
+                        params: [
                             Ident(
                                 BindingIdent {
                                     span: 11..20,

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -83,10 +83,10 @@ pub fn type_parser() -> impl Parser<char, TypeAnn, Error = Simple<char>> {
         let lam = lam_params
             .then_ignore(just_with_padding("=>"))
             .then(type_ann.clone())
-            .map_with_span(|(args, ret), span| {
+            .map_with_span(|(params, ret), span| {
                 TypeAnn::Lam(LamType {
                     span,
-                    params: args,
+                    params,
                     ret: Box::from(ret),
                 })
             });

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,19 +81,19 @@ impl Hash for VarType {
 pub struct LamType {
     pub id: i32,
     pub frozen: bool,
-    pub args: Vec<Type>, // TOOD: rename this params
+    pub params: Vec<Type>, // TOOD: rename this params
     pub ret: Box<Type>,
 }
 
 impl PartialEq for LamType {
     fn eq(&self, other: &Self) -> bool {
-        self.args == other.args && self.ret == other.ret
+        self.params == other.params && self.ret == other.ret
     }
 }
 
 impl Hash for LamType {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.args.hash(state);
+        self.params.hash(state);
         self.ret.hash(state);
     }
 }
@@ -242,7 +242,7 @@ impl fmt::Display for Type {
                 let id = chars.get(id.to_owned() as usize).unwrap();
                 write!(f, "{}", id)
             }
-            Type::Lam(LamType { args, ret, .. }) => write!(f, "({}) => {}", join(args, ", "), ret),
+            Type::Lam(LamType { params, ret, .. }) => write!(f, "({}) => {}", join(params, ", "), ret),
             Type::Prim(PrimType { prim, .. }) => write!(f, "{}", prim),
             Type::Lit(LitType { lit, .. }) => write!(f, "{}", lit),
             Type::Union(UnionType { types, .. }) => write!(f, "{}", join(types, " | ")),
@@ -300,7 +300,7 @@ pub fn freeze(ty: Type) -> Type {
         }),
         Type::Lam(lam) => Type::Lam(LamType {
             frozen: true,
-            args: lam.args.into_iter().map(freeze).collect(),
+            params: lam.params.into_iter().map(freeze).collect(),
             ret: Box::from(freeze(lam.ret.as_ref().clone())),
             ..lam
         }),


### PR DESCRIPTION
`args` should be used for application/calls and `params` for lambdas/functions.