### PR TITLE
Allow multiple, non-let statements in a block

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -69,7 +69,7 @@ pub struct Lambda {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Let {
     pub span: Span,
-    pub pattern: Pattern,
+    pub pattern: Option<Pattern>,
     pub value: Box<Expr>,
     pub body: Box<Expr>,
 }

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -115,9 +115,9 @@ pub fn build_pattern(pattern: &ast::Pattern) -> Pat {
 pub fn build_return_block(body: &ast::Expr) -> BlockStmt {
     match body {
         // Avoids wrapping in an IIFE when it isn't necessary.
-        ast::Expr::Let { .. } => BlockStmt {
+        ast::Expr::Let(r#let) => BlockStmt {
             span: DUMMY_SP,
-            stmts: let_to_children(body),
+            stmts: let_to_children(r#let),
         },
         _ => BlockStmt {
             span: DUMMY_SP,
@@ -179,9 +179,9 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
 
             let body: BlockStmtOrExpr = match &body.as_ref() {
                 // TODO: Avoid wrapping in an IIFE when it isn't necessary.
-                ast::Expr::Let { .. } => BlockStmtOrExpr::BlockStmt(BlockStmt {
+                ast::Expr::Let(r#let) => BlockStmtOrExpr::BlockStmt(BlockStmt {
                     span: DUMMY_SP,
-                    stmts: let_to_children(body),
+                    stmts: let_to_children(r#let),
                 }),
                 _ => BlockStmtOrExpr::Expr(Box::from(build_expr(body))),
             };
@@ -196,14 +196,14 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
                 return_type: None,
             })
         }
-        ast::Expr::Let { .. } => {
+        ast::Expr::Let(r#let) => {
             // Return an IIFE
             let arrow = Expr::Arrow(ArrowExpr {
                 span: DUMMY_SP,
                 params: vec![],
                 body: BlockStmtOrExpr::BlockStmt(BlockStmt {
                     span: DUMMY_SP,
-                    stmts: let_to_children(expr),
+                    stmts: let_to_children(r#let),
                 }),
                 is_async: false,
                 is_generator: false,
@@ -523,17 +523,13 @@ pub fn build_lit(lit: &ast::Lit) -> Lit {
     }
 }
 
-pub fn let_to_children(expr: &ast::Expr) -> Vec<Stmt> {
-    if let ast::Expr::Let(ast::Let {
-        pattern,
-        value,
-        body,
-        ..
-    }) = expr
-    {
-        // TODO: handle shadowed variables in the same scope by introducing
-        // unique identifiers.
-        let decl = Stmt::Decl(Decl::Var(VarDecl {
+pub fn let_to_children(r#let: &ast::Let) -> Vec<Stmt> {
+    let ast::Let {pattern, value, body, ..} = r#let;
+
+    // TODO: handle shadowed variables in the same scope by introducing
+    // unique identifiers.
+    let child = match pattern {
+        Some(pattern) => Stmt::Decl(Decl::Var(VarDecl {
             span: DUMMY_SP,
             kind: VarDeclKind::Const,
             declare: false,
@@ -543,19 +539,25 @@ pub fn let_to_children(expr: &ast::Expr) -> Vec<Stmt> {
                 init: Some(Box::from(build_expr(value))),
                 definite: false,
             }],
-        }));
+        })),
+        None => Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::from(build_expr(value)),
+        }),
+    };
 
-        let mut children: Vec<Stmt> = vec![decl];
-        let mut body = body.to_owned();
+    let mut children: Vec<Stmt> = vec![child];
+    let mut body = body.to_owned();
 
-        while let ast::Expr::Let(ast::Let {
-            pattern,
-            value,
-            body: next_body,
-            ..
-        }) = body.as_ref()
-        {
-            let decl = Stmt::Decl(Decl::Var(VarDecl {
+    while let ast::Expr::Let(ast::Let {
+        pattern,
+        value,
+        body: next_body,
+        ..
+    }) = body.as_ref()
+    {
+        let child = match pattern {
+            Some(pattern) => Stmt::Decl(Decl::Var(VarDecl {
                 span: DUMMY_SP,
                 kind: VarDeclKind::Const,
                 declare: false,
@@ -565,18 +567,20 @@ pub fn let_to_children(expr: &ast::Expr) -> Vec<Stmt> {
                     init: Some(Box::from(build_expr(value))),
                     definite: false,
                 }],
-            }));
-            children.push(decl);
-            body = next_body.to_owned();
-        }
-
-        children.push(Stmt::Return(ReturnStmt {
-            span: DUMMY_SP,
-            arg: Some(Box::from(build_expr(&body))),
-        }));
-
-        children
-    } else {
-        panic!("was expecting an ast::Expr::Let")
+            })),
+            None => Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::from(build_expr(value)),
+            }),
+        };
+        children.push(child);
+        body = next_body.to_owned();
     }
+
+    children.push(Stmt::Return(ReturnStmt {
+        span: DUMMY_SP,
+        arg: Some(Box::from(build_expr(&body))),
+    }));
+
+    children
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -164,6 +164,8 @@ mod tests {
         insta::assert_debug_snapshot!(parse("let foo = {let x = 5; x}"));
         insta::assert_debug_snapshot!(parse("let foo = {let x = 5; let y = 10; x + y}"));
         insta::assert_debug_snapshot!(parse("{let x = 5; let y = 10; x + y}"));
-        insta::assert_debug_snapshot!(parse("{let sum = {let x = 5; let y = 10; x + y}; sum}"))
+        insta::assert_debug_snapshot!(parse("{let sum = {let x = 5; let y = 10; x + y}; sum}"));
+        insta::assert_debug_snapshot!(parse("let foo = {let x = 5; console.log(x); x}"));
+        insta::assert_debug_snapshot!(parse("let foo = {console.log(x); x}"));
     }
 }

--- a/src/parser/snapshots/crochet__parser__tests__blocks-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-2.snap
@@ -20,15 +20,17 @@ Program {
                 Let(
                     Let {
                         span: 15..39,
-                        pattern: Ident(
-                            BindingIdent {
-                                span: 15..16,
-                                id: Ident {
+                        pattern: Some(
+                            Ident(
+                                BindingIdent {
                                     span: 15..16,
-                                    name: "x",
+                                    id: Ident {
+                                        span: 15..16,
+                                        name: "x",
+                                    },
+                                    type_ann: None,
                                 },
-                                type_ann: None,
-                            },
+                            ),
                         ),
                         value: Lit(
                             Num(
@@ -41,15 +43,17 @@ Program {
                         body: Let(
                             Let {
                                 span: 26..39,
-                                pattern: Ident(
-                                    BindingIdent {
-                                        span: 26..27,
-                                        id: Ident {
+                                pattern: Some(
+                                    Ident(
+                                        BindingIdent {
                                             span: 26..27,
-                                            name: "y",
+                                            id: Ident {
+                                                span: 26..27,
+                                                name: "y",
+                                            },
+                                            type_ann: None,
                                         },
-                                        type_ann: None,
-                                    },
+                                    ),
                                 ),
                                 value: Lit(
                                     Num(

--- a/src/parser/snapshots/crochet__parser__tests__blocks-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-3.snap
@@ -9,15 +9,17 @@ Program {
             expr: Let(
                 Let {
                     span: 5..29,
-                    pattern: Ident(
-                        BindingIdent {
-                            span: 5..6,
-                            id: Ident {
+                    pattern: Some(
+                        Ident(
+                            BindingIdent {
                                 span: 5..6,
-                                name: "x",
+                                id: Ident {
+                                    span: 5..6,
+                                    name: "x",
+                                },
+                                type_ann: None,
                             },
-                            type_ann: None,
-                        },
+                        ),
                     ),
                     value: Lit(
                         Num(
@@ -30,15 +32,17 @@ Program {
                     body: Let(
                         Let {
                             span: 16..29,
-                            pattern: Ident(
-                                BindingIdent {
-                                    span: 16..17,
-                                    id: Ident {
+                            pattern: Some(
+                                Ident(
+                                    BindingIdent {
                                         span: 16..17,
-                                        name: "y",
+                                        id: Ident {
+                                            span: 16..17,
+                                            name: "y",
+                                        },
+                                        type_ann: None,
                                     },
-                                    type_ann: None,
-                                },
+                                ),
                             ),
                             value: Lit(
                                 Num(

--- a/src/parser/snapshots/crochet__parser__tests__blocks-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-4.snap
@@ -9,28 +9,32 @@ Program {
             expr: Let(
                 Let {
                     span: 5..46,
-                    pattern: Ident(
-                        BindingIdent {
-                            span: 5..8,
-                            id: Ident {
+                    pattern: Some(
+                        Ident(
+                            BindingIdent {
                                 span: 5..8,
-                                name: "sum",
+                                id: Ident {
+                                    span: 5..8,
+                                    name: "sum",
+                                },
+                                type_ann: None,
                             },
-                            type_ann: None,
-                        },
+                        ),
                     ),
                     value: Let(
                         Let {
                             span: 16..40,
-                            pattern: Ident(
-                                BindingIdent {
-                                    span: 16..17,
-                                    id: Ident {
+                            pattern: Some(
+                                Ident(
+                                    BindingIdent {
                                         span: 16..17,
-                                        name: "x",
+                                        id: Ident {
+                                            span: 16..17,
+                                            name: "x",
+                                        },
+                                        type_ann: None,
                                     },
-                                    type_ann: None,
-                                },
+                                ),
                             ),
                             value: Lit(
                                 Num(
@@ -43,15 +47,17 @@ Program {
                             body: Let(
                                 Let {
                                     span: 27..40,
-                                    pattern: Ident(
-                                        BindingIdent {
-                                            span: 27..28,
-                                            id: Ident {
+                                    pattern: Some(
+                                        Ident(
+                                            BindingIdent {
                                                 span: 27..28,
-                                                name: "y",
+                                                id: Ident {
+                                                    span: 27..28,
+                                                    name: "y",
+                                                },
+                                                type_ann: None,
                                             },
-                                            type_ann: None,
-                                        },
+                                        ),
                                     ),
                                     value: Lit(
                                         Num(

--- a/src/parser/snapshots/crochet__parser__tests__blocks-5.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-5.snap
@@ -1,0 +1,91 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let foo = {let x = 5; console.log(x); x}\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..40,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..7,
+                    id: Ident {
+                        span: 4..7,
+                        name: "foo",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Let(
+                    Let {
+                        span: 15..39,
+                        pattern: Some(
+                            Ident(
+                                BindingIdent {
+                                    span: 15..16,
+                                    id: Ident {
+                                        span: 15..16,
+                                        name: "x",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                        value: Lit(
+                            Num(
+                                Num {
+                                    span: 19..20,
+                                    value: "5",
+                                },
+                            ),
+                        ),
+                        body: Let(
+                            Let {
+                                span: 22..39,
+                                pattern: None,
+                                value: App(
+                                    App {
+                                        span: 22..36,
+                                        lam: Member(
+                                            Member {
+                                                span: 22..33,
+                                                obj: Ident(
+                                                    Ident {
+                                                        span: 22..29,
+                                                        name: "console",
+                                                    },
+                                                ),
+                                                prop: Ident(
+                                                    Ident {
+                                                        span: 29..33,
+                                                        name: "log",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        args: [
+                                            Ident(
+                                                Ident {
+                                                    span: 34..35,
+                                                    name: "x",
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                body: Ident(
+                                    Ident {
+                                        span: 38..39,
+                                        name: "x",
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__blocks-6.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks-6.snap
@@ -1,0 +1,66 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let foo = {console.log(x); x}\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..29,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..7,
+                    id: Ident {
+                        span: 4..7,
+                        name: "foo",
+                    },
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Let(
+                    Let {
+                        span: 11..28,
+                        pattern: None,
+                        value: App(
+                            App {
+                                span: 11..25,
+                                lam: Member(
+                                    Member {
+                                        span: 11..22,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 11..18,
+                                                name: "console",
+                                            },
+                                        ),
+                                        prop: Ident(
+                                            Ident {
+                                                span: 18..22,
+                                                name: "log",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                args: [
+                                    Ident(
+                                        Ident {
+                                            span: 23..24,
+                                            name: "x",
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                        body: Ident(
+                            Ident {
+                                span: 27..28,
+                                name: "x",
+                            },
+                        ),
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__blocks.snap
+++ b/src/parser/snapshots/crochet__parser__tests__blocks.snap
@@ -20,15 +20,17 @@ Program {
                 Let(
                     Let {
                         span: 15..23,
-                        pattern: Ident(
-                            BindingIdent {
-                                span: 15..16,
-                                id: Ident {
+                        pattern: Some(
+                            Ident(
+                                BindingIdent {
                                     span: 15..16,
-                                    name: "x",
+                                    id: Ident {
+                                        span: 15..16,
+                                        name: "x",
+                                    },
+                                    type_ann: None,
                                 },
-                                type_ann: None,
-                            },
+                            ),
                         ),
                         value: Lit(
                             Num(

--- a/src/parser/snapshots/crochet__parser__tests__declarations-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__declarations-3.snap
@@ -20,15 +20,17 @@ Program {
                 Let(
                     Let {
                         span: 15..23,
-                        pattern: Ident(
-                            BindingIdent {
-                                span: 15..16,
-                                id: Ident {
+                        pattern: Some(
+                            Ident(
+                                BindingIdent {
                                     span: 15..16,
-                                    name: "x",
+                                    id: Ident {
+                                        span: 15..16,
+                                        name: "x",
+                                    },
+                                    type_ann: None,
                                 },
-                                type_ann: None,
-                            },
+                            ),
                         ),
                         value: Lit(
                             Num(


### PR DESCRIPTION
This allows the following code:
```
let foo () => {
   let x = 5;
   let y = 10;
   console.log(x);
   console.log(y);
   x + y
}
```
This wasn't allowed before since all lines except for the last line in a block had to be `let <id> = ...` statements.