### PR TITLE
Start alternative type inference implementation based on THIH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "crochet_thih"
+version = "0.1.0"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "crates/crochet_codegen",
     "crates/crochet_infer",
     "crates/crochet_parser",
+    "crates/crochet_thih",
 ]

--- a/crates/crochet_thih/Cargo.toml
+++ b/crates/crochet_thih/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "crochet_thih"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/crochet_thih/src/assump.rs
+++ b/crates/crochet_thih/src/assump.rs
@@ -1,0 +1,4 @@
+use super::id::*;
+use super::scheme::*;
+
+pub type Assump = (ID, Scheme);

--- a/crates/crochet_thih/src/id.rs
+++ b/crates/crochet_thih/src/id.rs
@@ -1,0 +1,1 @@
+pub type ID = String;

--- a/crates/crochet_thih/src/lib.rs
+++ b/crates/crochet_thih/src/lib.rs
@@ -1,9 +1,14 @@
 pub mod assump;
 pub mod id;
 pub mod pred;
-pub mod r#type;
 pub mod scheme;
 pub mod subst;
+
+pub mod lit;
+pub mod prim;
+pub mod r#type;
+
+pub mod unify;
 
 // Definitions:
 // - Pred == InIn(ID, Type)

--- a/crates/crochet_thih/src/lib.rs
+++ b/crates/crochet_thih/src/lib.rs
@@ -1,0 +1,29 @@
+pub mod assump;
+pub mod id;
+pub mod pred;
+pub mod r#type;
+pub mod scheme;
+pub mod subst;
+
+// Definitions:
+// - Pred == InIn(ID, Type)
+// - Qual<T> == (Vec<Pred>, T>)
+// - Assump == (ID, Scheme)
+// - Subst == Vec<(Tyvar, Type)>
+
+// Kind is used by Haskell as an optimization.  If the kinds
+// don't match then further checking isn't required.  In crochet
+// we can't use kinds because it supports:
+// - sub-typing
+// - optional function params
+// - optional properties on object types
+// - etc.
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/crochet_thih/src/lib.rs
+++ b/crates/crochet_thih/src/lib.rs
@@ -8,6 +8,7 @@ pub mod lit;
 pub mod prim;
 pub mod r#type;
 
+pub mod subtyping;
 pub mod unify;
 
 // Definitions:

--- a/crates/crochet_thih/src/lit.rs
+++ b/crates/crochet_thih/src/lit.rs
@@ -1,0 +1,12 @@
+use std::hash::Hash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Lit {
+    // We store all of the values as strings since f64 doesn't
+    // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.
+    Num(String),
+    Bool(bool),
+    Str(String),
+    // Null,
+    // Undefined,
+}

--- a/crates/crochet_thih/src/pred.rs
+++ b/crates/crochet_thih/src/pred.rs
@@ -1,0 +1,11 @@
+use super::r#type::*;
+use super::id::*;
+
+// data Pred   = IsIn Id Type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Pred {
+    IsIn(ID, Type)
+}
+
+// data Qual t = [Pred] :=> t
+pub type Qual<T> = (Pred, T);

--- a/crates/crochet_thih/src/prim.rs
+++ b/crates/crochet_thih/src/prim.rs
@@ -1,0 +1,10 @@
+use std::hash::Hash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Prim {
+    Num,
+    Bool,
+    Str,
+    // Undefined,
+    // Null,
+}

--- a/crates/crochet_thih/src/scheme.rs
+++ b/crates/crochet_thih/src/scheme.rs
@@ -1,0 +1,8 @@
+use super::r#type::*;
+use super::pred::*;
+
+// data Scheme = Forall [Kind] (Qual Type)
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Scheme {
+    Forall(Qual<Type>)
+}

--- a/crates/crochet_thih/src/subst.rs
+++ b/crates/crochet_thih/src/subst.rs
@@ -21,6 +21,6 @@ pub fn at_at(s1: &Subst, s2: &Subst) -> Subst {
     s2.iter()
         .map(|(u, t)| (u.to_owned(), t.apply(s1)))
         .into_iter()
-        .chain(s2.iter().cloned())
+        .chain(s1.iter().cloned())
         .collect()
 }

--- a/crates/crochet_thih/src/subst.rs
+++ b/crates/crochet_thih/src/subst.rs
@@ -1,0 +1,5 @@
+use super::id::*;
+use super::r#type::*;
+
+// type Subst  = [(Tyvar, Type)]
+pub type Subst = Vec<(ID, Type)>;

--- a/crates/crochet_thih/src/subst.rs
+++ b/crates/crochet_thih/src/subst.rs
@@ -1,5 +1,26 @@
+use std::collections::HashSet;
+
 use super::id::*;
 use super::r#type::*;
 
 // type Subst  = [(Tyvar, Type)]
 pub type Subst = Vec<(ID, Type)>;
+
+// class Types t where
+//   apply :: Subst -> t -> t
+//   tv    :: t -> [Tyvar]
+pub trait Types {
+    fn apply(&self, subs: &Subst) -> Self;
+    fn tv(&self) -> HashSet<ID>;
+}
+
+// infixr 4 @@
+// (@@)       :: Subst -> Subst -> Subst
+// s1 @@ s2    = [ (u, apply s1 t) | (u,t) <- s2 ] ++ s1
+pub fn at_at(s1: &Subst, s2: &Subst) -> Subst {
+    s2.iter()
+        .map(|(u, t)| (u.to_owned(), t.apply(s1)))
+        .into_iter()
+        .chain(s2.iter().cloned())
+        .collect()
+}

--- a/crates/crochet_thih/src/subtyping.rs
+++ b/crates/crochet_thih/src/subtyping.rs
@@ -1,0 +1,130 @@
+use super::lit::Lit;
+use super::prim::Prim;
+use super::r#type::*;
+
+#[derive(PartialEq, Eq)]
+pub enum Rel {
+    Subtype,
+    Supertype,
+}
+
+pub fn is_subtype(t1: &Type, t2: &Type) -> bool {
+    match (&t1.variant, &t2.variant) {
+        (Variant::Lit(lit), Variant::Prim(prim)) => {
+            matches!(
+                (lit, prim),
+                (Lit::Num(_), Prim::Num) | (Lit::Str(_), Prim::Str) | (Lit::Bool(_), Prim::Bool)
+            )
+        }
+        (Variant::Lam(args1, ret1), Variant::Lam(args2, ret2)) => {
+            // t1 must have at fewer number of args than t2 in order to called with the
+            // same args as t2.  This is because excess args are ignored my functions.
+            if args1.len() > args2.len() {
+                return false;
+            }
+
+            // If any of the t2's args are not subtypes of the corresponding t1 arg, then
+            // t1 cannot be safely called in place of t2.
+            if args1.iter().zip(args2).any(|(a1, a2)| !is_subtype(a2, a1)) {
+                return false;
+            }
+
+            // t1's return type must be a subtype of t2's return type.
+            is_subtype(ret1, ret2)
+        }
+        // If the types are the same then they are subtypes of each other.
+        (v1, v2) => v1 == v2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::lit::Lit;
+    use crate::prim::Prim;
+
+    fn num(val: &str) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Num(val.to_owned())),
+        }
+    }
+
+    fn str(val: &str) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Str(val.to_owned())),
+        }
+    }
+
+    fn bool(val: &bool) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Bool(val.to_owned())),
+        }
+    }
+
+    fn prim(prim: Prim) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Prim(prim),
+        }
+    }
+
+    fn lam(args: &[Type], ret: &Type) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Lam(args.to_owned(), Box::from(ret.to_owned())),
+        }
+    }
+
+    #[test]
+    fn lit_is_subtype_of_matching_prim() {
+        assert!(is_subtype(&num("5"), &prim(Prim::Num)));
+        assert!(is_subtype(&bool(&true), &prim(Prim::Bool)));
+        assert!(is_subtype(&str("hello"), &prim(Prim::Str)));
+    }
+
+    #[test]
+    fn lam_with_fewer_args_is_a_subtype() {
+        let lam1 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        let lam2 = lam(&[prim(Prim::Num), prim(Prim::Str)], &prim(Prim::Bool));
+        assert!(is_subtype(&lam1, &lam2));
+    }
+
+    #[test]
+    fn lam_with_supertype_args_is_a_subtype() {
+        let lam1 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        let lam2 = lam(&[num("5")], &prim(Prim::Bool));
+        assert!(is_subtype(&lam1, &lam2));
+    }
+
+    #[test]
+    fn lam_with_subtype_return_is_a_subtype() {
+        let lam1 = lam(&[prim(Prim::Num)], &bool(&true));
+        let lam2 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        assert!(is_subtype(&lam1, &lam2));
+    }
+
+    #[test]
+    fn lam_with_more_args_is_not_a_subtype() {
+        let lam1 = lam(&[prim(Prim::Num), prim(Prim::Str)], &prim(Prim::Bool));
+        let lam2 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        assert!(!is_subtype(&lam1, &lam2));
+    }
+
+    #[test]
+    fn lam_with_subtype_args_is_not_a_subtype() {
+        let lam1 = lam(&[num("5")], &prim(Prim::Bool));
+        let lam2 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        assert!(!is_subtype(&lam1, &lam2));
+    }
+
+    #[test]
+    fn lam_with_supertype_return_is_not_a_subtype() {
+        let lam1 = lam(&[prim(Prim::Num)], &prim(Prim::Bool));
+        let lam2 = lam(&[prim(Prim::Num)], &bool(&true));
+        assert!(!is_subtype(&lam1, &lam2));
+    }
+}

--- a/crates/crochet_thih/src/type.rs
+++ b/crates/crochet_thih/src/type.rs
@@ -1,0 +1,22 @@
+use super::id::*;
+
+// data Tyvar = Tyvar Id Kind
+//              deriving Eq
+
+// data Tycon = Tycon Id Kind
+//              deriving Eq
+
+// data Type  = TVar Tyvar | TCon Tycon | TAp  Type Type | TGen Int
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Type {
+    Var(ID),
+    Con(ID),
+    App(Box<Type>, Box<Type>),
+    Lam(Box<Type>, Box<Type>), // TODO: support n-ary args in the future
+}
+
+// NOTES:
+// - we can't use Kind because it's incompatible with crochet's type system
+// - Lam is introduced as a replacement for Kind
+// - additional types will be added into the future to fill other gaps due
+//   to the absence of Kind

--- a/crates/crochet_thih/src/type.rs
+++ b/crates/crochet_thih/src/type.rs
@@ -16,7 +16,7 @@ use super::subst::*;
 pub enum Variant {
     Var(ID),
     // Replaces TCon and TAp
-    Lam(Box<Type>, Box<Type>), // TODO: support n-ary args in the future
+    Lam(Vec<Type>, Box<Type>), // TODO: support n-ary args in the future
     Lit(Lit),
     Prim(Prim),
     // TODO: support more data types
@@ -65,11 +65,12 @@ impl Types for Type {
                     },
                 }
             },
-            Variant::Lam(arg, ret) => {
+            Variant::Lam(args, ret) => {
                 Type {
                     usage: None,
                     variant: Variant::Lam(
-                        Box::from(arg.as_ref().apply(s)),
+                        args.to_owned().apply(s),
+                        // Box::from(arg.as_ref().apply(s)),
                         Box::from(ret.as_ref().apply(s)),
                     ),
                 }
@@ -89,5 +90,17 @@ impl Types for Type {
             },
             _ => HashSet::new(),
         }
+    }
+}
+
+impl<I> Types for Vec<I>
+where
+    I: Types,
+{
+    fn apply(&self, subs: &Subst) -> Vec<I> {
+        self.iter().map(|c| c.apply(subs)).collect()
+    }
+    fn tv(&self) -> HashSet<ID> {
+        self.iter().flat_map(|c| c.tv()).collect()
     }
 }

--- a/crates/crochet_thih/src/type.rs
+++ b/crates/crochet_thih/src/type.rs
@@ -70,7 +70,6 @@ impl Types for Type {
                     usage: None,
                     variant: Variant::Lam(
                         args.to_owned().apply(s),
-                        // Box::from(arg.as_ref().apply(s)),
                         Box::from(ret.as_ref().apply(s)),
                     ),
                 }

--- a/crates/crochet_thih/src/type.rs
+++ b/crates/crochet_thih/src/type.rs
@@ -1,4 +1,9 @@
+use std::collections::HashSet;
+
 use super::id::*;
+use super::lit::*;
+use super::prim::*;
+use super::subst::*;
 
 // data Tyvar = Tyvar Id Kind
 //              deriving Eq
@@ -10,13 +15,59 @@ use super::id::*;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     Var(ID),
-    Con(ID),
-    App(Box<Type>, Box<Type>),
+    // Replaces TCon and TAp
     Lam(Box<Type>, Box<Type>), // TODO: support n-ary args in the future
+    Lit(Lit),
+    Prim(Prim),
+    // TODO: support more data types
 }
+
+// NOTES ON FLAGS:
+// - flags can be used to indicate additional properties of the type
+//   e.g. decl vs. call or arg vs. param
+// - these flags can be used to determine when sub-typing is allowed
+//   e.g. passing a number literal to as an arg for a param that's
+//   a number primitive
+// - QUESTINON: when creating (or applying) a substitution, should the
+//   flag be copied from the type variable to the target type?
 
 // NOTES:
 // - we can't use Kind because it's incompatible with crochet's type system
-// - Lam is introduced as a replacement for Kind
+// - Lam is a replacement for TCon and TAp since we can't use Kind
 // - additional types will be added into the future to fill other gaps due
 //   to the absence of Kind
+
+fn lookup(u: &ID, s: &Subst) -> Option<Type> {
+    s.iter().find(|(v, _)| u == v).map(|(_, t)| t.to_owned())
+}
+
+impl Types for Type {
+    fn apply(&self, s: &Subst) -> Type {
+        match self {
+            Type::Var(u) => {
+                match lookup(u, s) {
+                    Some(t) => t,
+                    None => Type::Var(u.to_owned()),
+                }
+            },
+            Type::Lam(arg, ret) => Type::Lam(
+                Box::from(arg.as_ref().apply(s)),
+                Box::from(ret.as_ref().apply(s)),
+            ),
+            t => t.to_owned(),
+        }
+    }
+    fn tv(&self) -> HashSet<ID> {
+        match self {
+            Type::Var(u) => {
+                let mut set = HashSet::new();
+                set.insert(u.to_owned());
+                set
+            },
+            Type::Lam(arg, ret) => {
+                arg.tv().union(&ret.tv()).cloned().collect()
+            },
+            _ => HashSet::new(),
+        }
+    }
+}

--- a/crates/crochet_thih/src/unify.rs
+++ b/crates/crochet_thih/src/unify.rs
@@ -8,7 +8,7 @@ use super::subst::*;
 pub enum Rel {
     Sub,
     Sup,
-    Exact,
+    Eql,
 }
 
 // mgu (TAp l r) (TAp l' r') = do s1 <- mgu l l'
@@ -19,33 +19,41 @@ pub enum Rel {
 // mgu (TCon tc1) (TCon tc2)
 //            | tc1==tc2 = return nullSubst
 // mgu t1 t2             = fail "types do not unify"
-pub fn mgu(t1: &Type, t2: &Type, rel: Rel) -> Subst {
-    if rel == Rel::Sup {
-        return mgu(t2, t1, Rel::Sub);
+pub fn mgu(t1: &Type, t2: &Type, rel: &Rel) -> Subst {
+    if rel == &Rel::Sup {
+        return mgu(t2, t1, &Rel::Sub);
     }
 
-    match (t1, t2) {
-        (Type::Var(u), t) | (t, Type::Var(u)) => var_bind(u, t),
-        (Type::Lam(arg1, ret1), Type::Lam(arg2, ret2)) => {
-            // TODO: tag the types so that we can differentiate between a
-            // Lam that's coming from the decl vs. one that's coming from
-            // a call (application).
-            let s1 = mgu(arg1, arg2, Rel::Exact);
-            let s2 = mgu(&ret1.apply(&s1), &ret2.apply(&s1), Rel::Exact);
+    match (&t1.variant, &t2.variant) {
+        (Variant::Var(u), _) => var_bind(u, t2),
+        (_, Variant::Var(u)) => var_bind(u, t1),
+        (Variant::Lam(arg1, ret1), Variant::Lam(arg2, ret2)) => {
+            let rel = match (&t1.usage, &t2.usage) {
+                (Some(Usage::FnCall), Some(Usage::FnDecl)) => Rel::Sub,
+                (Some(Usage::FnDecl), Some(Usage::FnCall)) => Rel::Sup,
+                (_, _) => Rel::Eql,
+            };
+
+            let s1 = mgu(arg1.as_ref(), arg2.as_ref(), &rel);
+            let s2 = mgu(&ret1.apply(&s1), &ret2.apply(&s1), &rel);
             at_at(&s2, &s1)
         }
-        (Type::Lit(lit1), Type::Lit(lit2)) if lit1 == lit2 => Subst::new(),
-        (Type::Prim(prim1), Type::Prim(prim2)) if prim1 == prim2 => Subst::new(),
-        (Type::Lit(lit), Type::Prim(prim)) if rel == Rel::Sub => {
-            match (lit, prim) {
-                (Lit::Num(_), Prim::Num) => Subst::new(),
-                (Lit::Str(_), Prim::Str) => Subst::new(),
-                (Lit::Bool(_), Prim::Bool) => Subst::new(),
-                _ => panic!("types do not unify"),
-            }
-        }
+        (Variant::Lit(lit1), Variant::Lit(lit2)) if lit1 == lit2 => Subst::new(),
+        (Variant::Prim(prim1), Variant::Prim(prim2)) if prim1 == prim2 => Subst::new(),
+        (v1, v2) if is_subtype(v1, v2) => Subst::new(),
         // TODO: support more data types
         _ => panic!("types do not unify"),
+    }
+}
+
+fn is_subtype(v1: &Variant, v2: &Variant) -> bool {
+    if let (Variant::Lit(lit), Variant::Prim(prim)) = (v1, v2) {
+        matches!(
+            (lit, prim),
+            (Lit::Num(_), Prim::Num) | (Lit::Str(_), Prim::Str) | (Lit::Bool(_), Prim::Bool)
+        )
+    } else {
+        false
     }
 }
 
@@ -55,7 +63,7 @@ pub fn mgu(t1: &Type, t2: &Type, rel: Rel) -> Subst {
 //             | otherwise        = return (u +-> t)
 // NOTE: the `kind` check is omitted since Kind is incompatible with Crochet's type system
 fn var_bind(id: &ID, t: &Type) -> Subst {
-    if *t == Type::Var(id.to_owned()) {
+    if t.variant == Variant::Var(id.to_owned()) {
         Subst::new()
     } else if t.tv().contains(id) {
         panic!("occurs check fails")
@@ -71,70 +79,123 @@ mod tests {
     use crate::lit::Lit;
     use crate::prim::Prim;
 
+    fn var(id: &str) -> Type {
+        Type {
+            usage: None,
+            variant: Variant::Var(id.to_owned()),
+        }
+    }
+
     fn num(val: &str) -> Type {
-        Type::Lit(Lit::Num(val.to_owned()))
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Num(val.to_owned())),
+        }
     }
 
     fn str(val: &str) -> Type {
-        Type::Lit(Lit::Str(val.to_owned()))
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Str(val.to_owned())),
+        }
     }
 
     fn bool(val: &bool) -> Type {
-        Type::Lit(Lit::Bool(val.to_owned()))
+        Type {
+            usage: None,
+            variant: Variant::Lit(Lit::Bool(val.to_owned())),
+        }
     }
 
     fn prim(prim: Prim) -> Type {
-        Type::Prim(prim)
+        Type {
+            usage: None,
+            variant: Variant::Prim(prim),
+        }
     }
 
     fn lam(arg: &Type, ret: &Type) -> Type {
-        Type::Lam(Box::from(arg.to_owned()), Box::from(ret.to_owned()))
+        Type {
+            usage: None,
+            variant: Variant::Lam(Box::from(arg.to_owned()), Box::from(ret.to_owned())),
+        }
+    }
+
+    #[test]
+    fn bindings() {
+        let result = mgu(&num("5"), &var("v1"), &Rel::Eql);
+        assert_eq!(result, vec![(String::from("v1"), num("5"))]);
+
+        let result = mgu(
+            &lam(&prim(Prim::Str), &var("v1")),
+            &lam(&var("v2"), &prim(Prim::Bool)),
+            &Rel::Eql,
+        );
+        assert_eq!(
+            result,
+            vec![
+                (String::from("v2"), prim(Prim::Str)),
+                (String::from("v1"), prim(Prim::Bool)),
+            ]
+        );
     }
 
     #[test]
     fn equal_lits() {
-        let result = mgu(&num("5"), &num("5"), Rel::Exact);
+        let result = mgu(&num("5"), &num("5"), &Rel::Eql);
         assert_eq!(result, Subst::new());
     }
 
     #[test]
     #[should_panic = "types do not unify"]
     fn unequal_lits() {
-        mgu(&num("5"), &num("15"), Rel::Exact);
+        mgu(&num("5"), &num("15"), &Rel::Eql);
     }
 
     #[test]
     fn equal_prims() {
-        let result = mgu(&prim(Prim::Num), &prim(Prim::Num), Rel::Exact);
+        let result = mgu(&prim(Prim::Num), &prim(Prim::Num), &Rel::Eql);
         assert_eq!(result, Subst::new());
     }
 
     #[test]
     #[should_panic = "types do not unify"]
     fn unequal_prims() {
-        mgu(&prim(Prim::Str), &prim(Prim::Num), Rel::Exact);
+        mgu(&prim(Prim::Str), &prim(Prim::Num), &Rel::Eql);
     }
 
     #[test]
     fn lit_and_prim_subtyping() {
-        assert_eq!(mgu(&num("5"), &prim(Prim::Num), Rel::Sub), Subst::new());
-        assert_eq!(mgu(&str("hello"), &prim(Prim::Str), Rel::Sub), Subst::new());
-        assert_eq!(mgu(&bool(&true), &prim(Prim::Bool), Rel::Sub), Subst::new());
+        assert_eq!(mgu(&num("5"), &prim(Prim::Num), &Rel::Sub), Subst::new());
+        assert_eq!(
+            mgu(&str("hello"), &prim(Prim::Str), &Rel::Sub),
+            Subst::new()
+        );
+        assert_eq!(
+            mgu(&bool(&true), &prim(Prim::Bool), &Rel::Sub),
+            Subst::new()
+        );
     }
 
     #[test]
     fn lit_and_prim_supertyping() {
-        assert_eq!(mgu(&prim(Prim::Num), &num("5"), Rel::Sup), Subst::new());
-        assert_eq!(mgu(&prim(Prim::Str), &str("hello"), Rel::Sup), Subst::new());
-        assert_eq!(mgu(&prim(Prim::Bool), &bool(&true), Rel::Sup), Subst::new());
+        assert_eq!(mgu(&prim(Prim::Num), &num("5"), &Rel::Sup), Subst::new());
+        assert_eq!(
+            mgu(&prim(Prim::Str), &str("hello"), &Rel::Sup),
+            Subst::new()
+        );
+        assert_eq!(
+            mgu(&prim(Prim::Bool), &bool(&true), &Rel::Sup),
+            Subst::new()
+        );
     }
 
     #[test]
     fn equal_lams() {
         let result = mgu(
             &lam(&prim(Prim::Num), &prim(Prim::Num)),
-            &lam(&prim(Prim::Num), &prim(Prim::Num)), 
-            Rel::Exact,
+            &lam(&prim(Prim::Num), &prim(Prim::Num)),
+            &Rel::Eql,
         );
         assert_eq!(result, Subst::new());
     }
@@ -144,8 +205,39 @@ mod tests {
     fn unequal_lams() {
         mgu(
             &lam(&prim(Prim::Num), &prim(Prim::Num)),
-            &lam(&prim(Prim::Str), &prim(Prim::Str)), 
-            Rel::Exact,
+            &lam(&prim(Prim::Str), &prim(Prim::Str)),
+            &Rel::Eql,
         );
+    }
+
+    #[test]
+    fn call_and_decl_with_subtypes() {
+        let mut call = lam(&num("5"), &num("10"));
+        call.usage = Some(Usage::FnCall);
+        let mut decl = lam(&prim(Prim::Num), &prim(Prim::Num));
+        decl.usage = Some(Usage::FnDecl);
+
+        assert_eq!(mgu(&call, &decl, &Rel::Eql), Subst::new());
+    }
+
+    #[test]
+    fn call_and_decl() {
+        let mut call = lam(&prim(Prim::Num), &prim(Prim::Num));
+        call.usage = Some(Usage::FnCall);
+        let mut decl = lam(&prim(Prim::Num), &prim(Prim::Num));
+        decl.usage = Some(Usage::FnDecl);
+
+        assert_eq!(mgu(&call, &decl, &Rel::Eql), Subst::new());
+    }
+
+    #[test]
+    #[should_panic = "types do not unify"]
+    fn call_and_decl_supertype_failure() {
+        let mut call = lam(&prim(Prim::Num), &prim(Prim::Num));
+        call.usage = Some(Usage::FnCall);
+        let mut decl = lam(&num("5"), &num("10"));
+        decl.usage = Some(Usage::FnDecl);
+
+        mgu(&call, &decl, &Rel::Eql);
     }
 }

--- a/crates/crochet_thih/src/unify.rs
+++ b/crates/crochet_thih/src/unify.rs
@@ -1,0 +1,151 @@
+use super::id::ID;
+use super::lit::Lit;
+use super::prim::Prim;
+use super::r#type::*;
+use super::subst::*;
+
+#[derive(PartialEq, Eq)]
+pub enum Rel {
+    Sub,
+    Sup,
+    Exact,
+}
+
+// mgu (TAp l r) (TAp l' r') = do s1 <- mgu l l'
+//                                s2 <- mgu (apply s1 r) (apply s1 r')
+//                                return (s2 @@ s1)
+// mgu (TVar u) t        = varBind u t
+// mgu t (TVar u)        = varBind u t
+// mgu (TCon tc1) (TCon tc2)
+//            | tc1==tc2 = return nullSubst
+// mgu t1 t2             = fail "types do not unify"
+pub fn mgu(t1: &Type, t2: &Type, rel: Rel) -> Subst {
+    if rel == Rel::Sup {
+        return mgu(t2, t1, Rel::Sub);
+    }
+
+    match (t1, t2) {
+        (Type::Var(u), t) | (t, Type::Var(u)) => var_bind(u, t),
+        (Type::Lam(arg1, ret1), Type::Lam(arg2, ret2)) => {
+            // TODO: tag the types so that we can differentiate between a
+            // Lam that's coming from the decl vs. one that's coming from
+            // a call (application).
+            let s1 = mgu(arg1, arg2, Rel::Exact);
+            let s2 = mgu(&ret1.apply(&s1), &ret2.apply(&s1), Rel::Exact);
+            at_at(&s2, &s1)
+        }
+        (Type::Lit(lit1), Type::Lit(lit2)) if lit1 == lit2 => Subst::new(),
+        (Type::Prim(prim1), Type::Prim(prim2)) if prim1 == prim2 => Subst::new(),
+        (Type::Lit(lit), Type::Prim(prim)) if rel == Rel::Sub => {
+            match (lit, prim) {
+                (Lit::Num(_), Prim::Num) => Subst::new(),
+                (Lit::Str(_), Prim::Str) => Subst::new(),
+                (Lit::Bool(_), Prim::Bool) => Subst::new(),
+                _ => panic!("types do not unify"),
+            }
+        }
+        // TODO: support more data types
+        _ => panic!("types do not unify"),
+    }
+}
+
+// varBind u t | t == TVar u      = return nullSubst
+//             | u `elem` tv t    = fail "occurs check fails"
+//             | kind u /= kind t = fail "kinds do not match"
+//             | otherwise        = return (u +-> t)
+// NOTE: the `kind` check is omitted since Kind is incompatible with Crochet's type system
+fn var_bind(id: &ID, t: &Type) -> Subst {
+    if *t == Type::Var(id.to_owned()) {
+        Subst::new()
+    } else if t.tv().contains(id) {
+        panic!("occurs check fails")
+    } else {
+        vec![(id.to_owned(), t.to_owned())]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::lit::Lit;
+    use crate::prim::Prim;
+
+    fn num(val: &str) -> Type {
+        Type::Lit(Lit::Num(val.to_owned()))
+    }
+
+    fn str(val: &str) -> Type {
+        Type::Lit(Lit::Str(val.to_owned()))
+    }
+
+    fn bool(val: &bool) -> Type {
+        Type::Lit(Lit::Bool(val.to_owned()))
+    }
+
+    fn prim(prim: Prim) -> Type {
+        Type::Prim(prim)
+    }
+
+    fn lam(arg: &Type, ret: &Type) -> Type {
+        Type::Lam(Box::from(arg.to_owned()), Box::from(ret.to_owned()))
+    }
+
+    #[test]
+    fn equal_lits() {
+        let result = mgu(&num("5"), &num("5"), Rel::Exact);
+        assert_eq!(result, Subst::new());
+    }
+
+    #[test]
+    #[should_panic = "types do not unify"]
+    fn unequal_lits() {
+        mgu(&num("5"), &num("15"), Rel::Exact);
+    }
+
+    #[test]
+    fn equal_prims() {
+        let result = mgu(&prim(Prim::Num), &prim(Prim::Num), Rel::Exact);
+        assert_eq!(result, Subst::new());
+    }
+
+    #[test]
+    #[should_panic = "types do not unify"]
+    fn unequal_prims() {
+        mgu(&prim(Prim::Str), &prim(Prim::Num), Rel::Exact);
+    }
+
+    #[test]
+    fn lit_and_prim_subtyping() {
+        assert_eq!(mgu(&num("5"), &prim(Prim::Num), Rel::Sub), Subst::new());
+        assert_eq!(mgu(&str("hello"), &prim(Prim::Str), Rel::Sub), Subst::new());
+        assert_eq!(mgu(&bool(&true), &prim(Prim::Bool), Rel::Sub), Subst::new());
+    }
+
+    #[test]
+    fn lit_and_prim_supertyping() {
+        assert_eq!(mgu(&prim(Prim::Num), &num("5"), Rel::Sup), Subst::new());
+        assert_eq!(mgu(&prim(Prim::Str), &str("hello"), Rel::Sup), Subst::new());
+        assert_eq!(mgu(&prim(Prim::Bool), &bool(&true), Rel::Sup), Subst::new());
+    }
+
+    #[test]
+    fn equal_lams() {
+        let result = mgu(
+            &lam(&prim(Prim::Num), &prim(Prim::Num)),
+            &lam(&prim(Prim::Num), &prim(Prim::Num)), 
+            Rel::Exact,
+        );
+        assert_eq!(result, Subst::new());
+    }
+
+    #[test]
+    #[should_panic = "types do not unify"]
+    fn unequal_lams() {
+        mgu(
+            &lam(&prim(Prim::Num), &prim(Prim::Num)),
+            &lam(&prim(Prim::Str), &prim(Prim::Str)), 
+            Rel::Exact,
+        );
+    }
+}


### PR DESCRIPTION
THIH = Typing Haskell in Haskell.

This PR implements `mgu()` along with basic subtype handling.