### PR TITLE
Implement `if-let` for non-refutable patterns

### DIFF
--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -60,6 +60,7 @@ export const App = () => {
   const changeExample = (event: React.ChangeEvent<HTMLSelectElement>) => {
     let value = event.target.value;
     switch (value) {
+      case "ifLet":
       case "functionOverloading":
       case "asyncAwait":
       case "jsx":
@@ -97,6 +98,7 @@ export const App = () => {
           <option value="jsx">JSX</option>
           <option value="fibonacci">Fibonacci</option>
           <option value="functionOverloading">Function Overloading</option>
+          <option value="ifLet">if let</option>
         </select>
       </div>
       <div>

--- a/demo/examples.js
+++ b/demo/examples.js
@@ -41,3 +41,11 @@ export const functionOverloading = [
   "let num = add(5, 10)",
   'let str = add("hello, ", "world")',
 ].join("\n");
+
+export const ifLet = [
+  "let p = {x: 5, y: 10}",
+  "",
+  "if let {x, y} = p {",
+  "  let sum = x + y;",
+  "}",
+].join("\n");

--- a/demo/examples.js
+++ b/demo/examples.js
@@ -48,4 +48,8 @@ export const ifLet = [
   "if let {x, y} = p {",
   "  let sum = x + y;",
   "}",
+  "",
+  "if let {x: a, y: b} = p {",
+  "  let sum = a + b;",
+  "}",
 ].join("\n");

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -55,7 +55,14 @@ pub struct IfElse {
     pub span: Span,
     pub cond: Box<Expr>,
     pub consequent: Box<Expr>,
-    pub alternate: Box<Expr>,
+    pub alternate: Option<Box<Expr>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LetExpr {
+    pub span: Span,
+    pub pat: Pattern,
+    pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -152,6 +159,7 @@ pub enum Expr {
     JSXElement(JSXElement),
     Lambda(Lambda),
     Let(Let),
+    LetExpr(LetExpr), // should only be used in `if let` expressions
     Lit(Lit),
     Op(Op),
     Obj(Obj),

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -76,6 +76,9 @@ pub fn infer(
         }) => {
             let cond_type = infer(cond, ctx, constraints)?;
             let cons_type = infer(consequent, ctx, constraints)?;
+            // If the alternate isn't present, then the type of the 
+            // consequent should be inferred as the empty type
+            // TODO: add an empty type
             let alt_type = infer(alternate, ctx, constraints)?;
 
             constraints.push(Constraint::from((cond_type, ctx.prim(Primitive::Bool))));

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -79,13 +79,12 @@ pub fn infer(
         }) => {
             let result_type = ctx.fresh_var();
 
-            let cond_type = infer(cond, ctx, constraints)?;
-            let cons_type = infer(consequent, ctx, constraints)?;
-
             match alternate {
                 Some(alternate) => {
+                    let cond_type = infer(cond, ctx, constraints)?;
                     constraints.push(Constraint::from((cond_type, ctx.prim(Primitive::Bool))));
 
+                    let cons_type = infer(consequent, ctx, constraints)?;
                     let alt_type = infer(alternate, ctx, constraints)?;
                     // We use unfrozen copies of cons_type and alt_type so that they can
                     // be widened if need be.  This does not affect the original frozen
@@ -96,6 +95,48 @@ pub fn infer(
                     Ok(result_type)
                 }
                 None => {
+                    let (cond_type, cons_type) = match cond.as_ref() {
+                        Expr::LetExpr(LetExpr { pat, expr, .. }) => {
+                            let mut new_ctx = ctx.clone();
+
+                            let mut init_cs = vec![];
+                            let init_type = infer(expr, ctx, &mut init_cs)?;
+                            constraints.append(&mut init_cs);
+
+                            let subs = run_solve(&init_cs, ctx)?;
+
+                            let (mut pat_type, new_vars) =
+                                infer_pattern(pat, &mut new_ctx, constraints, &HashMap::new())?;
+                            pat_type.flag = Some(Flag::Pattern);
+
+                            // Add bindings for the new variables inside the consequent block.
+                            for (name, scheme) in new_vars {
+                                new_ctx.values.insert(name, scheme);
+                            }
+
+                            // Order matters here: value_type appearing first indicates that
+                            // it should be treated as a sub-type of pattern_type.
+                            constraints.push(Constraint::from((init_type, pat_type)));
+
+                            let mut cons_cs = vec![];
+                            let cons_type = infer(consequent, &new_ctx, &mut cons_cs)?;
+                            let mut cons_cs = cons_cs.apply(&subs);
+                            constraints.append(&mut cons_cs);
+
+                            // Ensures that type variable ids are unique.
+                            ctx.state.count.set(new_ctx.state.count.get());
+
+                            let cond_type = ctx.prim(Primitive::Bool);
+
+                            (cond_type, cons_type)
+                        },
+                        _ => {
+                            let cond_type = infer(cond, ctx, constraints)?;
+                            let cons_type = infer(consequent, ctx, constraints)?;
+
+                            (cond_type, cons_type)
+                        },
+                    };
                     constraints.push(Constraint::from((cond_type, ctx.prim(Primitive::Bool))));
 
                     // The alternative must be undefined
@@ -130,6 +171,7 @@ pub fn infer(
                         infer_pattern(pattern, &mut new_ctx, constraints, &HashMap::new())?;
                     pat_type.flag = Some(Flag::Pattern);
 
+                    // Add bindings for the new variables inside the body.
                     for (name, scheme) in new_vars {
                         new_ctx.values.insert(name, scheme);
                     }

--- a/src/infer/infer_prog.rs
+++ b/src/infer/infer_prog.rs
@@ -57,6 +57,11 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
                             &HashMap::new(),
                         )?;
 
+                        let result = infer(init, &ctx, &mut constraints)?;
+                        if let foo = result {
+                            5;
+                        };
+
                         let init_type = infer(init, &ctx, &mut constraints)?;
 
                         constraints.push(Constraint::from((init_type.clone(), pat_type.clone())));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -201,4 +201,9 @@ mod tests {
         insta::assert_debug_snapshot!(parse("let get_bar = <T>(foo: Foo<T>) => foo.bar"));
         insta::assert_debug_snapshot!(parse("declare let get_bar: (Foo) => T"));
     }
+
+    #[test]
+    fn if_let() {
+        insta::assert_debug_snapshot!(parse("if let {x, y} = p { x + y; }"));
+    }
 }

--- a/src/parser/snapshots/crochet__parser__tests__if_let.snap
+++ b/src/parser/snapshots/crochet__parser__tests__if_let.snap
@@ -1,0 +1,86 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"if let {x, y} = p { x + y; }\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..28,
+            expr: IfElse(
+                IfElse {
+                    span: 0..28,
+                    cond: LetExpr(
+                        LetExpr {
+                            span: 0..28,
+                            pat: Object(
+                                ObjectPat {
+                                    span: 7..14,
+                                    props: [
+                                        Assign(
+                                            AssignPatProp {
+                                                span: 8..9,
+                                                key: Ident {
+                                                    span: 8..9,
+                                                    name: "x",
+                                                },
+                                                value: None,
+                                            },
+                                        ),
+                                        Assign(
+                                            AssignPatProp {
+                                                span: 11..12,
+                                                key: Ident {
+                                                    span: 11..12,
+                                                    name: "y",
+                                                },
+                                                value: None,
+                                            },
+                                        ),
+                                    ],
+                                    optional: false,
+                                    type_ann: None,
+                                },
+                            ),
+                            expr: Ident(
+                                Ident {
+                                    span: 16..17,
+                                    name: "p",
+                                },
+                            ),
+                        },
+                    ),
+                    consequent: Let(
+                        Let {
+                            span: 20..0,
+                            pattern: None,
+                            init: Op(
+                                Op {
+                                    span: 20..25,
+                                    op: Add,
+                                    left: Ident(
+                                        Ident {
+                                            span: 20..21,
+                                            name: "x",
+                                        },
+                                    ),
+                                    right: Ident(
+                                        Ident {
+                                            span: 24..25,
+                                            name: "y",
+                                        },
+                                    ),
+                                },
+                            ),
+                            body: Empty(
+                                Empty {
+                                    span: 0..0,
+                                },
+                            ),
+                        },
+                    ),
+                    alternate: None,
+                },
+            ),
+        },
+    ],
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -228,7 +228,7 @@ impl fmt::Display for Type {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scheme {
     pub qualifiers: Vec<i32>,
     pub ty: Type,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -967,6 +967,8 @@ fn infer_destructure_all_object_properties() {
 
     let result = format!("{}", ctx.values.get("x").unwrap());
     assert_eq!(result, "5");
+    let result = format!("{}", ctx.values.get("y").unwrap());
+    assert_eq!(result, "10");
 }
 
 #[test]
@@ -978,6 +980,18 @@ fn infer_destructure_some_object_properties() {
     let (_, ctx) = infer_prog(src);
 
     let result = format!("{}", ctx.values.get("x").unwrap());
+    assert_eq!(result, "5");
+}
+
+#[test]
+fn infer_destructure_some_object_properties_with_renaming() {
+    let src = r#"
+    let point = {x: 5, y: 10}
+    let {x: a} = point
+    "#;
+    let (_, ctx) = infer_prog(src);
+
+    let result = format!("{}", ctx.values.get("a").unwrap());
     assert_eq!(result, "5");
 }
 
@@ -1253,6 +1267,41 @@ fn codegen_if_let() {
     (()=>{
         const { x , y  } = p;
         x + y;
+        return undefined;
+    })();
+    "###);
+
+    let result = codegen_d_ts(&program, &ctx);
+
+    insta::assert_snapshot!(result, @r###"
+    export declare const p: {
+        x: 5;
+        y: 10;
+    };
+    ;
+    "###);
+}
+
+#[test]
+fn codegen_if_let_with_rename() {
+    let src = r#"
+    let p = {x: 5, y: 10}
+    if let {x: a, y: b} = p {
+        a + b;
+    }
+    "#;
+
+    let (program, ctx) = infer_prog(src);
+
+    let js = codegen_js(&program);
+    insta::assert_snapshot!(js, @r###"
+    export const p = {
+        x: 5,
+        y: 10
+    };
+    (()=>{
+        const { x: a , y: b  } = p;
+        a + b;
         return undefined;
     })();
     "###);


### PR DESCRIPTION
This enables the following code to type-check and codeine:
```
let p = {x: 5, y: 10}
if let {x, y} = p {
   let sum = x + y;
}
```