### PR TITLE
Add support for 'is' refutable pattern

### DIFF
--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -11,6 +11,7 @@ pub enum Pattern {
     Object(ObjectPat),
     Array(ArrayPat),
     Lit(LitPat),
+    Is(IsPat),
     // This can't be used at the top level similar to rest
     // Assign(AssignPat),
 }
@@ -23,6 +24,7 @@ impl Pattern {
             Pattern::Object(obj) => obj.span.to_owned(),
             Pattern::Array(array) => array.span.to_owned(),
             Pattern::Lit(lit) => lit.span.to_owned(),
+            Pattern::Is(is) => is.span.to_owned(),
         }
     }
 }
@@ -38,6 +40,13 @@ pub struct BindingIdent {
 pub struct LitPat {
     pub span: Span,
     pub lit: Lit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IsPat {
+    pub span: Span,
+    pub id: Ident,
+    pub is_id: Ident,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,5 +112,6 @@ pub fn is_refutable(pat: &Pattern) -> bool {
             })
         }
         Pattern::Lit(_) => true,
+        Pattern::Is(_) => true,
     }
 }

--- a/src/codegen/d_ts.rs
+++ b/src/codegen/d_ts.rs
@@ -104,6 +104,7 @@ pub fn build_pattern(pattern: &ast::Pattern, value: Option<&ast::Expr>, ctx: &Co
         ast::Pattern::Object(_) => todo!(),
         ast::Pattern::Array(_) => todo!(),
         ast::Pattern::Lit(_) => todo!(),
+        ast::Pattern::Is(_) => todo!(),
     }
 }
 
@@ -122,6 +123,7 @@ pub fn build_pattern_rec(pattern: &ast::Pattern) -> Pat {
         ast::Pattern::Object(_) => todo!(),
         ast::Pattern::Array(_) => todo!(),
         ast::Pattern::Lit(_) => todo!(),
+        ast::Pattern::Is(_) => todo!(),
     }
 }
 
@@ -268,6 +270,7 @@ pub fn build_type(
                                     ast::Pattern::Object(_) => todo!(),
                                     ast::Pattern::Array(_) => todo!(),
                                     ast::Pattern::Lit(_) => todo!(),
+                                    ast::Pattern::Is(_) => todo!(),
                                 }
                             })
                             .collect();

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -222,6 +222,7 @@ pub fn build_pattern(pattern: &ast::Pattern) -> Pat {
             })
         }
         ast::Pattern::Lit(_) => todo!(),
+        ast::Pattern::Is(_) => todo!(),
     }
 }
 
@@ -281,6 +282,7 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
                         ast::Pattern::Object(_) => todo!(),
                         ast::Pattern::Array(_) => todo!(),
                         ast::Pattern::Lit(_) => todo!(),
+                        ast::Pattern::Is(_) => todo!(),
                     };
                     Pat::Ident(BindingIdent {
                         id: Ident {
@@ -815,6 +817,7 @@ fn get_conds_for_pat(pat: &ast::Pattern, conds: &mut Vec<Condition>, path: &mut 
                 check: Check::EqualLit(lit.to_owned()),
             });
         }
+        ast::Pattern::Is(_) => todo!(),
     }
 }
 

--- a/src/codegen/js.rs
+++ b/src/codegen/js.rs
@@ -222,7 +222,14 @@ pub fn build_pattern(pattern: &ast::Pattern) -> Pat {
             })
         }
         ast::Pattern::Lit(_) => todo!(),
-        ast::Pattern::Is(_) => todo!(),
+        ast::Pattern::Is(ast::IsPat { id, .. }) => Pat::Ident(BindingIdent {
+            id: Ident {
+                span: DUMMY_SP,
+                sym: JsWord::from(id.name.to_owned()),
+                optional: false,
+            },
+            type_ann: None,
+        }),
     }
 }
 
@@ -817,7 +824,21 @@ fn get_conds_for_pat(pat: &ast::Pattern, conds: &mut Vec<Condition>, path: &mut 
                 check: Check::EqualLit(lit.to_owned()),
             });
         }
-        ast::Pattern::Is(_) => todo!(),
+        ast::Pattern::Is(ast::IsPat { is_id, .. }) => match is_id.name.as_ref() {
+            "string" | "number" | "boolean" => {
+                conds.push(Condition {
+                    path: path.to_owned(),
+                    check: Check::Typeof(is_id.name.to_owned()),
+                });
+            }
+            _ => {
+                println!("adding Check::Instanceof condition");
+                conds.push(Condition {
+                    path: path.to_owned(),
+                    check: Check::Instanceof(is_id.to_owned()),
+                });
+            }
+        },
     }
 }
 
@@ -857,7 +878,25 @@ fn cond_to_expr(cond: &Condition, id: &Ident) -> Expr {
             left: Box::from(left),
             right: Box::from(Expr::from(lit)),
         }),
-        Check::Typeof(_) => todo!(),
-        Check::Instanceof(_) => todo!(),
+        Check::Typeof(str) => Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::EqEqEq,
+            left: Box::from(Expr::Unary(UnaryExpr {
+                span: DUMMY_SP,
+                op: UnaryOp::TypeOf,
+                arg: Box::from(left),
+            })),
+            right: Box::from(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: JsWord::from(str.to_owned()),
+                raw: None,
+            }))),
+        }),
+        Check::Instanceof(id) => Expr::Bin(BinExpr {
+            span: DUMMY_SP,
+            op: BinaryOp::InstanceOf,
+            left: Box::from(left),
+            right: Box::from(Expr::Ident(Ident::from(id))),
+        }),
     }
 }

--- a/src/infer/constraint_solver.rs
+++ b/src/infer/constraint_solver.rs
@@ -208,6 +208,11 @@ fn unify_mismatched_types(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, 
         }
     }
 
+    // TODO: just checking if it's a subtype is not sufficient when doing pattern
+    // matching or destructuring.  For refutable patterns such as `literals`, the
+    // sub-type check should be reversed.  Instead of using `is_subtype` for these
+    // checks, we should instead have a `matches` function to check if one type
+    // can be said to "match" another.
     if is_subtype(t2, t1, ctx)? {
         if let Some(Flag::MatchPattern) = t2.flag {
             return Ok(Subst::new())

--- a/src/infer/infer_expr.rs
+++ b/src/infer/infer_expr.rs
@@ -107,7 +107,7 @@ pub fn infer(
 
                             let (pat_type, new_vars) =
                                 infer_pattern(pat, &mut new_ctx, constraints, &HashMap::new())?;
-                            let pat_type = set_flag(pat_type, &Flag::Pattern);
+                            let pat_type = set_flag(pat_type, &Flag::MatchPattern);
 
                             // Add bindings for the new variables inside the consequent block.
                             for (name, scheme) in new_vars {
@@ -169,7 +169,7 @@ pub fn infer(
 
                     let (pat_type, new_vars) =
                         infer_pattern(pattern, &mut new_ctx, constraints, &HashMap::new())?;
-                    let pat_type = set_flag(pat_type, &Flag::Pattern);
+                    let pat_type = set_flag(pat_type, &Flag::AssignPattern);
 
                     // Add bindings for the new variables inside the body.
                     for (name, scheme) in new_vars {

--- a/src/infer/infer_lambda.rs
+++ b/src/infer/infer_lambda.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::iter::Iterator;
 
 use crate::ast::*;
-use crate::types::{self, Flag, Type, Variant};
+use crate::types::{self, set_flag, Flag, Type, Variant};
 
 use super::constraint_solver::Constraint;
 use super::context::Context;
@@ -42,7 +42,7 @@ pub fn infer_lambda(
     let param_types: Result<Vec<Type>, String> = params
         .iter()
         .map(|param| {
-            let (mut param_type, new_vars) =
+            let (param_type, new_vars) =
                 infer_pattern(param, &mut new_ctx, constraints, &type_params_map)?;
 
             // NOTE: We may not actually need to do this.  The tests pass without it.
@@ -51,7 +51,7 @@ pub fn infer_lambda(
             // TODO: set the flag to Flag::Param so that we have more semantic
             // information if and when we need to resolve conflicts in the constraint
             // solver.
-            param_type.flag = Some(Flag::Parameter);
+            let param_type = set_flag(param_type, &Flag::Parameter);
 
             // Inserts any new variables introduced by infer_pattern() into
             // the current context.

--- a/src/infer/infer_prog.rs
+++ b/src/infer/infer_prog.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::ast::*;
-use crate::types::freeze_scheme;
+use crate::types::{freeze_scheme, set_flag, Flag};
 
 use super::constraint_solver::{is_subtype, run_solve, Constraint};
 use super::context::Context;
@@ -57,6 +57,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
                             &mut constraints,
                             &HashMap::new(),
                         )?;
+                        let pat_type = set_flag(pat_type, &Flag::AssignPattern);
                       
                         let init_type = infer(init, &ctx, &mut constraints)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -207,5 +207,6 @@ mod tests {
         insta::assert_debug_snapshot!(parse("if let {x, y} = p { x + y; }"));
         insta::assert_debug_snapshot!(parse("if let {x: a, y: b} = p { a + b; }"));
         insta::assert_debug_snapshot!(parse("if let {x: 5, y} = p { y; }"));
+        insta::assert_debug_snapshot!(parse("if let a is string = value"));
     }
 }

--- a/src/parser/snapshots/crochet__parser__tests__if_let-4.snap
+++ b/src/parser/snapshots/crochet__parser__tests__if_let-4.snap
@@ -1,0 +1,42 @@
+---
+source: src/parser/mod.rs
+expression: "parse(\"if let a is string = value\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..2,
+            expr: Ident(
+                Ident {
+                    span: 0..2,
+                    name: "if",
+                },
+            ),
+        },
+        VarDecl {
+            span: 3..26,
+            pattern: Is(
+                IsPat {
+                    span: 7..18,
+                    id: Ident {
+                        span: 7..8,
+                        name: "a",
+                    },
+                    is_id: Ident {
+                        span: 12..18,
+                        name: "string",
+                    },
+                },
+            ),
+            init: Some(
+                Ident(
+                    Ident {
+                        span: 21..26,
+                        name: "value",
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,7 +116,8 @@ pub enum Flag {
     MemberAccess,
     Parameter,
     Argument,
-    Pattern,
+    AssignPattern,
+    MatchPattern,
 }
 
 #[derive(Clone, Debug, Eq)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1248,6 +1248,27 @@ fn infer_if_let() {
 }
 
 #[test]
+fn infer_if_let_with_is() {
+    // NOTE:
+    // `if-let` should allow the LHS to be any sub type of the RHS
+    // this is the reverse of what `let` allows.
+    // TODO:
+    // - create separate flags for pattern matching for assignment
+    let src = r#"
+    declare let b: string | number
+    if let a is string = b {
+        a;
+    }
+    "#;
+
+    let (_, ctx) = infer_prog(src);
+
+    assert_eq!(format!("{}", ctx.values.get("b").unwrap()), "string | number");
+    // Ensures we aren't polluting the outside context
+    assert!(ctx.values.get("a").is_none());
+}
+
+#[test]
 fn codegen_if_let() {
     let src = r#"
     let p = {x: 5, y: 10}


### PR DESCRIPTION
TODO:
- [x] js codegen
- [x] unit testing

There's a bunch of stuff this doesn't handle yet.  I'm going to introduce a utility function in a separate PR to help with determining if a type matches another type in the context of pattern matching and if-let.