### PR TITLE
Infer rest/spread

### DIFF
--- a/crates/crochet_ast/src/expr.rs
+++ b/crates/crochet_ast/src/expr.rs
@@ -96,7 +96,19 @@ pub struct Op {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Obj {
     pub span: Span,
-    pub props: Vec<Prop>,
+    pub props: Vec<PropOrSpread>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PropOrSpread {
+    Spread(SpreadElement),
+    Prop(Box<Prop>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpreadElement {
+    pub span: Span,
+    pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -455,23 +455,28 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
             let props: Vec<PropOrSpread> = props
                 .iter()
                 .map(|prop| match prop {
-                    ast::Prop::Shorthand(ast::ident::Ident { name, .. }) => {
-                        PropOrSpread::Prop(Box::from(Prop::Shorthand(Ident {
-                            span: DUMMY_SP,
-                            sym: JsWord::from(name.clone()),
-                            optional: false,
-                        })))
-                    }
-                    ast::Prop::KeyValue(ast::KeyValueProp { name, value, .. }) => {
-                        PropOrSpread::Prop(Box::from(Prop::KeyValue(KeyValueProp {
-                            key: PropName::from(Ident {
-                                span: DUMMY_SP,
-                                sym: JsWord::from(name.clone()),
-                                optional: false,
-                            }),
-                            value: Box::from(build_expr(value)),
-                        })))
-                    }
+                    ast::PropOrSpread::Prop(prop) => {
+                        match prop.as_ref() {
+                            ast::Prop::Shorthand(ast::ident::Ident { name, .. }) => {
+                                PropOrSpread::Prop(Box::from(Prop::Shorthand(Ident {
+                                    span: DUMMY_SP,
+                                    sym: JsWord::from(name.clone()),
+                                    optional: false,
+                                })))
+                            }
+                            ast::Prop::KeyValue(ast::KeyValueProp { name, value, .. }) => {
+                                PropOrSpread::Prop(Box::from(Prop::KeyValue(KeyValueProp {
+                                    key: PropName::from(Ident {
+                                        span: DUMMY_SP,
+                                        sym: JsWord::from(name.clone()),
+                                        optional: false,
+                                    }),
+                                    value: Box::from(build_expr(value)),
+                                })))
+                            }
+                        }
+                    },
+                    ast::PropOrSpread::Spread(_) => todo!(),
                 })
                 .collect();
 

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -8,7 +8,7 @@ use super::context::{Context, Env};
 use super::infer_type_ann::*;
 use super::substitutable::Subst;
 use super::types::{self, freeze_scheme, Scheme, Type, Variant};
-use super::util::{generalize, normalize};
+use super::util::{generalize, normalize, simplify_intersection};
 
 pub fn infer_prog(prog: &Program) -> Result<Context, String> {
     let mut ctx: Context = Context::default();
@@ -358,25 +358,41 @@ fn infer(ctx: &Context, expr: &Expr) -> Result<(Subst, Type), String> {
         Expr::Obj(Obj { props, .. }) => {
             let mut ss: Vec<Subst> = vec![];
             let mut ps: Vec<types::TProp> = vec![];
+            let mut spread_types: Vec<_> = vec![];
             for p in props {
                 match p {
-                    Prop::Shorthand(_) => {
-                        // TODO: lookup the value in the current ctx
-                        todo!()
+                    PropOrSpread::Prop(p) => {
+                        match p.as_ref() {
+                            Prop::Shorthand(_) => {
+                                // TODO: lookup the value in the current ctx
+                                todo!()
+                            }
+                            Prop::KeyValue(KeyValueProp { name, value, .. }) => {
+                                let (s, t) = infer(ctx, value)?;
+                                ss.push(s);
+                                // TODO: check if the inferred type is T | undefined and use that
+                                // determine the value of optional
+                                ps.push(ctx.prop(name, t, false));
+                            }
+                        }
                     }
-                    Prop::KeyValue(KeyValueProp { name, value, .. }) => {
-                        let (s, t) = infer(ctx, value)?;
+                    PropOrSpread::Spread(SpreadElement { expr, .. }) => {
+                        let (s, t) = infer(ctx, expr)?;
                         ss.push(s);
-                        // TODO: check if the inferred type is T | undefined and use that
-                        // determine the value of optional
-                        ps.push(ctx.prop(name, t, false));
+                        spread_types.push(t);
                     }
                 }
             }
 
             let s = compose_many_subs(&ss);
-            let t = ctx.object(ps);
-            Ok((s, t))
+            if spread_types.is_empty() {
+                let t = ctx.object(ps);
+                Ok((s, t))
+            } else {
+                spread_types.push(ctx.object(ps));
+                let t = simplify_intersection(&spread_types, ctx);
+                Ok((s, t))
+            }
         }
         Expr::Await(_) => todo!(),
         Expr::Tuple(Tuple { elems, .. }) => {
@@ -436,7 +452,7 @@ fn unwrap_member_type(t: &Type, ctx: &Context) -> Type {
         if let Variant::Object(props) = &member.obj.as_ref().variant {
             let prop = props.iter().find(|prop| prop.name == member.prop);
             if let Some(prop) = prop {
-                return prop.get_type(ctx)
+                return prop.get_type(ctx);
             }
         }
     }
@@ -717,6 +733,24 @@ fn union_types(t1: &Type, t2: &Type, ctx: &Context) -> Type {
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
 fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
     let result = match (&t1.variant, &t2.variant) {
+        (_, Variant::Alias(types::AliasType { name, .. })) => {
+            match ctx.types.get(name) {
+                Some(scheme) => {
+                    // TODO: handle schemes with qualifiers
+                    unify(t1, &scheme.ty, ctx)
+                }
+                None => panic!("Can't find alias '{name}' in context"),
+            }
+        }
+        (Variant::Alias(types::AliasType { name, .. }), _) => {
+            match ctx.types.get(name) {
+                Some(scheme) => {
+                    // TODO: handle schemes with qualifiers
+                    unify(&scheme.ty, t2, ctx)
+                }
+                None => panic!("Can't find alias '{name}' in context"),
+            }
+        }
         (Variant::Lit(lit), Variant::Prim(prim)) => {
             let b = matches!(
                 (lit, prim),
@@ -841,26 +875,80 @@ fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 false => Err(String::from("Unification failure")),
             }
         }
-        (_, Variant::Alias(types::AliasType { name, .. })) => {
-            match ctx.types.get(name) {
-                Some(scheme) => {
-                    // TODO: handle schemes with qualifiers
-                    unify(t1, &scheme.ty, ctx)
-                }
-                None => panic!("Can't find alias '{name}' in context"),
-            }
-        }
-        (Variant::Alias(types::AliasType { name, .. }), _) => {
-            match ctx.types.get(name) {
-                Some(scheme) => {
-                    // TODO: handle schemes with qualifiers
-                    unify(&scheme.ty, t2, ctx)
-                }
-                None => panic!("Can't find alias '{name}' in context"),
-            }
-        }
         (Variant::Var, _) => bind(&t1.id, t2),
         (_, Variant::Var) => bind(&t2.id, t1),
+        (Variant::Object(props), Variant::Intersection(types)) => {
+            // NOTE: This assumes that the intersection has exactly two types and that
+            // one is an object type and the other is a type variable.
+            let obj_types: Vec<_> = types
+                .iter()
+                .filter(|t| matches!(t.variant, Variant::Object(_)))
+                .cloned()
+                .collect();
+            let rest_types: Vec<_> = types
+                .iter()
+                .filter(|t| matches!(t.variant, Variant::Var))
+                .cloned()
+                .collect();
+
+            let obj_type = simplify_intersection(&obj_types, ctx);
+
+            let s1 = unify(t1, &obj_type, ctx)?;
+
+            let obj_props = if let Variant::Object(props) = &obj_type.variant {
+                props.to_owned()
+            } else {
+                vec![]
+            };
+
+            let rest_props: Vec<_> = props
+                .iter()
+                .filter(|p| !obj_props.iter().any(|op| op.name == p.name))
+                .cloned()
+                .collect();
+
+            let rest_type = rest_types.get(0).unwrap();
+            let s2 = unify(&ctx.object(rest_props), rest_type, ctx)?;
+
+            let s = compose_subs(&s2, &s1);
+            Ok(s)
+        }
+        (Variant::Intersection(types), Variant::Object(props)) => {
+            let obj_types: Vec<_> = types
+                .iter()
+                .filter(|t| matches!(t.variant, Variant::Object(_)))
+                .cloned()
+                .collect();
+            let rest_types: Vec<_> = types
+                .iter()
+                .filter(|t| matches!(t.variant, Variant::Var))
+                .cloned()
+                .collect();
+
+            let obj_type = simplify_intersection(&obj_types, ctx);
+
+            match rest_types.len() {
+                0 => unify(&obj_type, t2, ctx),
+                1 => {
+                    let obj_props = match &obj_type.variant {
+                        Variant::Object(props) => props.to_owned(),
+                        _ => vec![],
+                    };
+
+                    let (obj_props, rest_props): (Vec<_>, Vec<_>) = props.iter().cloned()
+                        .partition(|p| obj_props.iter().any(|op| op.name == p.name));
+
+                    let s_obj = unify(&obj_type, &ctx.object(obj_props), ctx)?;
+
+                    let rest_type = rest_types.get(0).unwrap();
+                    let s_rest = unify(rest_type, &ctx.object(rest_props), ctx)?;
+
+                    let s = compose_subs(&s_rest, &s_obj);
+                    Ok(s)
+                }
+                _ => Err(String::from("Unification is undecidable")),
+            }
+        }
         (v1, v2) => {
             if v1 == v2 {
                 Ok(Subst::new())

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1124,6 +1124,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic="Only one rest is allowed in an object pattern"]
+    fn destructure_obj_with_rest_undecidable() {
+        let src = r#"
+        declare let point: {x: number, y: number, z?: number}
+        let {z, ...p, ...q} = point
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("q", &ctx), "{x: number, y: number}");
+    }
+
+    #[test]
     fn spread_an_object() {
         let src = r#"
         declare let point: {x: number, y: number}
@@ -1170,5 +1182,18 @@ mod tests {
         let ctx = infer_prog(src);
 
         assert_eq!(get_type("mag_2d", &ctx), "({x: number, y: number}) => number");
+    }
+
+    #[test]
+    #[should_panic="Unification is undecidable"]
+    fn infer_obj_from_spread_undecidable() {
+        let src = r#"
+        type Point = {x: number, y: number, z: number}
+        declare let mag: (Point) => number
+        let mag_2d = (p, q) => {
+            mag({...p, ...q, z: 0})
+        }
+        "#;
+        infer_prog(src);
     }
 }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -177,8 +177,6 @@ pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
         .collect();
     props.sort_by_key(|prop| prop.name.clone()); // ensure a stable order
 
-    let obj_type = ctx.object(props);
-
     let mut not_obj_types: Vec<_> = in_types
         .iter()
         .filter(|ty| !matches!(ty.variant, Variant::Object(_)))
@@ -187,7 +185,9 @@ pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
 
     let mut out_types = vec![];
     out_types.append(&mut not_obj_types);
-    out_types.push(obj_type);
+    if !props.is_empty() {
+        out_types.push(ctx.object(props));
+    }
     out_types.sort_by_key(|ty| ty.id); // ensure a stable order
 
     if out_types.len() == 1 {

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -190,11 +190,16 @@ mod tests {
         insta::assert_debug_snapshot!(parse("let foo = ([a, b]: [string, number]) => a"));
         insta::assert_debug_snapshot!(parse("let foo = ({a, b}) => b"));
         insta::assert_debug_snapshot!(parse("let foo = ({a, b}: {a: string, b: number}) => b"));
-        // TODO: renaming properties when destructuring objects
         // TODO: assigning defaults
         // TODO: type annotations
         // TODO: function params
         // TODO: disallowed patterns, e.g. top-level rest, non-top-level type annotations
+    }
+
+    #[test]
+    #[should_panic="Only one rest is allowed in an object pattern"]
+    fn multiple_rests_is_invalid() {
+        insta::assert_debug_snapshot!(parse("let {z, ...p, ...q} = point"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -107,6 +107,7 @@ mod tests {
     fn objects() {
         insta::assert_debug_snapshot!(parse("{x: 5, y: 10}"));
         insta::assert_debug_snapshot!(parse("let obj = {x, y}"));
+        insta::assert_debug_snapshot!(parse("let obj = {a, b, ...others}"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -203,6 +203,12 @@ mod tests {
     }
 
     #[test]
+    #[should_panic="Rest should come last in object pattern"]
+    fn rest_that_isnt_last_is_invalid() {
+        insta::assert_debug_snapshot!(parse("let {...p, z} = point"));
+    }
+
+    #[test]
     fn types() {
         insta::assert_debug_snapshot!(parse("let get_bar = <T>(foo: Foo<T>) => foo.bar"));
         insta::assert_debug_snapshot!(parse("declare let get_bar: (Foo) => T"));

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-3.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"let obj = {x, y}\")"
+expression: "parse(\"let obj = {a, b, ...others}\")"
 ---
 Program {
     body: [
         VarDecl {
-            span: 0..16,
+            span: 0..27,
             pattern: Ident(
                 BindingIdent {
                     span: 4..7,
@@ -19,13 +19,13 @@ Program {
             init: Some(
                 Obj(
                     Obj {
-                        span: 10..16,
+                        span: 10..27,
                         props: [
                             Prop(
                                 Shorthand(
                                     Ident {
                                         span: 11..12,
-                                        name: "x",
+                                        name: "a",
                                     },
                                 ),
                             ),
@@ -33,9 +33,20 @@ Program {
                                 Shorthand(
                                     Ident {
                                         span: 14..15,
-                                        name: "y",
+                                        name: "b",
                                     },
                                 ),
+                            ),
+                            Spread(
+                                SpreadElement {
+                                    span: 17..26,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 20..26,
+                                            name: "others",
+                                        },
+                                    ),
+                                },
                             ),
                         ],
                     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects.snap
@@ -10,33 +10,37 @@ Program {
                 Obj {
                     span: 0..13,
                     props: [
-                        KeyValue(
-                            KeyValueProp {
-                                span: 1..5,
-                                name: "x",
-                                value: Lit(
-                                    Num(
-                                        Num {
-                                            span: 4..5,
-                                            value: "5",
-                                        },
+                        Prop(
+                            KeyValue(
+                                KeyValueProp {
+                                    span: 1..5,
+                                    name: "x",
+                                    value: Lit(
+                                        Num(
+                                            Num {
+                                                span: 4..5,
+                                                value: "5",
+                                            },
+                                        ),
                                     ),
-                                ),
-                            },
+                                },
+                            ),
                         ),
-                        KeyValue(
-                            KeyValueProp {
-                                span: 7..12,
-                                name: "y",
-                                value: Lit(
-                                    Num(
-                                        Num {
-                                            span: 10..12,
-                                            value: "10",
-                                        },
+                        Prop(
+                            KeyValue(
+                                KeyValueProp {
+                                    span: 7..12,
+                                    name: "y",
+                                    value: Lit(
+                                        Num(
+                                            Num {
+                                                span: 10..12,
+                                                value: "10",
+                                            },
+                                        ),
                                     ),
-                                ),
-                            },
+                                },
+                            ),
                         ),
                     ],
                 },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-4.snap
@@ -29,33 +29,37 @@ Program {
                     Obj {
                         span: 15..28,
                         props: [
-                            KeyValue(
-                                KeyValueProp {
-                                    span: 16..20,
-                                    name: "x",
-                                    value: Lit(
-                                        Num(
-                                            Num {
-                                                span: 19..20,
-                                                value: "5",
-                                            },
+                            Prop(
+                                KeyValue(
+                                    KeyValueProp {
+                                        span: 16..20,
+                                        name: "x",
+                                        value: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 19..20,
+                                                    value: "5",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                },
+                                    },
+                                ),
                             ),
-                            KeyValue(
-                                KeyValueProp {
-                                    span: 22..27,
-                                    name: "y",
-                                    value: Lit(
-                                        Num(
-                                            Num {
-                                                span: 25..27,
-                                                value: "10",
-                                            },
+                            Prop(
+                                KeyValue(
+                                    KeyValueProp {
+                                        span: 22..27,
+                                        name: "y",
+                                        value: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 25..27,
+                                                    value: "10",
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                },
+                                    },
+                                ),
                             ),
                         ],
                     },


### PR DESCRIPTION
We currently use intersection types to model spread/rest at the type level.  This isn't actually the behaviour we want long term but it'll be good enough for now.