### PR TITLE
Update infer()'s lambda branch to use infer_pattern

### DIFF
--- a/src/infer/context.rs
+++ b/src/infer/context.rs
@@ -39,6 +39,10 @@ impl Context {
         let scheme = self.values.get(name).unwrap();
         self.instantiate(scheme)
     }
+    pub fn lookup_type(&self, name: &str) -> Type {
+        let scheme = self.types.get(name).unwrap();
+        self.instantiate(scheme)
+    }
 
     fn instantiate(&self, scheme: &Scheme) -> Type {
         let ids = scheme.qualifiers.iter().map(|id| id.to_owned());


### PR DESCRIPTION
Now we're using `infer_patter()` for both `Let` and `Lambda`.