### PR TITLE
Enable parsing of basic destructuring patterns.

### DIFF
--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -1,14 +1,15 @@
 use crate::ast::span::Span;
 use crate::ast::ident::Ident;
 use crate::ast::types::TypeAnn;
+use crate::ast::expr::Expr;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
     Ident(BindingIdent),
     Rest(RestPat),
-
-    // Array(ArrayPat),
-    // Object(ObjectPat),
+    Object(ObjectPat),
+    Array(ArrayPat),
+    // This can't be used at the top level similar to rest
     // Assign(AssignPat),
 }
 
@@ -17,6 +18,8 @@ impl Pattern {
         match self {
             Pattern::Ident(ident) => ident.span.to_owned(),
             Pattern::Rest(rest) => rest.span.to_owned(),
+            Pattern::Object(obj) => obj.span.to_owned(),
+            Pattern::Array(array) => array.span.to_owned(),
         }
     }
 }
@@ -33,4 +36,40 @@ pub struct RestPat {
     pub span: Span,
     pub arg: Box<Pattern>,
     pub type_ann: Option<TypeAnn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArrayPat {
+    pub span: Span,
+    pub elems: Vec<Option<Pattern>>,
+    pub optional: bool,
+    pub type_ann: Option<TypeAnn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectPat {
+    pub span: Span,
+    pub props: Vec<ObjectPatProp>,
+    pub optional: bool,
+    pub type_ann: Option<TypeAnn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectPatProp {
+    KeyValue(KeyValuePatProp),
+    Rest(RestPat),
+    Assign(AssignPatProp),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyValuePatProp {
+    pub key: Ident,
+    pub value: Box<Pattern>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignPatProp {
+    pub span: Span,
+    pub key: Ident,
+    pub value: Option<Box<Expr>>,
 }

--- a/src/codegen/d_ts.rs
+++ b/src/codegen/d_ts.rs
@@ -101,6 +101,8 @@ pub fn build_pattern(pattern: &ast::Pattern, value: Option<&ast::Expr>, ctx: &Co
             })
         }
         ast::Pattern::Rest(_) => todo!(),
+        ast::Pattern::Object(_) => todo!(),
+        ast::Pattern::Array(_) => todo!(),
     }
 }
 
@@ -116,6 +118,8 @@ pub fn build_pattern_rec(pattern: &ast::Pattern) -> Pat {
             arg: Box::from(build_pattern_rec(arg.as_ref())),
             type_ann: None,
         }),
+        ast::Pattern::Object(_) => todo!(),
+        ast::Pattern::Array(_) => todo!(),
     }
 }
 
@@ -259,6 +263,8 @@ pub fn build_type(
                                             type_ann,
                                         })
                                     }
+                                    ast::Pattern::Object(_) => todo!(),
+                                    ast::Pattern::Array(_) => todo!(),
                                 }
                             })
                             .collect();

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -109,6 +109,8 @@ pub fn build_pattern(pattern: &ast::Pattern) -> Pat {
             type_ann: None,
         }),
         ast::Pattern::Rest(_) => todo!(),
+        ast::Pattern::Object(_) => todo!(),
+        ast::Pattern::Array(_) => todo!(),
     }
 }
 
@@ -165,6 +167,8 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
                     let name = match pat {
                         ast::Pattern::Ident(ast::BindingIdent { id, .. }) => id.name.to_owned(),
                         ast::Pattern::Rest(_) => todo!(),
+                        ast::Pattern::Object(_) => todo!(),
+                        ast::Pattern::Array(_) => todo!(),
                     };
                     Pat::Ident(BindingIdent {
                         id: Ident {

--- a/src/infer/infer.rs
+++ b/src/infer/infer.rs
@@ -316,6 +316,8 @@ fn infer(expr: &Expr, ctx: &Context) -> Result<InferResult, String> {
                         None => ctx.fresh_var(),
                     },
                     Pattern::Rest(_) => todo!(),
+                    Pattern::Object(_) => todo!(),
+                    Pattern::Array(_) => todo!(),
                 })
                 .collect();
             let mut new_ctx = ctx.clone();
@@ -329,6 +331,8 @@ fn infer(expr: &Expr, ctx: &Context) -> Result<InferResult, String> {
                         new_ctx.values.insert(id.name.to_string(), scheme)
                     }
                     Pattern::Rest(_) => todo!(),
+                    Pattern::Object(_) => todo!(),
+                    Pattern::Array(_) => todo!(),
                 };
             }
             new_ctx.is_async = is_async.to_owned();
@@ -534,6 +538,8 @@ fn infer_pattern(
             Ok((new_ctx, cs))
         }
         Pattern::Rest(_) => todo!(),
+        Pattern::Object(_) => todo!(),
+        Pattern::Array(_) => todo!(),
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -168,4 +168,18 @@ mod tests {
         insta::assert_debug_snapshot!(parse("let foo = {let x = 5; console.log(x); x}"));
         insta::assert_debug_snapshot!(parse("let foo = {console.log(x); x}"));
     }
+
+    #[test]
+    fn destructuring() {
+        insta::assert_debug_snapshot!(parse("let {x, y} = point"));
+        insta::assert_debug_snapshot!(parse("let {a, b, ...rest} = letters"));
+        insta::assert_debug_snapshot!(parse("let {p0: {x, y}, p1: {x, y}} = line"));
+        insta::assert_debug_snapshot!(parse("let [a, b, ...rest] = letters"));
+        insta::assert_debug_snapshot!(parse("let [foo, ...[bar, ...rest]] = baz"));
+        // TODO: renaming properties when destructuring objects
+        // TODO: assigning defaults
+        // TODO: type annotations
+        // TODO: function params
+        // TODO: disallowed patterns, e.g. top-level rest, non-top-level type annotations
+    }
 }

--- a/src/parser/pattern.rs
+++ b/src/parser/pattern.rs
@@ -4,17 +4,91 @@ use crate::ast::*;
 use crate::parser::types::*;
 use crate::parser::util::just_with_padding;
 
-// TODO: handle destructuring of objects and arrays
+// NOTE: Destructuring assignments admits different patterns from destructuring
+// function params.  We'll need to have different parsers for those.
 pub fn pattern_parser() -> BoxedParser<'static, char, Pattern, Simple<char>> {
     let type_ann = type_parser();
+    let mut top_level = true;
 
-    let parser = text::ident()
-        .map_with_span(|name, span| Ident { name, span })
-        .then(just_with_padding(":").ignore_then(type_ann).or_not())
-        .map_with_span(|(id, type_ann), span: Span| {
-            Pattern::Ident(BindingIdent { span, id, type_ann })
-        })
-        .padded();
+    let parser = recursive(|pat| {
+        let ident_pat = text::ident()
+            .map_with_span(|name, span| Ident { name, span })
+            .then(just_with_padding(":").ignore_then(type_ann).or_not())
+            .map_with_span(|(id, type_ann), span: Span| {
+                Pattern::Ident(BindingIdent { span, id, type_ann })
+            })
+            .padded();
+
+        // NOTE: rest patterns must appear instead of other patterns
+        // It's an error for them appear at the top-level, e.g.
+        // let ...x = [1,2,3];
+        // Also, type annotation can only appear at the top-level as well.
+        let rest_pat = just("...")
+            .ignore_then(pat.clone())
+            .map_with_span(|arg, span| RestPat {
+                span,
+                arg: Box::from(arg),
+                type_ann: None,
+            });
+
+        let array_pat = pat.clone()
+            .separated_by(just_with_padding(","))
+            .delimited_by(just_with_padding("["), just_with_padding("]"))
+            .map_with_span(|elems, span| {
+                Pattern::Array(ArrayPat {
+                    span,
+                    // The reason why each elem is wrapped in Some() is that
+                    // it's possible to have a pattern with skipped elements
+                    // althought the parser doesn't support this yet.
+                    elems: elems.iter().cloned().map(Some).collect(),
+                    optional: false,
+                    type_ann: None,
+                })
+            });
+
+        let key_value_pat_prop = text::ident()
+            .map_with_span(|name, span| Ident { span, name })
+            .then_ignore(just_with_padding(":"))
+            .then(pat.clone())
+            .map(|(key, value)| {
+                ObjectPatProp::KeyValue(KeyValuePatProp {
+                    key,
+                    value: Box::from(value),
+                })
+            });
+
+        // TODO: support default values
+        let assign_pat_prop = text::ident()
+            .map_with_span(|name, span| Ident { span, name })
+            .map_with_span(|key, span| {
+                ObjectPatProp::Assign(AssignPatProp {
+                    span,
+                    key,
+                    value: None,
+                })
+            });
+
+        // NOTE: There can only be a single rest element and it must be last
+        let obj_pat_prop = choice((
+            rest_pat.clone().map(ObjectPatProp::Rest),
+            key_value_pat_prop,
+            assign_pat_prop,
+        ))
+        .separated_by(just_with_padding(","))
+        .delimited_by(just_with_padding("{"), just_with_padding("}"))
+        .map_with_span(|props, span| {
+            Pattern::Object(ObjectPat {
+                span,
+                props,
+                optional: false,
+                type_ann: None,
+            })
+        });
+
+        top_level = false;
+
+        choice((ident_pat, array_pat, obj_pat_prop, rest_pat.map(Pattern::Rest)))
+    });
 
     parser.boxed()
 }

--- a/src/parser/snapshots/crochet__parser__tests__destructuring-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__destructuring-2.snap
@@ -1,0 +1,65 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let {a, b, ...rest} = letters\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..29,
+            pattern: Object(
+                ObjectPat {
+                    span: 4..20,
+                    props: [
+                        Assign(
+                            AssignPatProp {
+                                span: 5..6,
+                                key: Ident {
+                                    span: 5..6,
+                                    name: "a",
+                                },
+                                value: None,
+                            },
+                        ),
+                        Assign(
+                            AssignPatProp {
+                                span: 8..9,
+                                key: Ident {
+                                    span: 8..9,
+                                    name: "b",
+                                },
+                                value: None,
+                            },
+                        ),
+                        Rest(
+                            RestPat {
+                                span: 11..18,
+                                arg: Ident(
+                                    BindingIdent {
+                                        span: 14..18,
+                                        id: Ident {
+                                            span: 14..18,
+                                            name: "rest",
+                                        },
+                                        type_ann: None,
+                                    },
+                                ),
+                                type_ann: None,
+                            },
+                        ),
+                    ],
+                    optional: false,
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 22..29,
+                        name: "letters",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__destructuring-3.snap
+++ b/src/parser/snapshots/crochet__parser__tests__destructuring-3.snap
@@ -1,0 +1,103 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let {p0: {x, y}, p1: {x, y}} = line\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..35,
+            pattern: Object(
+                ObjectPat {
+                    span: 4..29,
+                    props: [
+                        KeyValue(
+                            KeyValuePatProp {
+                                key: Ident {
+                                    span: 5..7,
+                                    name: "p0",
+                                },
+                                value: Object(
+                                    ObjectPat {
+                                        span: 9..15,
+                                        props: [
+                                            Assign(
+                                                AssignPatProp {
+                                                    span: 10..11,
+                                                    key: Ident {
+                                                        span: 10..11,
+                                                        name: "x",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                            Assign(
+                                                AssignPatProp {
+                                                    span: 13..14,
+                                                    key: Ident {
+                                                        span: 13..14,
+                                                        name: "y",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                        ],
+                                        optional: false,
+                                        type_ann: None,
+                                    },
+                                ),
+                            },
+                        ),
+                        KeyValue(
+                            KeyValuePatProp {
+                                key: Ident {
+                                    span: 17..19,
+                                    name: "p1",
+                                },
+                                value: Object(
+                                    ObjectPat {
+                                        span: 21..27,
+                                        props: [
+                                            Assign(
+                                                AssignPatProp {
+                                                    span: 22..23,
+                                                    key: Ident {
+                                                        span: 22..23,
+                                                        name: "x",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                            Assign(
+                                                AssignPatProp {
+                                                    span: 25..26,
+                                                    key: Ident {
+                                                        span: 25..26,
+                                                        name: "y",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                        ],
+                                        optional: false,
+                                        type_ann: None,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    optional: false,
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 31..35,
+                        name: "line",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__destructuring-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__destructuring-4.snap
@@ -1,0 +1,71 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let [a, b, ...rest] = letters\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..29,
+            pattern: Array(
+                ArrayPat {
+                    span: 4..20,
+                    elems: [
+                        Some(
+                            Ident(
+                                BindingIdent {
+                                    span: 5..6,
+                                    id: Ident {
+                                        span: 5..6,
+                                        name: "a",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                        Some(
+                            Ident(
+                                BindingIdent {
+                                    span: 8..9,
+                                    id: Ident {
+                                        span: 8..9,
+                                        name: "b",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                        Some(
+                            Rest(
+                                RestPat {
+                                    span: 11..18,
+                                    arg: Ident(
+                                        BindingIdent {
+                                            span: 14..18,
+                                            id: Ident {
+                                                span: 14..18,
+                                                name: "rest",
+                                            },
+                                            type_ann: None,
+                                        },
+                                    ),
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                    ],
+                    optional: false,
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 22..29,
+                        name: "letters",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__destructuring-5.snap
+++ b/src/parser/snapshots/crochet__parser__tests__destructuring-5.snap
@@ -1,0 +1,88 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let [foo, ...[bar, ...rest]] = baz\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..34,
+            pattern: Array(
+                ArrayPat {
+                    span: 4..29,
+                    elems: [
+                        Some(
+                            Ident(
+                                BindingIdent {
+                                    span: 5..8,
+                                    id: Ident {
+                                        span: 5..8,
+                                        name: "foo",
+                                    },
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                        Some(
+                            Rest(
+                                RestPat {
+                                    span: 10..27,
+                                    arg: Array(
+                                        ArrayPat {
+                                            span: 13..27,
+                                            elems: [
+                                                Some(
+                                                    Ident(
+                                                        BindingIdent {
+                                                            span: 14..17,
+                                                            id: Ident {
+                                                                span: 14..17,
+                                                                name: "bar",
+                                                            },
+                                                            type_ann: None,
+                                                        },
+                                                    ),
+                                                ),
+                                                Some(
+                                                    Rest(
+                                                        RestPat {
+                                                            span: 19..26,
+                                                            arg: Ident(
+                                                                BindingIdent {
+                                                                    span: 22..26,
+                                                                    id: Ident {
+                                                                        span: 22..26,
+                                                                        name: "rest",
+                                                                    },
+                                                                    type_ann: None,
+                                                                },
+                                                            ),
+                                                            type_ann: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            optional: false,
+                                            type_ann: None,
+                                        },
+                                    ),
+                                    type_ann: None,
+                                },
+                            ),
+                        ),
+                    ],
+                    optional: false,
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 31..34,
+                        name: "baz",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/parser/snapshots/crochet__parser__tests__destructuring.snap
+++ b/src/parser/snapshots/crochet__parser__tests__destructuring.snap
@@ -1,0 +1,49 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"let {x, y} = point\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..18,
+            pattern: Object(
+                ObjectPat {
+                    span: 4..11,
+                    props: [
+                        Assign(
+                            AssignPatProp {
+                                span: 5..6,
+                                key: Ident {
+                                    span: 5..6,
+                                    name: "x",
+                                },
+                                value: None,
+                            },
+                        ),
+                        Assign(
+                            AssignPatProp {
+                                span: 8..9,
+                                key: Ident {
+                                    span: 8..9,
+                                    name: "y",
+                                },
+                                value: None,
+                            },
+                        ),
+                    ],
+                    optional: false,
+                    type_ann: None,
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 13..18,
+                        name: "point",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}


### PR DESCRIPTION
There's still a lot to do in order to have restructuring working in terms of inference and codegen.  I'm going to split to work up into several PRs so that it's a bit easier to follow the changes.
