### PR TITLE
Update parser to handle arbitrary interleaving of member access and function calls

### DIFF
--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -155,9 +155,7 @@ mod tests {
         insta::assert_debug_snapshot!(parse("a.b.c"));
         insta::assert_debug_snapshot!(parse("foo.bar()"));
         insta::assert_debug_snapshot!(parse("p.x * p.x + p.y * p.y"));
-        // TODO: rework the parser to allow this test case to pass
-        // This likely requires extracting `atom` out into its own recursive parser
-        // insta::assert_debug_snapshot!(parse("foo().bar()"));
+        insta::assert_debug_snapshot!(parse("foo().bar()"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-4.snap
@@ -1,0 +1,40 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"foo().bar()\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..11,
+            expr: App(
+                App {
+                    span: 0..11,
+                    lam: Member(
+                        Member {
+                            span: 0..9,
+                            obj: App(
+                                App {
+                                    span: 0..5,
+                                    lam: Ident(
+                                        Ident {
+                                            span: 0..3,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    args: [],
+                                },
+                            ),
+                            prop: Ident(
+                                Ident {
+                                    span: 5..9,
+                                    name: "bar",
+                                },
+                            ),
+                        },
+                    ),
+                    args: [],
+                },
+            ),
+        },
+    ],
+}


### PR DESCRIPTION
This allows us to do things like: `foo().bar()` which weren't possible before.  This is an important step in our ability to support fluent APIs in the future.