### PR TITLE
Allow calls with args that are subtypes of params, enable partial application

### DIFF
--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -57,7 +57,7 @@ impl Context {
         scheme.ty.apply(&subs)
     }
 
-    fn fresh_id(&self) -> i32 {
+    pub fn fresh_id(&self) -> i32 {
         let id = self.state.count.get() + 1;
         self.state.count.set(id);
         id
@@ -82,7 +82,7 @@ impl Context {
         Type {
             id: self.fresh_id(),
             frozen: false,
-            variant: Variant::Lam(types::LamType { params, ret }),
+            variant: Variant::Lam(types::LamType { params, ret, is_call: false }),
             flag,
         }
     }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -952,12 +952,29 @@ mod tests {
     fn pass_callback_with_too_few_params() {
         let src = r#"
         declare let fold_num: ((number, number) => boolean, number) => number
-        let result = fold_num((x) => x, 0)
+        let result = fold_num((x) => true, 0)
         "#;
 
         let ctx = infer_prog(src);
 
         assert_eq!(get_type("result", &ctx), "number");
+    }
+
+    #[test]
+    #[should_panic="Couldn't unify lambdas"]
+    fn pass_callback_with_too_many_params() {
+        // This is not allowed because `fold_num` can't provide all of the params
+        // that the callback is expecting and it would result in partial application
+        // when the `fold_num` is not expecting it.  While it's possible to conceive
+        // of a scenario where a callback returns a function and a partially applied
+        // calback results in correct function, allowing this in the type checker
+        // is bound to result in confusing and hard to understand code.
+        let src = r#"
+        declare let fold_num: ((number, number) => boolean, number) => number
+        let result = fold_num((x, y, z) => true, 0)
+        "#;
+
+        infer_prog(src);
     }
 
     // TODO: TypeScript takes the union of the params when unifying them

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -36,9 +36,10 @@ impl Substitutable for Type {
                 let variant = match &self.variant {
                     Variant::Var => self.variant.to_owned(),
                     // TODO: handle widening of lambdas
-                    Variant::Lam(LamType { params, ret }) => Variant::Lam(LamType {
-                        params: params.iter().map(|param| param.apply(sub)).collect(),
-                        ret: Box::from(ret.apply(sub)),
+                    Variant::Lam(lam) => Variant::Lam(LamType {
+                        is_call: lam.is_call,
+                        params: lam.params.iter().map(|param| param.apply(sub)).collect(),
+                        ret: Box::from(lam.ret.apply(sub)),
                     }),
                     Variant::Prim(_) => self.variant.to_owned(),
                     Variant::Lit(_) => self.variant.to_owned(),

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -53,6 +53,7 @@ impl Hash for VarType {
 pub struct LamType {
     pub params: Vec<Type>, // TOOD: rename this params
     pub ret: Box<Type>,
+    pub is_call: bool,
 }
 
 impl PartialEq for LamType {
@@ -188,6 +189,7 @@ fn set_frozen(ty: Type, frozen: bool) -> Type {
     let variant = match ty.variant {
         Variant::Var => Variant::Var,
         Variant::Lam(lam) => Variant::Lam(LamType {
+            is_call: lam.is_call,
             params: lam.params.into_iter().map(freeze).collect(),
             ret: Box::from(freeze(lam.ret.as_ref().clone())),
         }),
@@ -238,6 +240,7 @@ pub fn set_flag(ty: Type, flag: &Flag) -> Type {
     let variant = match ty.variant {
         Variant::Var => Variant::Var,
         Variant::Lam(lam) => Variant::Lam(LamType {
+            is_call: lam.is_call,
             params: lam.params.into_iter().map(|p| set_flag(p, flag)).collect(),
             ret: Box::from(set_flag(lam.ret.as_ref().clone(), flag)),
         }),

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -35,15 +35,16 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
     fn norm_type(ty: &Type, mapping: &HashMap<i32, Type>, ctx: &Context) -> Type {
         match &ty.variant {
             Variant::Var => mapping.get(&ty.id).unwrap().to_owned(),
-            Variant::Lam(LamType { params, ret }) => {
-                let params: Vec<_> = params
+            Variant::Lam(lam) => {
+                let params: Vec<_> = lam.params
                     .iter()
                     .map(|param| norm_type(param, mapping, ctx))
                     .collect();
                 Type {
                     variant: Variant::Lam(LamType {
+                        is_call: lam.is_call,
                         params,
-                        ret: Box::from(norm_type(ret, mapping, ctx)),
+                        ret: Box::from(norm_type(&lam.ret, mapping, ctx)),
                     }),
                     ..ty.to_owned()
                 }


### PR DESCRIPTION
TODO:
- [x] differentiate between unifying a call vs unifying two lambdas when assigning or passing a lambda as a param