### PR TITLE
Refactor subtyping code to make better use of Flag

### DIFF
--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -28,14 +28,14 @@ fn solver(u: Unifier, ctx: &Context) -> Result<Subst, String> {
 
     let rest = &cs[1..]; // const [_ , ...rest] = cs;
 
-    println!("-----------");
-    println!("constraints:");
-    for Constraint {
-        types: (left, right),
-    } in cs.iter()
-    {
-        println!("{left} = {right}")
-    }
+    // println!("-----------");
+    // println!("constraints:");
+    // for Constraint {
+    //     types: (left, right),
+    // } in cs.iter()
+    // {
+    //     println!("{left} = {right}")
+    // }
 
     match cs.get(0) {
         Some(Constraint { types: (t1, t2) }) => {

--- a/src/infer/infer.rs
+++ b/src/infer/infer.rs
@@ -233,7 +233,6 @@ fn infer(expr: &Expr, ctx: &Context) -> Result<InferResult, String> {
     match expr {
         Expr::Ident(Ident { name, .. }) => {
             let ty = ctx.lookup_value(name);
-            println!("lookup_value({name}) = {:?}", ty);
             Ok((ty, vec![]))
         }
         Expr::App(App { lam, args, .. }) => {

--- a/src/infer/infer_pattern.rs
+++ b/src/infer/infer_pattern.rs
@@ -1,10 +1,11 @@
 use std::iter::Iterator;
 
 use crate::ast::*;
-use crate::types::{self, freeze, Scheme, Type};
+use crate::types::{self, Scheme, Type};
 
 use super::constraint_solver::Constraint;
 use super::context::Context;
+use super::infer_type_ann::infer_type_ann;
 
 pub fn infer_pattern(
     pattern: &Pattern,
@@ -30,7 +31,7 @@ fn _get_type_ann_type(pattern: &Pattern, ctx: &Context) -> Option<Type> {
         Pattern::Array(array) => array.type_ann.to_owned(),
     };
 
-    type_ann.map(|type_ann| type_ann_to_type(&type_ann, ctx))
+    type_ann.map(|type_ann| infer_type_ann(&type_ann, ctx))
 }
 
 // As a result of inferring a pattern, we must:
@@ -135,60 +136,9 @@ fn _infer_pattern_rec(pattern: &Pattern, ctx: &mut Context, cs: &mut Vec<Constra
     }
 }
 
-
 fn type_to_scheme(ty: &Type) -> Scheme {
     Scheme {
         qualifiers: vec![],
         ty: ty.clone(),
-    }
-}
-
-pub fn type_ann_to_type(type_ann: &TypeAnn, ctx: &Context) -> Type {
-    freeze(_type_ann_to_type(type_ann, ctx))
-}
-
-fn _type_ann_to_type(type_ann: &TypeAnn, ctx: &Context) -> Type {
-    match type_ann {
-        TypeAnn::Lam(LamType { params, ret, .. }) => {
-            let params: Vec<_> = params
-                .iter()
-                .map(|arg| _type_ann_to_type(arg, ctx))
-                .collect();
-            let ret = Box::from(_type_ann_to_type(ret.as_ref(), ctx));
-            ctx.lam(params, ret)
-        }
-        TypeAnn::Lit(LitType { lit, .. }) => ctx.lit(lit.to_owned()),
-        TypeAnn::Prim(PrimType { prim, .. }) => ctx.prim(prim.to_owned()),
-        TypeAnn::Object(ObjectType { props, .. }) => {
-            let props: Vec<_> = props
-                .iter()
-                .map(|prop| types::TProp {
-                    name: prop.name.to_owned(),
-                    optional: prop.optional,
-                    ty: _type_ann_to_type(prop.type_ann.as_ref(), ctx),
-                })
-                .collect();
-            ctx.object(&props)
-        }
-        TypeAnn::TypeRef(TypeRef {
-            name, type_params, ..
-        }) => {
-            let type_params = type_params.clone().map(|params| {
-                params
-                    .iter()
-                    .map(|param| _type_ann_to_type(param, ctx))
-                    .collect()
-            });
-            ctx.alias(name, type_params)
-        }
-        TypeAnn::Union(UnionType { types, .. }) => {
-            ctx.union(types.iter().map(|ty| _type_ann_to_type(ty, ctx)).collect())
-        }
-        TypeAnn::Intersection(IntersectionType { types, .. }) => {
-            ctx.intersection(types.iter().map(|ty| _type_ann_to_type(ty, ctx)).collect())
-        }
-        TypeAnn::Tuple(TupleType { types, .. }) => {
-            ctx.tuple(types.iter().map(|ty| _type_ann_to_type(ty, ctx)).collect())
-        }
     }
 }

--- a/src/infer/infer_type_ann.rs
+++ b/src/infer/infer_type_ann.rs
@@ -1,0 +1,60 @@
+use std::iter::Iterator;
+
+use crate::ast::*;
+use crate::types::{self, freeze, Type, Flag};
+
+use super::context::Context;
+
+pub fn infer_type_ann(type_ann: &TypeAnn, ctx: &Context) -> Type {
+    freeze(infer_type_ann_rec(type_ann, ctx))
+}
+
+fn infer_type_ann_rec(type_ann: &TypeAnn, ctx: &Context) -> Type {
+    match type_ann {
+        TypeAnn::Lam(LamType { params, ret, .. }) => {
+            let params: Vec<_> = params
+                .iter()
+                .map(|arg| {
+                    let mut ty = infer_type_ann_rec(arg, ctx);
+                    ty.flag = Some(Flag::SubtypeWins);
+                    ty
+                })
+                .collect();
+            let ret = Box::from(infer_type_ann_rec(ret.as_ref(), ctx));
+            ctx.lam(params, ret)
+        }
+        TypeAnn::Lit(LitType { lit, .. }) => ctx.lit(lit.to_owned()),
+        TypeAnn::Prim(PrimType { prim, .. }) => ctx.prim(prim.to_owned()),
+        TypeAnn::Object(ObjectType { props, .. }) => {
+            let props: Vec<_> = props
+                .iter()
+                .map(|prop| types::TProp {
+                    name: prop.name.to_owned(),
+                    optional: prop.optional,
+                    ty: infer_type_ann_rec(prop.type_ann.as_ref(), ctx),
+                })
+                .collect();
+            ctx.object(&props)
+        }
+        TypeAnn::TypeRef(TypeRef {
+            name, type_params, ..
+        }) => {
+            let type_params = type_params.clone().map(|params| {
+                params
+                    .iter()
+                    .map(|param| infer_type_ann_rec(param, ctx))
+                    .collect()
+            });
+            ctx.alias(name, type_params)
+        }
+        TypeAnn::Union(UnionType { types, .. }) => {
+            ctx.union(types.iter().map(|ty| infer_type_ann_rec(ty, ctx)).collect())
+        }
+        TypeAnn::Intersection(IntersectionType { types, .. }) => {
+            ctx.intersection(types.iter().map(|ty| infer_type_ann_rec(ty, ctx)).collect())
+        }
+        TypeAnn::Tuple(TupleType { types, .. }) => {
+            ctx.tuple(types.iter().map(|ty| infer_type_ann_rec(ty, ctx)).collect())
+        }
+    }
+}

--- a/src/infer/mod.rs
+++ b/src/infer/mod.rs
@@ -2,6 +2,7 @@ mod constraint_solver;
 mod context;
 mod infer_mem;
 mod infer_pattern;
+mod infer_type_ann;
 mod infer;
 mod substitutable;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,7 +103,8 @@ impl Hash for LamType {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Flag {
     MemberAccess,
-    SubtypesWin,
+    SubtypeWins,
+    SupertypeWins,
 }
 
 #[derive(Clone, Debug, Eq)]


### PR DESCRIPTION
This PR introduces a `Flag::SupertypeWins` to handle things like `let x: number = 5` where we want to allow the assignment of `5` to `x`, but we want the type of `x` to be `number`.  It also deduplicates the two versions of `type_ann_to_type()` that we had kicking around.