### PR TITLE
Remove a number of unnecessary type inference structs

### DIFF
--- a/src/codegen/d_ts.rs
+++ b/src/codegen/d_ts.rs
@@ -185,7 +185,7 @@ pub fn build_type(
                 type_params: None,
             })
         }
-        Variant::Prim(types::PrimType { prim, .. }) => {
+        Variant::Prim(prim) => {
             let kind = match prim {
                 crate::types::Primitive::Num => TsKeywordTypeKind::TsNumberKeyword,
                 crate::types::Primitive::Bool => TsKeywordTypeKind::TsBooleanKeyword,
@@ -199,7 +199,7 @@ pub fn build_type(
                 kind,
             })
         }
-        Variant::Lit(types::LitType { lit, .. }) => {
+        Variant::Lit(lit) => {
             let lit = match lit {
                 crate::types::Lit::Num(n) => TsLit::Number(Number {
                     span: DUMMY_SP,
@@ -322,7 +322,7 @@ pub fn build_type(
                 _ => panic!("mismatch"),
             }
         }
-        Variant::Union(types::UnionType { types, .. }) => {
+        Variant::Union(types) => {
             TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
                 span: DUMMY_SP,
                 types: types
@@ -331,7 +331,7 @@ pub fn build_type(
                     .collect(),
             }))
         }
-        Variant::Intersection(types::IntersectionType { types, .. }) => {
+        Variant::Intersection(types) => {
             TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
                 TsIntersectionType {
                     span: DUMMY_SP,
@@ -342,7 +342,7 @@ pub fn build_type(
                 },
             ))
         }
-        Variant::Object(types::ObjectType { props, .. }) => {
+        Variant::Object(props) => {
             let members: Vec<TsTypeElement> = props
                 .iter()
                 .map(|prop| {
@@ -389,7 +389,7 @@ pub fn build_type(
                     .collect(),
             }),
         }),
-        Variant::Tuple(types::TupleType { types, .. }) => TsType::TsTupleType(TsTupleType {
+        Variant::Tuple(types) => TsType::TsTupleType(TsTupleType {
             span: DUMMY_SP,
             elem_types: types
                 .iter()

--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -59,6 +59,7 @@ impl Context {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Var,
+            widen_flag: None,
         }
     }
     pub fn lam(&self, params: Vec<Type>, ret: Box<Type>) -> Type {
@@ -66,13 +67,15 @@ impl Context {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Lam(types::LamType { params, ret }),
+            widen_flag: None,
         }
     }
     pub fn prim(&self, prim: types::Primitive) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Prim(types::PrimType { prim }),
+            variant: Variant::Prim(prim),
+            widen_flag: None,
         }
     }
     pub fn lit(&self, lit: Lit) -> Type {
@@ -86,38 +89,40 @@ impl Context {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Lit(types::LitType { lit }),
+            variant: Variant::Lit(lit),
+            widen_flag: None,
         }
     }
     pub fn lit_type(&self, lit: types::Lit) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Lit(types::LitType { lit }),
+            variant: Variant::Lit(lit),
+            widen_flag: None,
         }
     }
     pub fn union(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Union(types::UnionType { types }),
+            variant: Variant::Union(types),
+            widen_flag: None,
         }
     }
     pub fn intersection(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Intersection(types::IntersectionType { types }),
+            variant: Variant::Intersection(types),
+            widen_flag: None,
         }
     }
     pub fn object(&self, props: &[types::TProp], widen_flag: Option<WidenFlag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Object(types::ObjectType {
-                props: props.to_vec(),
-                widen_flag,
-            }),
+            variant: Variant::Object(props.to_vec()),
+            widen_flag,
         }
     }
     pub fn prop(&self, name: &str, ty: Type, optional: bool) -> types::TProp {
@@ -135,20 +140,23 @@ impl Context {
                 name: name.to_owned(),
                 type_params,
             }),
+            widen_flag: None,
         }
     }
     pub fn tuple(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Tuple(types::TupleType { types }),
+            variant: Variant::Tuple(types),
+            widen_flag: None,
         }
     }
-    pub fn rest(&self, ty: Type) -> Type {
+    pub fn rest(&self, arg: Type) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Rest(types::RestType { ty: Box::from(ty) }),
+            variant: Variant::Rest(Box::from(arg)),
+            widen_flag: None,
         }
     }
     pub fn mem(&self, obj: Type, prop: &str) -> Type {
@@ -159,6 +167,7 @@ impl Context {
                 obj: Box::from(obj),
                 prop: prop.to_owned(),
             }),
+            widen_flag: None,
         }
     }
 }

--- a/src/infer/infer_mem.rs
+++ b/src/infer/infer_mem.rs
@@ -65,11 +65,11 @@ fn type_of_property_on_type(
             todo!()
         },
         Variant::Intersection(_) => todo!(),
-        Variant::Object(obj) => {
+        Variant::Object(props) => {
             // TODO: allow the use of string literals to access properties on
             // object types.
             let mem = ctx.mem(ty.clone(), &prop.name());
-            let prop = obj.props.iter().find(|p| p.name == prop.name());
+            let prop = props.iter().find(|p| p.name == prop.name());
 
             match prop {
                 Some(_) => Ok((mem, vec![])),
@@ -96,8 +96,8 @@ fn type_of_property_on_type(
 fn unwrap_member_type(ty: &Type, ctx: &Context) -> Type {
     match &ty.variant {
         Variant::Member(member) => match &member.obj.as_ref().variant {
-            Variant::Object(obj) => {
-                let prop = obj.props.iter().find(|prop| prop.name == member.prop);
+            Variant::Object(props) => {
+                let prop = props.iter().find(|prop| prop.name == member.prop);
                 match prop {
                     Some(prop) => match prop.optional {
                         true => ctx.union(vec![


### PR DESCRIPTION
This simplifies the code a bunch since now we don't have destructure as many things in the inference code.