### PR TITLE
Add support for tagged template literals

### DIFF
--- a/crates/crochet/tests/codegen_test.rs
+++ b/crates/crochet/tests/codegen_test.rs
@@ -14,6 +14,19 @@ fn string_literal() {
 }
 
 #[test]
+fn template_literal() {
+    let src = r#"
+    let name = "world"
+    let msg = `hello, ${name}!`
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    export const name = "world";
+    export const msg = `hello, ${name}!`;
+    "###);
+}
+
+#[test]
 fn number_literal_whole() {
     insta::assert_snapshot!(compile("123"), @"123;");
 }

--- a/crates/crochet_ast/src/expr.rs
+++ b/crates/crochet_ast/src/expr.rs
@@ -176,6 +176,27 @@ pub struct Empty {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateElem {
+    pub span: Span,
+    pub raw: Lit,
+    pub cooked: Lit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateLiteral {
+    pub span: Span,
+    pub exprs: Vec<Expr>,
+    pub quasis: Vec<TemplateElem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedTemplateLiteral {
+    pub span: Span,
+    pub tag: Ident,
+    pub template: TemplateLiteral,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     App(App),
     Fix(Fix),
@@ -192,6 +213,8 @@ pub enum Expr {
     Tuple(Tuple),
     Member(Member),
     Empty(Empty),
+    TemplateLiteral(TemplateLiteral),
+    TaggedTemplateLiteral(TaggedTemplateLiteral),
 }
 
 impl Expr {
@@ -212,6 +235,8 @@ impl Expr {
             Expr::Member(member) => member.span.to_owned(),
             Expr::Empty(empty) => empty.span.to_owned(),
             Expr::LetExpr(let_expr) => let_expr.span.to_owned(),
+            Expr::TemplateLiteral(tl) => tl.span.to_owned(),
+            Expr::TaggedTemplateLiteral(ttl) => ttl.span.to_owned(),
         }
     }
 }

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -528,6 +528,12 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
         ast::Expr::LetExpr(_) => {
             panic!("LetExpr should always be handled by the IfElse branch")
         }
+        ast::Expr::TemplateLiteral(_) => {
+            todo!()
+        }
+        ast::Expr::TaggedTemplateLiteral(_) => {
+            todo!()
+        }
     }
 }
 

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -492,7 +492,7 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
             span: DUMMY_SP,
             elems: elems
                 .iter()
-                .map(|ast::ExprOrSpread {spread, expr}| {
+                .map(|ast::ExprOrSpread { spread, expr }| {
                     Some(ExprOrSpread {
                         spread: spread.to_owned().map(|_| DUMMY_SP),
                         expr: Box::from(build_expr(expr.as_ref())),
@@ -528,8 +528,33 @@ pub fn build_expr(expr: &ast::Expr) -> Expr {
         ast::Expr::LetExpr(_) => {
             panic!("LetExpr should always be handled by the IfElse branch")
         }
-        ast::Expr::TemplateLiteral(_) => {
-            todo!()
+        ast::Expr::TemplateLiteral(ast::TemplateLiteral { exprs, quasis, .. }) => {
+            Expr::Tpl(Tpl {
+                span: DUMMY_SP,
+                exprs: exprs
+                    .iter()
+                    .map(|expr| Box::from(build_expr(expr)))
+                    .collect(),
+                quasis: quasis
+                    .iter()
+                    .map(|quasi| {
+                        let cooked = match &quasi.cooked {
+                            ast::Lit::Str(ast::Str { value, .. }) => value,
+                            _ => panic!("quasi.cooked must be a string"),
+                        };
+                        let raw = match &quasi.raw {
+                            ast::Lit::Str(ast::Str { value, .. }) => value,
+                            _ => panic!("quasi.raw must be a string"),
+                        };
+                        TplElement {
+                            span: DUMMY_SP,
+                            cooked: Some(JsWord::from(cooked.to_owned())),
+                            raw: JsWord::from(raw.to_owned()),
+                            tail: false, // TODO: set this to `true` if it's the last quasi
+                        }
+                    })
+                    .collect(),
+            })
         }
         ast::Expr::TaggedTemplateLiteral(_) => {
             todo!()

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -390,10 +390,22 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             let s = Subst::default();
             Ok((s, t))
         }
-        Expr::TemplateLiteral(_) => {
-            todo!()
+        Expr::TemplateLiteral(TemplateLiteral { exprs, quasis: _, .. }) => {
+            let t = ctx.prim(Primitive::Str);
+            let result: Result<Vec<(Subst, Type)>, String> = exprs.iter().map(|expr| {
+                infer_expr(ctx, expr)
+            }).collect();
+            // We ignore the types of expressions if there are any because any expression
+            // in JavaScript has a string representation.
+            let (ss, _): (Vec<_>, Vec<_>) = result?.iter().cloned().unzip();
+            let s = compose_many_subs(&ss);
+            Ok((s, t))
         }
         Expr::TaggedTemplateLiteral(_) => {
+            // TODO: treat this like a call/application
+            // NOTE: requires:
+            // - arrays
+            // - rest params
             todo!()
         }
     };

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -390,6 +390,12 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             let s = Subst::default();
             Ok((s, t))
         }
+        Expr::TemplateLiteral(_) => {
+            todo!()
+        }
+        Expr::TaggedTemplateLiteral(_) => {
+            todo!()
+        }
     };
 
     let (s, t) = result?;

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1308,24 +1308,24 @@ mod tests {
     }
 
     #[test]
-    #[should_panic="not enough elements to unpack"]
+    #[should_panic = "not enough elements to unpack"]
     fn infer_tuple_rest_no_enough_elements_to_unpack() {
         let src = r#"
         let tuple = [5]
         let [a, ...b, c] = tuple
         "#;
-        
+
         infer_prog(src);
     }
 
     #[test]
-    #[should_panic="Only one rest pattern is allowed in a tuple"]
+    #[should_panic = "Only one rest pattern is allowed in a tuple"]
     fn infer_tuple_more_than_one_rest() {
         let src = r#"
         let tuple = [5, "hello", true]
         let [a, ...b, ...c, d] = tuple
         "#;
-        
+
         infer_prog(src);
     }
 
@@ -1400,8 +1400,7 @@ mod tests {
 
         assert_eq!(get_type("tuple", &ctx), "[5, \"hello\", true]");
     }
-    
-    
+
     #[test]
     fn infer_multiple_tuple_spreads() {
         let src = r#"
@@ -1415,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic="Can only spread tuple types inside a tuple"]
+    #[should_panic = "Can only spread tuple types inside a tuple"]
     fn spread_non_tuple_type_should_fail() {
         let src = r#"
         let p = {x: 5, y: 10}
@@ -1625,9 +1624,8 @@ mod tests {
         infer_prog(src);
     }
 
-    // let h = (f, x, y) => f(x) + f(y)
     #[test]
-    fn this_should_work() {
+    fn infer_fn_based_on_multiple_different_calls() {
         let src = r#"let h = (f, x, y) => f(x) + f(y)"#;
         let ctx = infer_prog(src);
 
@@ -1635,5 +1633,29 @@ mod tests {
             get_type("h", &ctx),
             "<t0>((t0) => number, t0, t0) => number"
         );
+    }
+
+    #[test]
+    fn infer_template_literal_as_string() {
+        let src = r#"let str = `hello, "world"!`"#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("str", &ctx), "string");
+    }
+
+    #[test]
+    fn infer_template_literal_with_expressions_as_string() {
+        let src = r#"let str = `hello, ${true}!`"#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("str", &ctx), "string");
+    }
+
+    #[test]
+    #[should_panic="Unification failure"]
+    fn detect_type_errors_inside_template_literal_expressions() {
+        let src = r#"let str = `hello, ${5 + true}!`"#;
+        
+        infer_prog(src);
     }
 }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -47,6 +47,16 @@ mod tests {
     }
 
     #[test]
+    fn template_literals() {
+        insta::assert_debug_snapshot!(parse("`Hello, world`"));
+        insta::assert_debug_snapshot!(parse("`Hello, ${name}`"));
+        insta::assert_debug_snapshot!(parse("`(${x}, ${y})`"));
+        insta::assert_debug_snapshot!(parse("`Hello, \"world\"`"));
+        insta::assert_debug_snapshot!(parse("`foo ${`bar ${baz}`}`"));
+        insta::assert_debug_snapshot!(parse("sql`SELECT * FROM ${table} WHERE id = ${id}`"));
+    }
+
+    #[test]
     fn operations() {
         insta::assert_debug_snapshot!(parse("1 + 2 - 3"));
         insta::assert_debug_snapshot!(parse("x * y / z"));

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-2.snap
@@ -1,0 +1,56 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"`Hello, ${name}`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..16,
+            expr: TemplateLiteral(
+                TemplateLiteral {
+                    span: 0..16,
+                    exprs: [
+                        Ident(
+                            Ident {
+                                span: 10..14,
+                                name: "name",
+                            },
+                        ),
+                    ],
+                    quasis: [
+                        TemplateElem {
+                            span: 1..10,
+                            raw: Str(
+                                Str {
+                                    span: 1..10,
+                                    value: "Hello, ",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 1..10,
+                                    value: "Hello, ",
+                                },
+                            ),
+                        },
+                        TemplateElem {
+                            span: 15..16,
+                            raw: Str(
+                                Str {
+                                    span: 15..16,
+                                    value: "",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 15..16,
+                                    value: "",
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-3.snap
@@ -1,0 +1,77 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"`(${x}, ${y})`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..14,
+            expr: TemplateLiteral(
+                TemplateLiteral {
+                    span: 0..14,
+                    exprs: [
+                        Ident(
+                            Ident {
+                                span: 4..5,
+                                name: "x",
+                            },
+                        ),
+                        Ident(
+                            Ident {
+                                span: 10..11,
+                                name: "y",
+                            },
+                        ),
+                    ],
+                    quasis: [
+                        TemplateElem {
+                            span: 1..4,
+                            raw: Str(
+                                Str {
+                                    span: 1..4,
+                                    value: "(",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 1..4,
+                                    value: "(",
+                                },
+                            ),
+                        },
+                        TemplateElem {
+                            span: 6..10,
+                            raw: Str(
+                                Str {
+                                    span: 6..10,
+                                    value: ", ",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 6..10,
+                                    value: ", ",
+                                },
+                            ),
+                        },
+                        TemplateElem {
+                            span: 12..14,
+                            raw: Str(
+                                Str {
+                                    span: 12..14,
+                                    value: ")",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 12..14,
+                                    value: ")",
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-4.snap
@@ -1,0 +1,34 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"`Hello, \\\"world\\\"`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..16,
+            expr: TemplateLiteral(
+                TemplateLiteral {
+                    span: 0..16,
+                    exprs: [],
+                    quasis: [
+                        TemplateElem {
+                            span: 1..16,
+                            raw: Str(
+                                Str {
+                                    span: 1..16,
+                                    value: "Hello, \"world\"",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 1..16,
+                                    value: "Hello, \"world\"",
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-5.snap
@@ -1,0 +1,95 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"`foo ${`bar ${baz}`}`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..21,
+            expr: TemplateLiteral(
+                TemplateLiteral {
+                    span: 0..21,
+                    exprs: [
+                        TemplateLiteral(
+                            TemplateLiteral {
+                                span: 7..19,
+                                exprs: [
+                                    Ident(
+                                        Ident {
+                                            span: 14..17,
+                                            name: "baz",
+                                        },
+                                    ),
+                                ],
+                                quasis: [
+                                    TemplateElem {
+                                        span: 8..14,
+                                        raw: Str(
+                                            Str {
+                                                span: 8..14,
+                                                value: "bar ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                span: 8..14,
+                                                value: "bar ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        span: 18..19,
+                                        raw: Str(
+                                            Str {
+                                                span: 18..19,
+                                                value: "",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                span: 18..19,
+                                                value: "",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                    ],
+                    quasis: [
+                        TemplateElem {
+                            span: 1..7,
+                            raw: Str(
+                                Str {
+                                    span: 1..7,
+                                    value: "foo ",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 1..7,
+                                    value: "foo ",
+                                },
+                            ),
+                        },
+                        TemplateElem {
+                            span: 20..21,
+                            raw: Str(
+                                Str {
+                                    span: 20..21,
+                                    value: "",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 20..21,
+                                    value: "",
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-6.snap
@@ -1,0 +1,84 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"sql`SELECT * FROM ${table} WHERE id = ${id}`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..44,
+            expr: TaggedTemplateLiteral(
+                TaggedTemplateLiteral {
+                    span: 0..44,
+                    tag: Ident {
+                        span: 0..3,
+                        name: "sql",
+                    },
+                    template: TemplateLiteral {
+                        span: 0..44,
+                        exprs: [
+                            Ident(
+                                Ident {
+                                    span: 20..25,
+                                    name: "table",
+                                },
+                            ),
+                            Ident(
+                                Ident {
+                                    span: 40..42,
+                                    name: "id",
+                                },
+                            ),
+                        ],
+                        quasis: [
+                            TemplateElem {
+                                span: 4..20,
+                                raw: Str(
+                                    Str {
+                                        span: 4..20,
+                                        value: "SELECT * FROM ",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 4..20,
+                                        value: "SELECT * FROM ",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 26..40,
+                                raw: Str(
+                                    Str {
+                                        span: 26..40,
+                                        value: " WHERE id = ",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 26..40,
+                                        value: " WHERE id = ",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 43..44,
+                                raw: Str(
+                                    Str {
+                                        span: 43..44,
+                                        value: "",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 43..44,
+                                        value: "",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                },
+            ),
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals.snap
@@ -1,0 +1,34 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"`Hello, world`\")"
+---
+Program {
+    body: [
+        Expr {
+            span: 0..14,
+            expr: TemplateLiteral(
+                TemplateLiteral {
+                    span: 0..14,
+                    exprs: [],
+                    quasis: [
+                        TemplateElem {
+                            span: 1..14,
+                            raw: Str(
+                                Str {
+                                    span: 1..14,
+                                    value: "Hello, world",
+                                },
+                            ),
+                            cooked: Str(
+                                Str {
+                                    span: 1..14,
+                                    value: "Hello, world",
+                                },
+                            ),
+                        },
+                    ],
+                },
+            ),
+        },
+    ],
+}


### PR DESCRIPTION
TODO:
- [x] type inference (template literal)
- [x] code generation (template literal)

In order to support type inference of tagged template literals, we need to add support for arrays and rest params on functions.