### PR TITLE
Rename WidenFlag to Flag and add helper functions to Context

### DIFF
--- a/src/infer/infer_mem.rs
+++ b/src/infer/infer_mem.rs
@@ -1,6 +1,6 @@
 use super::constraint_solver::Constraint;
 use crate::ast::*;
-use crate::types::{self, Type, WidenFlag, Variant};
+use crate::types::{self, Type, Flag, Variant};
 
 use super::context::Context;
 use super::infer::InferResult;
@@ -33,7 +33,7 @@ fn type_of_property_on_type(
             // expression to be inferred:
             // let mag_square = (point) => point.x * point.x + point.y * point.y
             let tv = ctx.fresh_var();
-            let obj = ctx.object(
+            let obj = ctx.object_with_flag(
                 &[types::TProp {
                     name: prop.name(),
                     // We assume the property is not optional when inferring an
@@ -41,7 +41,7 @@ fn type_of_property_on_type(
                     optional: false,
                     ty: tv.clone(),
                 }],
-                Some(WidenFlag::Intersection),
+                Flag::MemberAccess,
             );
             let mem1 = ctx.mem(ty.clone(), &prop.name());
             let mem2 = ctx.mem(obj.clone(), &prop.name());

--- a/src/infer/infer_pattern.rs
+++ b/src/infer/infer_pattern.rs
@@ -125,7 +125,7 @@ fn _infer_pattern_rec(pattern: &Pattern, ctx: &mut Context, cs: &mut Vec<Constra
                 }
             }).collect();
 
-            let obj_type = ctx.object(&props, None);
+            let obj_type = ctx.object(&props);
 
             match rest_opt_ty {
                 Some(rest_ty) => ctx.intersection(vec![obj_type, rest_ty]),
@@ -168,7 +168,7 @@ fn _type_ann_to_type(type_ann: &TypeAnn, ctx: &Context) -> Type {
                     ty: _type_ann_to_type(prop.type_ann.as_ref(), ctx),
                 })
                 .collect();
-            ctx.object(&props, None)
+            ctx.object(&props)
         }
         TypeAnn::TypeRef(TypeRef {
             name, type_params, ..

--- a/src/types.rs
+++ b/src/types.rs
@@ -101,9 +101,8 @@ impl Hash for LamType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum WidenFlag {
-    Intersection,
-    Union,
+pub enum Flag {
+    MemberAccess,
     SubtypesWin,
 }
 
@@ -165,7 +164,7 @@ pub struct Type {
     pub variant: Variant,
     pub id: i32,
     pub frozen: bool,
-    pub widen_flag: Option<WidenFlag>,
+    pub flag: Option<Flag>,
 }
 
 impl PartialEq for Type {


### PR DESCRIPTION
In the future `Flag` will be used to determine how to resolve conflicting types during unification so it seems like it should have a more general name than `WidenFlag`.

This PR also adds a bunch of helper functions to Context to make it easier to construct `Type`s either with or without a flag.