### PR TITLE
Replace 'in' with ';' when using let in expressions

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -30,6 +30,12 @@ pub enum Statement {
     }, // NOTE: does not include Expr::Let
 }
 
+// #[derive(Debug, Clone, PartialEq, Eq)]
+// struct Block {
+//     pub span: Span,
+//     pub stmts: Vec<Expr>,
+// }
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct App {
     pub span: Span,

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -12,6 +12,15 @@ pub enum Pattern {
     // Assign(AssignPat),
 }
 
+impl Pattern {
+    pub fn span(&self) -> Span {
+        match self {
+            Pattern::Ident(ident) => ident.span.to_owned(),
+            Pattern::Rest(rest) => rest.span.to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BindingIdent {
     pub span: Span,

--- a/src/infer/infer.rs
+++ b/src/infer/infer.rs
@@ -664,12 +664,12 @@ mod tests {
 
     #[test]
     fn infer_let_with_type_ann() {
-        assert_eq!(parse_and_infer_expr("let x: number = 5 in x"), "number");
+        assert_eq!(parse_and_infer_expr("{let x: number = 5; x}"), "number");
     }
 
     #[test]
     #[should_panic = "unification failed"]
     fn infer_let_with_incorrect_type_ann() {
-        parse_and_infer_expr("let x: string = 5 in x");
+        parse_and_infer_expr("{let x: string = 5; x}");
     }
 }

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -15,11 +15,12 @@ pub fn just_with_padding(inputs: &str) -> Padded<Just<char, &str, Simple<char>>>
 pub fn decl_parser() -> impl Parser<char, Statement, Error = Simple<char>> {
     // We use `just` instead of `just_with_padding` here to ensure that
     // the span doesn't include leading whitespace.
+    let pattern = pattern_parser();
     let var_decl_with_init = just("declare")
         .or_not()
         .then_ignore(just_with_padding("let"))
         .then(just_with_padding("rec").or_not())
-        .then(pattern_parser())
+        .then(pattern.clone())
         .then_ignore(just_with_padding("="))
         .then(expr_parser())
         .map_with_span(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -86,7 +86,7 @@ mod tests {
     fn declarations() {
         insta::assert_debug_snapshot!(parse("let x = 5"));
         insta::assert_debug_snapshot!(parse("let x = (a, b) => a + b"));
-        insta::assert_debug_snapshot!(parse("let foo = let x = 5 in x"));
+        insta::assert_debug_snapshot!(parse("let foo = {let x = 5; x}"));
         insta::assert_debug_snapshot!(parse("let rec f = () => f()")); // recursive
     }
 
@@ -157,5 +157,13 @@ mod tests {
         insta::assert_debug_snapshot!(parse("type Num = number"));
         insta::assert_debug_snapshot!(parse("type Point = {x: number, y: number}"));
         // TODO: add support for type params
+    }
+
+    #[test]
+    fn blocks() {
+        insta::assert_debug_snapshot!(parse("let foo = {let x = 5; x}"));
+        insta::assert_debug_snapshot!(parse("let foo = {let x = 5; let y = 10; x + y}"));
+        insta::assert_debug_snapshot!(parse("{let x = 5; let y = 10; x + y}"));
+        insta::assert_debug_snapshot!(parse("{let sum = {let x = 5; let y = 10; x + y}; sum}"))
     }
 }

--- a/src/parser/pattern.rs
+++ b/src/parser/pattern.rs
@@ -5,14 +5,16 @@ use crate::parser::types::*;
 use crate::parser::util::just_with_padding;
 
 // TODO: handle destructuring of objects and arrays
-pub fn pattern_parser() -> impl Parser<char, Pattern, Error = Simple<char>> {
+pub fn pattern_parser() -> BoxedParser<'static, char, Pattern, Simple<char>> {
     let type_ann = type_parser();
 
-    text::ident()
+    let parser = text::ident()
         .map_with_span(|name, span| Ident { name, span })
         .then(just_with_padding(":").ignore_then(type_ann).or_not())
         .map_with_span(|(id, type_ann), span: Span| {
             Pattern::Ident(BindingIdent { span, id, type_ann })
         })
-        .padded()
+        .padded();
+
+    parser.boxed()
 }

--- a/src/parser/snapshots/crochet__parser__tests__blocks-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-2.snap
@@ -1,0 +1,88 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let foo = {let x = 5; let y = 10; x + y}\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..40,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..7,
+                    id: Ident {
+                        span: 4..7,
+                        name: "foo",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Let(
+                    Let {
+                        span: 15..39,
+                        pattern: Ident(
+                            BindingIdent {
+                                span: 15..16,
+                                id: Ident {
+                                    span: 15..16,
+                                    name: "x",
+                                },
+                                type_ann: None,
+                            },
+                        ),
+                        value: Lit(
+                            Num(
+                                Num {
+                                    span: 19..20,
+                                    value: "5",
+                                },
+                            ),
+                        ),
+                        body: Let(
+                            Let {
+                                span: 26..39,
+                                pattern: Ident(
+                                    BindingIdent {
+                                        span: 26..27,
+                                        id: Ident {
+                                            span: 26..27,
+                                            name: "y",
+                                        },
+                                        type_ann: None,
+                                    },
+                                ),
+                                value: Lit(
+                                    Num(
+                                        Num {
+                                            span: 30..32,
+                                            value: "10",
+                                        },
+                                    ),
+                                ),
+                                body: Op(
+                                    Op {
+                                        span: 34..39,
+                                        op: Add,
+                                        left: Ident(
+                                            Ident {
+                                                span: 34..35,
+                                                name: "x",
+                                            },
+                                        ),
+                                        right: Ident(
+                                            Ident {
+                                                span: 38..39,
+                                                name: "y",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__blocks-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-3.snap
@@ -1,0 +1,75 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"{let x = 5; let y = 10; x + y}\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..30,
+            expr: Let(
+                Let {
+                    span: 5..29,
+                    pattern: Ident(
+                        BindingIdent {
+                            span: 5..6,
+                            id: Ident {
+                                span: 5..6,
+                                name: "x",
+                            },
+                            type_ann: None,
+                        },
+                    ),
+                    value: Lit(
+                        Num(
+                            Num {
+                                span: 9..10,
+                                value: "5",
+                            },
+                        ),
+                    ),
+                    body: Let(
+                        Let {
+                            span: 16..29,
+                            pattern: Ident(
+                                BindingIdent {
+                                    span: 16..17,
+                                    id: Ident {
+                                        span: 16..17,
+                                        name: "y",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                            value: Lit(
+                                Num(
+                                    Num {
+                                        span: 20..22,
+                                        value: "10",
+                                    },
+                                ),
+                            ),
+                            body: Op(
+                                Op {
+                                    span: 24..29,
+                                    op: Add,
+                                    left: Ident(
+                                        Ident {
+                                            span: 24..25,
+                                            name: "x",
+                                        },
+                                    ),
+                                    right: Ident(
+                                        Ident {
+                                            span: 28..29,
+                                            name: "y",
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__blocks-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-4.snap
@@ -1,0 +1,96 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"{let sum = {let x = 5; let y = 10; x + y}; sum}\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..47,
+            expr: Let(
+                Let {
+                    span: 5..46,
+                    pattern: Ident(
+                        BindingIdent {
+                            span: 5..8,
+                            id: Ident {
+                                span: 5..8,
+                                name: "sum",
+                            },
+                            type_ann: None,
+                        },
+                    ),
+                    value: Let(
+                        Let {
+                            span: 16..40,
+                            pattern: Ident(
+                                BindingIdent {
+                                    span: 16..17,
+                                    id: Ident {
+                                        span: 16..17,
+                                        name: "x",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                            value: Lit(
+                                Num(
+                                    Num {
+                                        span: 20..21,
+                                        value: "5",
+                                    },
+                                ),
+                            ),
+                            body: Let(
+                                Let {
+                                    span: 27..40,
+                                    pattern: Ident(
+                                        BindingIdent {
+                                            span: 27..28,
+                                            id: Ident {
+                                                span: 27..28,
+                                                name: "y",
+                                            },
+                                            type_ann: None,
+                                        },
+                                    ),
+                                    value: Lit(
+                                        Num(
+                                            Num {
+                                                span: 31..33,
+                                                value: "10",
+                                            },
+                                        ),
+                                    ),
+                                    body: Op(
+                                        Op {
+                                            span: 35..40,
+                                            op: Add,
+                                            left: Ident(
+                                                Ident {
+                                                    span: 35..36,
+                                                    name: "x",
+                                                },
+                                            ),
+                                            right: Ident(
+                                                Ident {
+                                                    span: 39..40,
+                                                    name: "y",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                    body: Ident(
+                        Ident {
+                            span: 43..46,
+                            name: "sum",
+                        },
+                    ),
+                },
+            ),
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__blocks.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks.snap
@@ -1,0 +1,53 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let foo = {let x = 5; x}\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..24,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..7,
+                    id: Ident {
+                        span: 4..7,
+                        name: "foo",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Let(
+                    Let {
+                        span: 15..23,
+                        pattern: Ident(
+                            BindingIdent {
+                                span: 15..16,
+                                id: Ident {
+                                    span: 15..16,
+                                    name: "x",
+                                },
+                                type_ann: None,
+                            },
+                        ),
+                        value: Lit(
+                            Num(
+                                Num {
+                                    span: 19..20,
+                                    value: "5",
+                                },
+                            ),
+                        ),
+                        body: Ident(
+                            Ident {
+                                span: 22..23,
+                                name: "x",
+                            },
+                        ),
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__declarations-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__declarations-3.snap
@@ -1,6 +1,6 @@
 ---
 source: src/parser/mod.rs
-expression: "parse(\"let foo = let x = 5 in x\")"
+expression: "parse(\"let foo = {let x = 5; x}\")"
 ---
 Program {
     body: [
@@ -19,12 +19,12 @@ Program {
             init: Some(
                 Let(
                     Let {
-                        span: 10..24,
+                        span: 15..23,
                         pattern: Ident(
                             BindingIdent {
-                                span: 14..15,
+                                span: 15..16,
                                 id: Ident {
-                                    span: 14..15,
+                                    span: 15..16,
                                     name: "x",
                                 },
                                 type_ann: None,
@@ -33,14 +33,14 @@ Program {
                         value: Lit(
                             Num(
                                 Num {
-                                    span: 18..19,
+                                    span: 19..20,
                                     value: "5",
                                 },
                             ),
                         ),
                         body: Ident(
                             Ident {
-                                span: 23..24,
+                                span: 22..23,
                                 name: "x",
                             },
                         ),

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 use crate::parser::util::just_with_padding;
 use crate::types::Primitive;
 
-pub fn type_parser() -> impl Parser<char, TypeAnn, Error = Simple<char>> {
+pub fn type_parser() -> BoxedParser<'static, char, TypeAnn, Simple<char>> {
     let prim = choice((
         just("number").to(Primitive::Num),
         just("string").to(Primitive::Str),
@@ -56,7 +56,7 @@ pub fn type_parser() -> impl Parser<char, TypeAnn, Error = Simple<char>> {
             })
         });
 
-    recursive(|type_ann| {
+    let parser = recursive(|type_ann| {
         let alias_params = type_ann
             .clone()
             .separated_by(just_with_padding(","))
@@ -155,7 +155,9 @@ pub fn type_parser() -> impl Parser<char, TypeAnn, Error = Simple<char>> {
             // happens to be a union.
             lam, union, atom,
         ))
-    })
+    });
+
+    parser.boxed()
 }
 
 #[cfg(test)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -41,7 +41,7 @@ fn infer_lam() {
 
 #[test]
 fn infer_let_inside_function() {
-    assert_eq!(infer("() => let x = 5 in x"), "() => 5");
+    assert_eq!(infer("() => {let x = 5; x}"), "() => 5");
 }
 
 #[test]
@@ -813,4 +813,13 @@ fn codegen_object_type_with_optional_property() {
     };
     export declare const point: Point;
     "###);
+}
+
+#[test]
+fn infer_nested_block() {
+    let src = "let result = {let sum = {let x = 5; let y = 10; x + y}; sum}";
+    let (_, ctx) = infer_prog(src);
+
+    let result = format!("{}", ctx.values.get("result").unwrap());
+    assert_eq!(result, "number");
 }


### PR DESCRIPTION
Fixes #61.

This PR also allows blocks to be nested, e.g.
```
    let result = {
        let sum = {
            let x = 5;
            let y = 10;
            x + y
        };
        sum
    }
```