### PR TITLE
Add support for tuples

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -83,6 +83,12 @@ pub struct Await {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tuple {
+    pub span: Span,
+    pub elements: Vec<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     App(App),
     Fix(Fix),
@@ -95,6 +101,7 @@ pub enum Expr {
     Op(Op),
     Obj(Obj),
     Await(Await),
+    Tuple(Tuple),
 }
 
 impl Expr {
@@ -111,6 +118,7 @@ impl Expr {
             Expr::Op(op) => op.span.to_owned(),
             Expr::Obj(obj) => obj.span.to_owned(),
             Expr::Await(r#await) => r#await.span.to_owned(),
+            Expr::Tuple(tuple) => tuple.span.to_owned(),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -12,4 +12,4 @@ pub use jsx::*;
 pub use literal::*;
 pub use pattern::*;
 pub use span::*;
-pub use types::{TypeAnn, PrimType, LamType, LitType, TypeRef, ObjectType, TProp, UnionType};
+pub use types::{TypeAnn, PrimType, LamType, LitType, TypeRef, ObjectType, TProp, UnionType, TupleType};

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -47,6 +47,12 @@ pub struct UnionType {
     pub types: Vec<TypeAnn>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TupleType {
+    pub span: Span,
+    pub types: Vec<TypeAnn>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
     Lam(LamType),
@@ -55,4 +61,5 @@ pub enum TypeAnn {
     Object(ObjectType),
     TypeRef(TypeRef),
     Union(UnionType),
+    Tuple(TupleType),
 }

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -393,6 +393,7 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
             arg: Box::from(build_expr(expr.as_ref())),
         }),
         ast::Expr::JSXElement(elem) => Expr::JSXElement(Box::from(build_jsx_element(elem))),
+        ast::Expr::Tuple(_) => todo!(),
     }
 }
 

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -175,11 +175,28 @@ pub fn is_subtype(t1: &Type, t2: &Type) -> bool {
         ) => {
             // It's okay if t1 has extra properties, but it has to have all of t2's properties.
             props2.iter().all(|prop2| {
-                props1.iter().any(|prop1| {
-                    prop1.name == prop2.name && is_subtype(&prop1.ty, &prop2.ty)
-                })
+                props1
+                    .iter()
+                    .any(|prop1| prop1.name == prop2.name && is_subtype(&prop1.ty, &prop2.ty))
             })
-        },
+        }
+        (
+            Type::Tuple(TupleType { types: types1, .. }),
+            Type::Tuple(TupleType { types: types2, .. }),
+        ) => {
+            // It's okay if t1 has extra properties, but it has to have all of t2's properties.
+            if types1.len() < types2.len() {
+                panic!("t1 contain at least the same number of elements as t2");
+            }
+            types1
+                .iter()
+                .zip(types2.iter())
+                .all(|(t1, t2)| is_subtype(t1, t2))
+        }
+        (Type::Union(_), Type::Union(_)) => {
+            panic!("is_subtype() can't handle t1 being a union yet")
+        }
+        (_, Type::Union(UnionType { types, .. })) => types.iter().any(|t2| is_subtype(t1, t2)),
         _ => false,
     }
 }

--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -136,4 +136,11 @@ impl Context {
             type_params,
         })
     }
+    pub fn tuple(&self, types: Vec<Type>) -> Type {
+        Type::Tuple(types::TupleType {
+            id: self.fresh_id(),
+            frozen: false,
+            types,
+        })
+    }
 }

--- a/src/infer/substitutable.rs
+++ b/src/infer/substitutable.rs
@@ -87,6 +87,14 @@ impl Substitutable for Type {
                     }),
                 }),
             },
+            Type::Tuple(TupleType { id, frozen, types }) => match sub.get(id) {
+                Some(replacement) => replacement.to_owned(),
+                None => Type::Tuple(TupleType {
+                    id: id.to_owned(),
+                    frozen: frozen.to_owned(),
+                    types: types.iter().map(|ty| ty.apply(sub)).collect(),
+                }),
+            },
         }
     }
     fn ftv(&self) -> HashSet<i32> {
@@ -106,6 +114,7 @@ impl Substitutable for Type {
             Type::Alias(AliasType { type_params, .. }) => {
                 type_params.iter().flat_map(|ty| ty.ftv()).collect()
             }
+            Type::Tuple(TupleType { types, .. }) =>  types.iter().flat_map(|ty| ty.ftv()).collect(),
         }
     }
 }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -65,6 +65,12 @@ pub fn expr_parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .delimited_by(just_with_padding("{"), just_with_padding("}"))
             .map_with_span(|properties, span: Span| Expr::Obj(Obj { span, properties }));
 
+        let tuple = expr.clone()
+            .separated_by(just_with_padding(","))
+            .allow_trailing()
+            .delimited_by(just_with_padding("["), just_with_padding("]"))
+            .map_with_span(|elements, span: Span| Expr::Tuple(Tuple { span, elements }));
+
         let atom = choice((
             if_else,
             r#bool,
@@ -72,6 +78,7 @@ pub fn expr_parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             r#str,
             ident,
             obj,
+            tuple,
             jsx_parser(expr.clone().boxed()).boxed(),
             expr.clone()
                 .delimited_by(just_with_padding("("), just_with_padding(")")),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -132,4 +132,11 @@ mod tests {
         insta::assert_debug_snapshot!(parse("   let x = 5")); // with leading whitespace
         insta::assert_debug_snapshot!(parse("declare let x: number"));
     }
+
+    #[test]
+    fn tuples() {
+        insta::assert_debug_snapshot!(parse("let x = []"));
+        insta::assert_debug_snapshot!(parse("let x = [1, 2, 3]"));
+        insta::assert_debug_snapshot!(parse("let x = [1, [a, b]]"));
+    }
 }

--- a/src/parser/snapshots/crochet__parser__tests__tuples-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__tuples-2.snap
@@ -1,0 +1,55 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let x = [1, 2, 3]\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..17,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..5,
+                    id: Ident {
+                        span: 4..5,
+                        name: "x",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 8..17,
+                        elements: [
+                            Lit(
+                                Num(
+                                    Num {
+                                        span: 9..10,
+                                        value: "1",
+                                    },
+                                ),
+                            ),
+                            Lit(
+                                Num(
+                                    Num {
+                                        span: 12..13,
+                                        value: "2",
+                                    },
+                                ),
+                            ),
+                            Lit(
+                                Num(
+                                    Num {
+                                        span: 15..16,
+                                        value: "3",
+                                    },
+                                ),
+                            ),
+                        ],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__tuples-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__tuples-3.snap
@@ -1,0 +1,58 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let x = [1, [a, b]]\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..19,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..5,
+                    id: Ident {
+                        span: 4..5,
+                        name: "x",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 8..19,
+                        elements: [
+                            Lit(
+                                Num(
+                                    Num {
+                                        span: 9..10,
+                                        value: "1",
+                                    },
+                                ),
+                            ),
+                            Tuple(
+                                Tuple {
+                                    span: 12..18,
+                                    elements: [
+                                        Ident(
+                                            Ident {
+                                                span: 13..14,
+                                                name: "a",
+                                            },
+                                        ),
+                                        Ident(
+                                            Ident {
+                                                span: 16..17,
+                                                name: "b",
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__tuples.snap
+++ b/src/parser/snapshots/crochet__parser__tests__tuples.snap
@@ -1,0 +1,30 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let x = []\")"
+---
+Program {
+    body: [
+        Decl {
+            span: 0..10,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..5,
+                    id: Ident {
+                        span: 4..5,
+                        name: "x",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 8..10,
+                        elements: [],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -106,12 +106,20 @@ pub fn type_parser() -> impl Parser<char, TypeAnn, Error = Simple<char>> {
             .delimited_by(just_with_padding("{"), just_with_padding("}"))
             .map_with_span(|props, span: Span| TypeAnn::Object(ObjectType { span, props }));
 
+        let tuple = type_ann
+            .clone()
+            .separated_by(just_with_padding(","))
+            .allow_trailing()
+            .delimited_by(just_with_padding("["), just_with_padding("]"))
+            .map_with_span(|types, span: Span| TypeAnn::Tuple(TupleType { span, types }));
+
         let atom = choice((
             r#bool,
             num,
             r#str,
             prim,
             obj,
+            tuple,
             alias,
             type_ann
                 .clone()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,8 +2,8 @@ use chumsky::prelude::*;
 use std::collections::HashMap;
 
 use crochet::ast::Program;
-use crochet::infer::*;
 use crochet::codegen::*;
+use crochet::infer::*;
 use crochet::parser::parser;
 
 fn infer(input: &str) -> String {
@@ -62,10 +62,7 @@ fn infer_fn_param() {
 
 #[test]
 fn infer_fn_with_param_types() {
-    assert_eq!(
-        infer("(a: 5, b: 10) => a + b"),
-        "(5, 10) => number"
-    );
+    assert_eq!(infer("(a: 5, b: 10) => a + b"), "(5, 10) => number");
 }
 
 #[test]
@@ -247,10 +244,22 @@ fn infer_inequalities() {
     let gte = (a, b) => a >= b
     "###;
     let (_, env) = infer_prog(src);
-    assert_eq!(format!("{}", env.get("lt").unwrap()), "(number, number) => boolean");
-    assert_eq!(format!("{}", env.get("lte").unwrap()), "(number, number) => boolean");
-    assert_eq!(format!("{}", env.get("gt").unwrap()), "(number, number) => boolean");
-    assert_eq!(format!("{}", env.get("gte").unwrap()), "(number, number) => boolean");
+    assert_eq!(
+        format!("{}", env.get("lt").unwrap()),
+        "(number, number) => boolean"
+    );
+    assert_eq!(
+        format!("{}", env.get("lte").unwrap()),
+        "(number, number) => boolean"
+    );
+    assert_eq!(
+        format!("{}", env.get("gt").unwrap()),
+        "(number, number) => boolean"
+    );
+    assert_eq!(
+        format!("{}", env.get("gte").unwrap()),
+        "(number, number) => boolean"
+    );
 }
 
 #[test]
@@ -481,3 +490,57 @@ fn calling_a_fn_with_an_obj_missing_a_property() {
     infer_prog(src);
 }
 
+#[test]
+fn infer_literal_tuple() {
+    let src = r#"let tuple = [1, "two", true]"#;
+    let (_, env) = infer_prog(src);
+
+    let result = format!("{}", env.get("tuple").unwrap());
+    assert_eq!(result, "[1, \"two\", true]");
+}
+
+#[test]
+fn infer_tuple_with_type_annotation() {
+    let src = r#"let tuple: [number, string, boolean] = [1, "two", true]"#;
+    let (_, env) = infer_prog(src);
+
+    let result = format!("{}", env.get("tuple").unwrap());
+    assert_eq!(result, "[number, string, boolean]");
+}
+
+#[test]
+fn infer_tuple_with_type_annotation_and_extra_element() {
+    let src = r#"let tuple: [number, string, boolean] = [1, "two", true, "ignored"]"#;
+    let (_, env) = infer_prog(src);
+
+    let result = format!("{}", env.get("tuple").unwrap());
+    assert_eq!(result, "[number, string, boolean]");
+}
+
+#[test]
+#[should_panic = "value is not a subtype of decl's declared type"]
+fn infer_tuple_with_type_annotation_and_incorrect_element() {
+    let src = r#"let tuple: [number, string, boolean] = [1, "two", 3]"#;
+    infer_prog(src);
+}
+
+#[test]
+#[should_panic = "t1 contain at least the same number of elements as t2"]
+fn infer_tuple_with_not_enough_elements() {
+    let src = r#"let tuple: [number, string, boolean] = [1, "two"]"#;
+    infer_prog(src);
+}
+
+#[test]
+fn infer_var_with_union_type_annotation() {
+    let src = r#"
+    let a: number | string = 5
+    let b: number | string = "ten"
+    "#;
+    let (_, env) = infer_prog(src);
+
+    let a = format!("{}", env.get("a").unwrap());
+    assert_eq!(a, "number | string");
+    let b = format!("{}", env.get("b").unwrap());
+    assert_eq!(b, "number | string");
+}


### PR DESCRIPTION
This also updates `is_subtype` to handle checking tuple and union subtypes.  