### PR TITLE
Handle fucntions with an empty body

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -144,6 +144,11 @@ pub struct ComputedPropName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Empty {
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     App(App),
     Fix(Fix),
@@ -158,6 +163,7 @@ pub enum Expr {
     Await(Await),
     Tuple(Tuple),
     Member(Member),
+    Empty(Empty),
 }
 
 impl Expr {
@@ -176,6 +182,7 @@ impl Expr {
             Expr::Await(r#await) => r#await.span.to_owned(),
             Expr::Tuple(tuple) => tuple.span.to_owned(),
             Expr::Member(member) => member.span.to_owned(),
+            Expr::Empty(empty) => empty.span.to_owned(),
         }
     }
 }

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -436,6 +436,11 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
                 prop,
             })
         }
+        ast::Expr::Empty(_) => Expr::from(Ident {
+            span: DUMMY_SP,
+            sym: JsWord::from("undefined"),
+            optional: false,
+        }),
     }
 }
 

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -253,6 +253,7 @@ pub fn infer(
         Expr::Tuple(Tuple { elems, .. }) => {
             Ok(ctx.tuple(infer_many(elems, ctx, constraints)?))
         }
+        Expr::Empty(_) => Ok(ctx.prim(Primitive::Undefined)), // should this be a literal maybe?
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1180,3 +1180,26 @@ fn top_level_inferred_types_are_frozen() {
     let add = ctx.values.get("add").unwrap();
     assert!(add.ty.frozen);
 }
+
+#[test]
+fn return_empty() {
+    let src = r#"
+    let foo = () => {}
+    "#;
+    let (_, ctx) = infer_prog(src);
+
+    assert_eq!(format!("{}", ctx.values.get("foo").unwrap()), "() => undefined");
+}
+
+#[test]
+#[ignore] // TODO: figure out how to parse this
+fn return_empty_with_body() {
+    let src = r#"
+    let foo = () => {
+        let a = 5;
+    }
+    "#;
+    let (_, ctx) = infer_prog(src);
+
+    assert_eq!(format!("{}", ctx.values.get("foo").unwrap()), "() => undefined");
+}


### PR DESCRIPTION
This will be used to support `if` statements without an `else` block in the future as well as `if-let`.