### PR TITLE
Don't require parens around the condition on 'if' statements

### DIFF
--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -77,9 +77,7 @@ pub fn expr_parser() -> BoxedParser<'static, char, Expr, Simple<char>> {
 
         // TODO: handle chaining of if-else
         let if_else = just_with_padding("if")
-            // .ignore_then(just_with_padding("("))
             .ignore_then(expr.clone())
-            // .then_ignore(just_with_padding(")"))
             .then(block.clone())
             .then_ignore(just_with_padding("else"))
             .then(block.clone())

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -77,9 +77,9 @@ pub fn expr_parser() -> BoxedParser<'static, char, Expr, Simple<char>> {
 
         // TODO: handle chaining of if-else
         let if_else = just_with_padding("if")
-            .ignore_then(just_with_padding("("))
+            // .ignore_then(just_with_padding("("))
             .ignore_then(expr.clone())
-            .then_ignore(just_with_padding(")"))
+            // .then_ignore(just_with_padding(")"))
             .then(block.clone())
             .then_ignore(just_with_padding("else"))
             .then(block.clone())

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn if_else() {
-        insta::assert_debug_snapshot!(parse("if (true) { 5 } else { 10 }"));
+        insta::assert_debug_snapshot!(parse("if true { 5 } else { 10 }"));
     }
 
     #[test]

--- a/src/parser/snapshots/crochet__parser__tests__if_else.snap
+++ b/src/parser/snapshots/crochet__parser__tests__if_else.snap
@@ -1,18 +1,18 @@
 ---
 source: src/parser/mod.rs
-expression: "parse(\"if (true) { 5 } else { 10 }\")"
+expression: "parse(\"if true { 5 } else { 10 }\")"
 ---
 Program {
     body: [
         Expr {
-            span: 0..27,
+            span: 0..25,
             expr: IfElse(
                 IfElse {
-                    span: 0..27,
+                    span: 0..25,
                     cond: Lit(
                         Bool(
                             Bool {
-                                span: 4..8,
+                                span: 3..8,
                                 value: true,
                             },
                         ),
@@ -20,7 +20,7 @@ Program {
                     consequent: Lit(
                         Num(
                             Num {
-                                span: 12..13,
+                                span: 10..11,
                                 value: "5",
                             },
                         ),
@@ -28,7 +28,7 @@ Program {
                     alternate: Lit(
                         Num(
                             Num {
-                                span: 23..25,
+                                span: 21..23,
                                 value: "10",
                             },
                         ),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -192,7 +192,7 @@ fn infer_with_subtyping() {
 
 #[test]
 fn infer_if_else_without_widening() {
-    let (_, ctx) = infer_prog("let x = if (true) { 5 } else { 5 }");
+    let (_, ctx) = infer_prog("let x = if true { 5 } else { 5 }");
     let result = format!("{}", ctx.values.get("x").unwrap());
     assert_eq!(result, "5");
 }
@@ -207,8 +207,8 @@ fn infer_if_else_with_widening() {
 #[test]
 fn infer_if_else_with_multiple_widenings() {
     let src = r#"
-    let x = if (true) { 5 } else { 10 }
-    let y = if (false) { x } else { 15 }
+    let x = if true { 5 } else { 10 }
+    let y = if false { x } else { 15 }
     "#;
     let (program, ctx) = infer_prog(src);
     let result = format!("{}", ctx.values.get("y").unwrap());
@@ -264,7 +264,7 @@ fn infer_inequalities() {
 
 #[test]
 fn infer_let_rec_until() {
-    let src = "let rec until = (p, f, x) => if (p(x)) { x } else { until(p, f, f(x)) }";
+    let src = "let rec until = (p, f, x) => if p(x) { x } else { until(p, f, f(x)) }";
     let (program, ctx) = infer_prog(src);
     let result = format!("{}", ctx.values.get("until").unwrap());
     insta::assert_snapshot!(result, @"<t0>((t0) => boolean, (t0) => t0, t0) => t0");
@@ -276,10 +276,10 @@ fn infer_let_rec_until() {
 #[test]
 fn infer_fib() {
     let src = r###"
-    let rec fib = (n) => if (n == 0) {
+    let rec fib = (n) => if n == 0 {
         0
     } else {
-        if (n == 1) {
+        if n == 1 {
             1
         } else {
             fib(n - 1) + fib(n - 2)
@@ -342,7 +342,7 @@ fn codegen_let_rec() {
 fn codegen_if_else() {
     let src = r#"
     let cond = true
-    let result = if (cond) { 5 } else { 5 }
+    let result = if cond { 5 } else { 5 }
     "#;
     let (program, ctx) = infer_prog(src);
 
@@ -553,7 +553,7 @@ fn infer_var_with_union_type_annotation() {
 fn infer_widen_tuple_return() {
     let src = r#"
     let result = (cond) => {
-        if (cond) {
+        if cond {
             [1, 2]
         } else {
             [true, false]
@@ -581,7 +581,7 @@ fn infer_widen_tuple_return() {
 fn infer_widen_tuples_with_type_annotations() {
     let src = r#"
     let result = (cond) => {
-        if (cond) {
+        if cond {
             let x: [number, number] = [1, 2] in
             x
         } else {


### PR DESCRIPTION
This is so that the syntax for `if let` won't look that different from `if` when support is added for it in the future.