### PR TITLE
Make 'else' optional, allow trailing ';'

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -55,7 +55,7 @@ pub struct IfElse {
     pub span: Span,
     pub cond: Box<Expr>,
     pub consequent: Box<Expr>,
-    pub alternate: Box<Expr>,
+    pub alternate: Option<Box<Expr>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -347,9 +347,9 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
                     span: DUMMY_SP,
                     test: Box::from(build_expr(cond.as_ref())),
                     cons: Box::from(Stmt::Block(build_return_block(consequent.as_ref()))),
-                    alt: Some(Box::from(Stmt::Block(build_return_block(
-                        alternate.as_ref(),
-                    )))),
+                    alt: alternate
+                        .as_ref()
+                        .map(|alt| Box::from(Stmt::Block(build_return_block(alt.as_ref())))),
                 })],
             });
 
@@ -379,7 +379,7 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
             let props: Vec<PropOrSpread> = props
                 .iter()
                 .map(|prop| match prop {
-                    ast::Prop::Shorthand(ast::ident::Ident {name, ..}) => {
+                    ast::Prop::Shorthand(ast::ident::Ident { name, .. }) => {
                         PropOrSpread::Prop(Box::from(Prop::Shorthand(Ident {
                             span: DUMMY_SP,
                             sym: JsWord::from(name.clone()),

--- a/src/parser/snapshots/crochet__parser__tests__if_else-2.snap
+++ b/src/parser/snapshots/crochet__parser__tests__if_else-2.snap
@@ -23,32 +23,36 @@ Program {
                             },
                         ),
                     ),
-                    alternate: IfElse(
-                        IfElse {
-                            span: 16..39,
-                            cond: Ident(
-                                Ident {
-                                    span: 19..20,
-                                    name: "b",
-                                },
-                            ),
-                            consequent: Lit(
-                                Num(
-                                    Num {
-                                        span: 23..25,
-                                        value: "10",
+                    alternate: Some(
+                        IfElse(
+                            IfElse {
+                                span: 16..39,
+                                cond: Ident(
+                                    Ident {
+                                        span: 19..20,
+                                        name: "b",
                                     },
                                 ),
-                            ),
-                            alternate: Lit(
-                                Num(
-                                    Num {
-                                        span: 35..37,
-                                        value: "20",
-                                    },
+                                consequent: Lit(
+                                    Num(
+                                        Num {
+                                            span: 23..25,
+                                            value: "10",
+                                        },
+                                    ),
                                 ),
-                            ),
-                        },
+                                alternate: Some(
+                                    Lit(
+                                        Num(
+                                            Num {
+                                                span: 35..37,
+                                                value: "20",
+                                            },
+                                        ),
+                                    ),
+                                ),
+                            },
+                        ),
                     ),
                 },
             ),

--- a/src/parser/snapshots/crochet__parser__tests__if_else.snap
+++ b/src/parser/snapshots/crochet__parser__tests__if_else.snap
@@ -25,12 +25,14 @@ Program {
                             },
                         ),
                     ),
-                    alternate: Lit(
-                        Num(
-                            Num {
-                                span: 21..23,
-                                value: "10",
-                            },
+                    alternate: Some(
+                        Lit(
+                            Num(
+                                Num {
+                                    span: 21..23,
+                                    value: "10",
+                                },
+                            ),
                         ),
                     ),
                 },

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -205,6 +205,19 @@ fn infer_if_else_with_widening() {
 }
 
 #[test]
+fn infer_only_if_must_be_undefined() {
+    let (_, ctx) = infer_prog("let x = if true { let a = 5; }");
+    let result = format!("{}", ctx.values.get("x").unwrap());
+    assert_eq!(result, "undefined");
+}
+
+#[test]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: \"unification failed\""]
+fn infer_only_if_must_be_undefined_error() {
+    infer_prog("let x = if true { let a = 5; a }");
+}
+
+#[test]
 fn infer_if_else_with_widening_of_top_level_vars() {
     let src = r#"
     let a = 5
@@ -1192,7 +1205,6 @@ fn return_empty() {
 }
 
 #[test]
-#[ignore] // TODO: figure out how to parse this
 fn return_empty_with_body() {
     let src = r#"
     let foo = () => {


### PR DESCRIPTION
When there's a trailing `;` in a block, the type of that block's value will be inferred as `undefined`.