### PR TITLE
Allow partial object destructuring

### DIFF
--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -103,9 +103,7 @@ fn unifies(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 let mut cs: Vec<Constraint> = vec![];
                 for p1 in props1 {
                     let p2 = props2.iter().find(|p2| p1.name == p2.name).unwrap();
-                    cs.push(Constraint {
-                        types: (p1.ty.clone(), p2.ty.clone()),
-                    });
+                    cs.push(Constraint::from((p1.get_type(ctx), p2.get_type(ctx))));
                 }
                 unify_many(&cs, ctx)
             } else if t2.flag == Some(Flag::Pattern) {
@@ -114,16 +112,14 @@ fn unifies(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 // argument passed to a function during a call/application.
                 let mut cs: Vec<Constraint> = vec![];
                 for p2 in props2 {
-                    let p1_type = match p2.optional {
+                    let p1 = match p2.optional {
                         true => match props1.iter().find(|p1| p1.name == p2.name) {
-                            Some(prop) => prop.ty.clone(),
+                            Some(prop) => prop,
                             None => continue,
                         },
-                        false => props1.iter().find(|p1| p1.name == p2.name).unwrap().ty.clone(),
+                        false => props1.iter().find(|p1| p1.name == p2.name).unwrap(),
                     };
-                    cs.push(Constraint {
-                        types: (p1_type, p2.ty.clone()),
-                    });
+                    cs.push(Constraint::from((p1.get_type(ctx), p2.get_type(ctx))));
                 }
                 unify_many(&cs, ctx)
             } else {
@@ -193,7 +189,7 @@ fn unify_mismatched_types(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, 
                 // TODO: propagate errors instead of unwrap()-ing
                 let prop2 = props2.get(0).unwrap();
                 let prop1 = props1.iter().find(|p| p.name == prop2.name).unwrap();
-                return unifies(&prop1.ty, &prop2.ty, ctx);
+                return unifies(&prop1.get_type(ctx), &prop2.get_type(ctx), ctx);
             } else {
                 let new_type = intersect_types(t1, t2, ctx);
                 // We should never widen object types with the MemberAccess flag
@@ -291,7 +287,7 @@ pub fn is_subtype(t1: &Type, t2: &Type, ctx: &Context) -> Result<bool, String> {
                             .iter()
                             .map(|prop1| {
                                 Ok(prop1.name == prop2.name
-                                    && is_subtype(&prop1.ty, &prop2.ty, ctx)?)
+                                    && is_subtype(&prop1.get_type(ctx), &prop2.get_type(ctx), ctx)?)
                             })
                             .collect();
                         Ok(inner_result?.into_iter().any(identity))
@@ -438,7 +434,7 @@ fn intersect_properties(props1: &[TProp], props2: &[TProp], ctx: &Context) -> Ve
             props2.iter().find(|p2| p1.name == p2.name).map(|p2| TProp {
                 name: p1.name.to_owned(),
                 optional: p1.optional && p2.optional,
-                ty: intersect_types(&p1.ty, &p2.ty, ctx),
+                ty: intersect_types(&p1.get_type(ctx), &p2.get_type(ctx), ctx),
             })
         })
         .collect();

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -189,7 +189,10 @@ fn unify_mismatched_types(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, 
                 // TODO: propagate errors instead of unwrap()-ing
                 let prop2 = props2.get(0).unwrap();
                 let prop1 = props1.iter().find(|p| p.name == prop2.name).unwrap();
-                return unifies(&prop1.get_type(ctx), &prop2.get_type(ctx), ctx);
+                return unifies(&prop1.ty.to_owned(), &prop2.ty.to_owned(), ctx);
+                // TODO: check if either of the properties is optional and resolve
+                // the mismatch accordingly using .get_type(ctx) to convert an optional
+                // prop with type T to T | undefined.
             } else {
                 let new_type = intersect_types(t1, t2, ctx);
                 // We should never widen object types with the MemberAccess flag

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -108,6 +108,24 @@ fn unifies(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     });
                 }
                 unify_many(&cs, ctx)
+            } else if t2.flag == Some(Flag::Pattern) {
+                // NOTE: Patterns appear as the LHS of a let-binding or as the type of a function param.
+                // As such, the pattern must be a super type of the initializer in the let-binding or the
+                // argument passed to a function during a call/application.
+                let mut cs: Vec<Constraint> = vec![];
+                for p2 in props2 {
+                    let p1_type = match p2.optional {
+                        true => match props1.iter().find(|p1| p1.name == p2.name) {
+                            Some(prop) => prop.ty.clone(),
+                            None => continue,
+                        },
+                        false => props1.iter().find(|p1| p1.name == p2.name).unwrap().ty.clone(),
+                    };
+                    cs.push(Constraint {
+                        types: (p1_type, p2.ty.clone()),
+                    });
+                }
+                unify_many(&cs, ctx)
             } else {
                 unify_mismatched_types(t1, t2, ctx)
             }
@@ -134,7 +152,6 @@ fn unifies(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
 }
 
 fn get_aliased_type(alias: &AliasType, ctx: &Context) -> Type {
-    println!("get_aliased_type: {:#?}", alias);
     let scheme = ctx.types.get(&alias.name).unwrap();
     let subs: Subst = match &alias.type_params {
         Some(params) => {
@@ -198,7 +215,7 @@ fn unify_mismatched_types(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, 
         return Ok(result);
     }
 
-    println!("unifcation failed: {:?} {:?}", t1, t2);
+    println!("unifcation failed");
 
     Err(String::from("unification failed"))
 }
@@ -309,8 +326,16 @@ pub fn is_subtype(t1: &Type, t2: &Type, ctx: &Context) -> Result<bool, String> {
             match ctx.types.get(&alias.name) {
                 Some(scheme) => {
                     // TODO: handle schemes with qualifiers
-                    let aliased_def = scheme.ty.to_owned();
-                    is_subtype(t1, &aliased_def, ctx)
+                    is_subtype(t1, &scheme.ty, ctx)
+                }
+                None => panic!("Can't find alias in context"),
+            }
+        }
+        (Variant::Alias(alias), _) => {
+            match ctx.types.get(&alias.name) {
+                Some(scheme) => {
+                    // TODO: handle schemes with qualifiers
+                    is_subtype(&scheme.ty, t2, ctx)
                 }
                 None => panic!("Can't find alias in context"),
             }

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -189,10 +189,7 @@ fn unify_mismatched_types(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, 
                 // TODO: propagate errors instead of unwrap()-ing
                 let prop2 = props2.get(0).unwrap();
                 let prop1 = props1.iter().find(|p| p.name == prop2.name).unwrap();
-                return unifies(&prop1.ty.to_owned(), &prop2.ty.to_owned(), ctx);
-                // TODO: check if either of the properties is optional and resolve
-                // the mismatch accordingly using .get_type(ctx) to convert an optional
-                // prop with type T to T | undefined.
+                return unifies(&prop1.get_type(ctx), &prop2.get_type(ctx), ctx);
             } else {
                 let new_type = intersect_types(t1, t2, ctx);
                 // We should never widen object types with the MemberAccess flag

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -39,6 +39,12 @@ pub fn infer(
         Expr::App(App { lam, args, .. }) => {
             let fn_type = infer(lam, ctx, constraints)?;
             let args_types = infer_many(args, ctx, constraints)?;
+            let args_types = args_types.iter().map(|arg| {
+                let mut arg = arg.to_owned();
+                arg.flag = Some(Flag::Argument);
+                arg
+            }).collect();
+            println!("args_types = {:#?}", args_types);
             let ret_type = ctx.fresh_var();
 
             constraints.push(Constraint::from((

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -38,13 +38,14 @@ pub fn infer(
 
         Expr::App(App { lam, args, .. }) => {
             let fn_type = infer(lam, ctx, constraints)?;
+
             let args_types = infer_many(args, ctx, constraints)?;
             let args_types = args_types.iter().map(|arg| {
                 let mut arg = arg.to_owned();
                 arg.flag = Some(Flag::Argument);
                 arg
             }).collect();
-            println!("args_types = {:#?}", args_types);
+
             let ret_type = ctx.fresh_var();
 
             constraints.push(Constraint::from((

--- a/src/infer/infer_lambda.rs
+++ b/src/infer/infer_lambda.rs
@@ -39,7 +39,7 @@ pub fn infer_lambda(
         None => HashMap::default(),
     };
 
-    let param_tvs: Result<Vec<_>, String> = params
+    let param_types: Result<Vec<Type>, String> = params
         .iter()
         .map(|param| {
             let (mut param_type, new_vars) =
@@ -73,11 +73,11 @@ pub fn infer_lambda(
         false => ctx.alias("Promise", Some(vec![ret])),
     };
 
-    let lam_ty = ctx.lam(param_tvs?, Box::new(ret));
+    let lam_type = ctx.lam(param_types?, Box::new(ret));
 
     // TODO: add a constraint for the return type if it's specified
 
-    Ok(lam_ty)
+    Ok(lam_type)
 }
 
 fn is_promise(ty: &Type) -> bool {

--- a/src/infer/infer_mem.rs
+++ b/src/infer/infer_mem.rs
@@ -23,7 +23,7 @@ pub fn infer_mem(
 
 fn type_of_property_on_type(
     ty: Type,
-    prop: &MemberProp,
+    mem_prop: &MemberProp, // property on a member access expression
     ctx: &Context,
 ) -> Result<(Type, Vec<Constraint>), String> {
     match &ty.variant {
@@ -34,7 +34,7 @@ fn type_of_property_on_type(
             let tv = ctx.fresh_var();
             let obj = ctx.object_with_flag(
                 vec![types::TProp {
-                    name: prop.name(),
+                    name: mem_prop.name(),
                     // We assume the property is not optional when inferring an
                     // object from a member access.
                     optional: false,
@@ -42,8 +42,8 @@ fn type_of_property_on_type(
                 }],
                 Flag::MemberAccess,
             );
-            let mem1 = ctx.mem(ty.clone(), &prop.name());
-            let mem2 = ctx.mem(obj.clone(), &prop.name());
+            let mem1 = ctx.mem(ty.clone(), &mem_prop.name());
+            let mem2 = ctx.mem(obj.clone(), &mem_prop.name());
             Ok((
                 tv,
                 vec![
@@ -67,8 +67,8 @@ fn type_of_property_on_type(
         Variant::Object(props) => {
             // TODO: allow the use of string literals to access properties on
             // object types.
-            let mem = ctx.mem(ty.clone(), &prop.name());
-            let prop = props.iter().find(|p| p.name == prop.name());
+            let mem = ctx.mem(ty.clone(), &mem_prop.name());
+            let prop = props.iter().find(|p| p.name == mem_prop.name());
 
             match prop {
                 Some(_) => Ok((mem, vec![])),
@@ -99,7 +99,7 @@ fn type_of_property_on_type(
                     let aliased_def = scheme.ty.apply(&subs);
 
                     // Recurses to get the prop on the underlying type.
-                    type_of_property_on_type(aliased_def, prop, ctx)
+                    type_of_property_on_type(aliased_def, mem_prop, ctx)
                 }
                 None => Err(String::from("Can't find alias in context")),
             }
@@ -116,14 +116,7 @@ fn unwrap_member_type(ty: &Type, ctx: &Context) -> Type {
             Variant::Object(props) => {
                 let prop = props.iter().find(|prop| prop.name == member.prop);
                 match prop {
-                    // TODO: figure out how to make TProp#get_type(ctx) work here
-                    Some(prop) => match prop.optional {
-                        true => ctx.union(vec![
-                            unwrap_member_type(&prop.ty, ctx),
-                            ctx.prim(types::Primitive::Undefined),
-                        ]),
-                        false => unwrap_member_type(&prop.ty, ctx),
-                    },
+                    Some(prop) => prop.get_type(ctx),
                     None => ty.to_owned(),
                 }
             }

--- a/src/infer/infer_mem.rs
+++ b/src/infer/infer_mem.rs
@@ -116,6 +116,7 @@ fn unwrap_member_type(ty: &Type, ctx: &Context) -> Type {
             Variant::Object(props) => {
                 let prop = props.iter().find(|prop| prop.name == member.prop);
                 match prop {
+                    // TODO: figure out how to make TProp#get_type(ctx) work here
                     Some(prop) => match prop.optional {
                         true => ctx.union(vec![
                             unwrap_member_type(&prop.ty, ctx),

--- a/src/infer/util.rs
+++ b/src/infer/util.rs
@@ -68,7 +68,9 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     .map(|prop| TProp {
                         name: prop.name.clone(),
                         optional: prop.optional,
-                        ty: norm_type(&prop.get_type(ctx), mapping, ctx),
+                        // NOTE: we don't use prop.get_type(ctx) here because we're tracking
+                        // the optionality of the property in the TProp that's returned.
+                        ty: norm_type(&prop.ty, mapping, ctx),
                     })
                     .collect();
                 Type {
@@ -130,6 +132,9 @@ pub fn generalize(env: &Env, ty: &Type) -> Scheme {
 }
 
 // TODO: make this recursive
+// TODO: handle optional properties correctly
+// Maybe we can have a function that will canonicalize objects by converting 
+// `x: T | undefined` to `x?: T`
 pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
     let obj_types: Vec<_> = in_types
         .iter()
@@ -143,7 +148,7 @@ pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
     let mut props_map: DefaultHashMap<String, HashSet<Type>> = defaulthashmap!();
     for props in obj_types {
         for prop in props {
-            props_map[prop.name.clone()].insert(prop.get_type(ctx));
+            props_map[prop.name.clone()].insert(prop.ty.clone());
         }
     }
 

--- a/src/infer/util.rs
+++ b/src/infer/util.rs
@@ -68,7 +68,7 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     .map(|prop| TProp {
                         name: prop.name.clone(),
                         optional: prop.optional,
-                        ty: norm_type(&prop.ty, mapping, ctx),
+                        ty: norm_type(&prop.get_type(ctx), mapping, ctx),
                     })
                     .collect();
                 Type {
@@ -143,7 +143,7 @@ pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
     let mut props_map: DefaultHashMap<String, HashSet<Type>> = defaulthashmap!();
     for props in obj_types {
         for prop in props {
-            props_map[prop.name.clone()].insert(prop.ty.clone());
+            props_map[prop.name.clone()].insert(prop.get_type(ctx));
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,8 @@ use itertools::join;
 use std::fmt;
 use std::hash::Hash;
 
+use crate::infer::Context;
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Lit {
     // We store all of the values as strings since f64 doesn't
@@ -51,6 +53,15 @@ pub struct TProp {
     pub name: String,
     pub optional: bool,
     pub ty: Type,
+}
+
+impl TProp {
+    pub fn get_type(&self, ctx: &Context) -> Type {
+        match self.optional {
+            true => ctx.union(vec![self.ty.to_owned(), ctx.prim(Primitive::Undefined)]),
+            false => self.ty.to_owned(),
+        }
+    }
 }
 
 impl fmt::Display for TProp {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -756,8 +756,7 @@ fn infer_assigning_to_obj_with_optional_props() {
     let (_, ctx) = infer_prog(src);
 
     let x = format!("{}", ctx.values.get("x").unwrap());
-    // TODO: figure out where this extra 'undefined' is coming from
-    assert_eq!(x, "number | undefined | undefined");
+    assert_eq!(x, "number | undefined");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -756,7 +756,8 @@ fn infer_assigning_to_obj_with_optional_props() {
     let (_, ctx) = infer_prog(src);
 
     let x = format!("{}", ctx.values.get("x").unwrap());
-    assert_eq!(x, "number | undefined");
+    // TODO: figure out where this extra 'undefined' is coming from
+    assert_eq!(x, "number | undefined | undefined");
 }
 
 #[test]


### PR DESCRIPTION
This allows the same sort of partial destructuring that's supported in JavaScript, i.e.
```
let {x} = {x: 5, y: 10};
```
In the future we may want to require ellipsis when doing partial destructuring so as to communicate to the reader of the code whether there are other properties that are being ignored.
