### PR TITLE
Add support for array types

### DIFF
--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -1613,3 +1613,25 @@ fn codegen_if_let_with_is_class() {
     })();
     "###);
 }
+
+
+#[test]
+fn codegen_array() {
+    let src = r#"
+    let arr: string[] = ["hello", "world"]
+    "#;
+
+    let (program, ctx) = infer_prog(src);
+
+    let js = codegen_js(&program);
+    insta::assert_snapshot!(js, @r###"
+    export const arr = [
+        "hello",
+        "world"
+    ];
+    "###);
+
+    let result = codegen_d_ts(&program, &ctx);
+    insta::assert_snapshot!(result, @"export declare const arr: string[];
+");
+}

--- a/crates/crochet_ast/src/types.rs
+++ b/crates/crochet_ast/src/types.rs
@@ -62,6 +62,12 @@ pub struct TupleType {
     pub types: Vec<TypeAnn>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArrayType {
+    pub span: Span,
+    pub elem_type: Box<TypeAnn>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
     Lam(LamType),
@@ -72,6 +78,7 @@ pub enum TypeAnn {
     Union(UnionType),
     Intersection(IntersectionType),
     Tuple(TupleType),
+    Array(ArrayType),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -405,6 +405,10 @@ pub fn build_type(
                 })
                 .collect(),
         }),
+        Variant::Array(t) => TsType::TsArrayType(TsArrayType {
+            span: DUMMY_SP,
+            elem_type: Box::from(build_type(t, None, None)),
+        }),
         Variant::Rest(_) => todo!(),
         Variant::Member(_) => todo!(),
     }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -232,6 +232,21 @@ impl Context {
         }
     }
 
+    pub fn array(&self, t: Type) -> Type {
+        self.array_with_option_flag(t, None)
+    }
+    pub fn array_with_flag(&self, t: Type, flag: Flag) -> Type {
+        self.array_with_option_flag(t, Some(flag))
+    }
+    fn array_with_option_flag(&self, t: Type, flag: Option<Flag>) -> Type {
+        Type {
+            id: self.fresh_id(),
+            frozen: false,
+            variant: Variant::Array(Box::from(t)),
+            flag,
+        }
+    }
+
     pub fn rest(&self, arg: Type) -> Type {
         self.rest_with_option_flag(arg, None)
     }

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -30,6 +30,7 @@ pub fn infer_pattern(
     match get_type_ann(pat) {
         Some(type_ann) => {
             let type_ann_ty = infer_type_ann_with_params(&type_ann, ctx, type_param_map);
+
             // Allowing type_ann_ty to be a subtype of pat_type because
             // only non-refutable patterns can have type annotations.
             let s = unify(&type_ann_ty, &pat_type, ctx)?;
@@ -37,7 +38,8 @@ pub fn infer_pattern(
             // Substs are applied to any new variables introduced.  This handles
             // the situation where explicit types have be provided for function
             // parameters.
-            Ok((s.clone(), new_vars.apply(&s), type_ann_ty))
+            let a = new_vars.apply(&s);
+            Ok((s, a, type_ann_ty))
         }
         None => Ok((Subst::new(), new_vars, pat_type)),
     }
@@ -193,6 +195,7 @@ pub fn infer_pattern_and_init(
     // infer_pattern can generate a non-empty Subst when the pattern includes
     // a type annotation.
     let s = compose_many_subs(&[is, ps, s]);
+    let t = pa.apply(&s);
 
-    Ok((pa.apply(&s), s))
+    Ok((t, s))
 }

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -44,7 +44,8 @@ pub fn infer_scheme_with_type_params(
 }
 
 pub fn infer_type_ann(type_ann: &TypeAnn, ctx: &Context) -> Type {
-    freeze(infer_type_ann_rec(type_ann, ctx, &HashMap::default()))
+    let type_ann_ty = infer_type_ann_rec(type_ann, ctx, &HashMap::default());
+    freeze(type_ann_ty)
 }
 
 pub fn infer_type_ann_with_params(

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -3,8 +3,8 @@ use std::iter::Iterator;
 
 use crochet_ast::*;
 
-use super::types::{freeze, Scheme, Type, TProp};
 use super::context::Context;
+use super::types::{freeze, Scheme, TProp, Type};
 
 pub fn infer_scheme(type_ann: &TypeAnn, ctx: &Context) -> Scheme {
     match type_ann {
@@ -99,20 +99,23 @@ fn infer_type_ann_rec(
         TypeAnn::Union(UnionType { types, .. }) => ctx.union(
             types
                 .iter()
-                .map(|ty| infer_type_ann_rec(ty, ctx, type_param_map))
+                .map(|t| infer_type_ann_rec(t, ctx, type_param_map))
                 .collect(),
         ),
         TypeAnn::Intersection(IntersectionType { types, .. }) => ctx.intersection(
             types
                 .iter()
-                .map(|ty| infer_type_ann_rec(ty, ctx, type_param_map))
+                .map(|t| infer_type_ann_rec(t, ctx, type_param_map))
                 .collect(),
         ),
         TypeAnn::Tuple(TupleType { types, .. }) => ctx.tuple(
             types
                 .iter()
-                .map(|ty| infer_type_ann_rec(ty, ctx, type_param_map))
+                .map(|t| infer_type_ann_rec(t, ctx, type_param_map))
                 .collect(),
         ),
+        TypeAnn::Array(ArrayType { elem_type, .. }) => {
+            ctx.array(infer_type_ann_rec(elem_type, ctx, type_param_map))
+        }
     }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1658,4 +1658,39 @@ mod tests {
         
         infer_prog(src);
     }
+
+    #[test]
+    fn assign_empty_tuple_to_array() {
+        let src = r#"let arr: string[] = []"#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("arr", &ctx), "string[]");
+    }
+
+    #[test]
+    fn assign_tuple_with_values_to_array() {
+        let src = r#"let arr: string[] = ["hello", "world"]"#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("arr", &ctx), "string[]");
+    }
+
+    #[test]
+    fn pass_tuple_as_array_param() {
+        let src = r#"
+        declare let concat: (string[]) => string
+        let result = concat(["hello", "world"])
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("result", &ctx), "string");
+    }
+
+    #[test]
+    #[should_panic="Unification failure"]
+    fn assign_tuple_with_to_array_with_incompatible_types() {
+        let src = r#"let arr: string[] = ["hello", 5]"#;
+        
+        infer_prog(src);
+    }
 }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -34,7 +34,7 @@ impl Substitutable for Type {
                         ..alias.to_owned()
                     }),
                     Variant::Tuple(types) => Variant::Tuple(types.apply(sub)),
-                    Variant::Array(t) => Variant::Rest(Box::from(t.apply(sub))),
+                    Variant::Array(t) => Variant::Array(Box::from(t.apply(sub))),
                     Variant::Rest(arg) => Variant::Rest(Box::from(arg.apply(sub))),
                     Variant::Member(member) => Variant::Member(MemberType {
                         obj: Box::from(member.obj.apply(sub)),

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -34,6 +34,7 @@ impl Substitutable for Type {
                         ..alias.to_owned()
                     }),
                     Variant::Tuple(types) => Variant::Tuple(types.apply(sub)),
+                    Variant::Array(t) => Variant::Rest(Box::from(t.apply(sub))),
                     Variant::Rest(arg) => Variant::Rest(Box::from(arg.apply(sub))),
                     Variant::Member(member) => Variant::Member(MemberType {
                         obj: Box::from(member.obj.apply(sub)),
@@ -63,6 +64,7 @@ impl Substitutable for Type {
             Variant::Object(props) => props.ftv(),
             Variant::Alias(AliasType { type_params, .. }) => type_params.ftv(),
             Variant::Tuple(types) => types.ftv(),
+            Variant::Array(t) => t.ftv(),
             Variant::Rest(arg) => arg.ftv(),
             Variant::Member(MemberType { obj, .. }) => obj.ftv(),
         }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -169,6 +169,18 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
 
             Ok(compose_many_subs(&ss))
         }
+        (Variant::Tuple(tuple_types), Variant::Array(array_type)) => {
+            if tuple_types.is_empty() {
+                Ok(Subst::default())
+            } else {
+                let mut ss = vec![];
+                for t1 in tuple_types.iter() {
+                    let s = unify(t1, array_type.as_ref(), ctx)?;
+                    ss.push(s)
+                }
+                Ok(compose_many_subs(&ss))
+            }
+        }
         (Variant::Union(types), _) => {
             let result: Result<Vec<_>, _> = types.iter().map(|t1| unify(t1, t2, ctx)).collect();
             let ss = result?; // This is only okay if all calls to is_subtype are okay

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -101,6 +101,10 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     ..ty.to_owned()
                 }
             }
+            Variant::Array(t) => Type {
+                variant: Variant::Array(Box::from(norm_type(t, mapping, ctx))),
+                ..ty.to_owned()
+            },
             Variant::Rest(arg) => Type {
                 variant: Variant::Rest(Box::from(norm_type(arg, mapping, ctx))),
                 ..ty.to_owned()

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -235,6 +235,10 @@ mod tests {
     fn types() {
         insta::assert_debug_snapshot!(parse("let get_bar = <T>(foo: Foo<T>) => foo.bar"));
         insta::assert_debug_snapshot!(parse("declare let get_bar: (Foo) => T"));
+        insta::assert_debug_snapshot!(parse("let str_arr: string[] = []"));
+        insta::assert_debug_snapshot!(parse("let thunk_arr: (() => undefined)[] = []"));
+        insta::assert_debug_snapshot!(parse("let arr: string[] | number[] = []"));
+        insta::assert_debug_snapshot!(parse("let nested_arr: string[][] = []"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-3.snap
@@ -1,0 +1,42 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let str_arr: string[] = []\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..26,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..22,
+                    id: Ident {
+                        span: 4..11,
+                        name: "str_arr",
+                    },
+                    type_ann: Some(
+                        Array(
+                            ArrayType {
+                                span: 0..0,
+                                elem_type: Prim(
+                                    PrimType {
+                                        span: 13..19,
+                                        prim: Str,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 24..26,
+                        elems: [],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
@@ -1,0 +1,56 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let thunk_arr: (() => undefined)[] = []\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..39,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..35,
+                    id: Ident {
+                        span: 4..13,
+                        name: "thunk_arr",
+                    },
+                    type_ann: Some(
+                        Array(
+                            ArrayType {
+                                span: 0..0,
+                                elem_type: Lam(
+                                    LamType {
+                                        span: 16..31,
+                                        params: [
+                                            Intersection(
+                                                IntersectionType {
+                                                    span: 17..17,
+                                                    types: [],
+                                                },
+                                            ),
+                                        ],
+                                        ret: Prim(
+                                            PrimType {
+                                                span: 22..31,
+                                                prim: Undefined,
+                                            },
+                                        ),
+                                        type_params: None,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 37..39,
+                        elems: [],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-5.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let arr: string[] | number[] = []\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..33,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..29,
+                    id: Ident {
+                        span: 4..7,
+                        name: "arr",
+                    },
+                    type_ann: Some(
+                        Union(
+                            UnionType {
+                                span: 9..29,
+                                types: [
+                                    Array(
+                                        ArrayType {
+                                            span: 0..0,
+                                            elem_type: Prim(
+                                                PrimType {
+                                                    span: 9..15,
+                                                    prim: Str,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    Array(
+                                        ArrayType {
+                                            span: 0..0,
+                                            elem_type: Prim(
+                                                PrimType {
+                                                    span: 20..26,
+                                                    prim: Num,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    ),
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 31..33,
+                        elems: [],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-6.snap
@@ -1,0 +1,47 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let nested_arr: string[][] = []\")"
+---
+Program {
+    body: [
+        VarDecl {
+            span: 0..31,
+            pattern: Ident(
+                BindingIdent {
+                    span: 4..27,
+                    id: Ident {
+                        span: 4..14,
+                        name: "nested_arr",
+                    },
+                    type_ann: Some(
+                        Array(
+                            ArrayType {
+                                span: 0..0,
+                                elem_type: Array(
+                                    ArrayType {
+                                        span: 0..0,
+                                        elem_type: Prim(
+                                            PrimType {
+                                                span: 16..22,
+                                                prim: Str,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+            init: Some(
+                Tuple(
+                    Tuple {
+                        span: 29..31,
+                        elems: [],
+                    },
+                ),
+            ),
+            declare: false,
+        },
+    ],
+}

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-10.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/crochet_parser/src/types.rs
-expression: "parse_type(\"(A, B) => C | D\")"
+source: crates/crochet_parser/src/type_ann.rs
+expression: "parse_type(\"(A, B) => C & D\")"
 ---
 Lam(
     LamType {
@@ -21,8 +21,8 @@ Lam(
                 },
             ),
         ],
-        ret: Union(
-            UnionType {
+        ret: Intersection(
+            IntersectionType {
                 span: 10..15,
                 types: [
                     TypeRef(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-2.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"(number, string) => boolean\")"
 ---
 Lam(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-3.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"{x: number, y: number}\")"
 ---
 Object(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-4.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/crochet_parser/src/types.rs
-expression: "parse_type(\"(A, B) => C & D\")"
+source: crates/crochet_parser/src/type_ann.rs
+expression: "parse_type(\"(A, B) => C | D\")"
 ---
 Lam(
     LamType {
@@ -21,8 +21,8 @@ Lam(
                 },
             ),
         ],
-        ret: Intersection(
-            IntersectionType {
+        ret: Union(
+            UnionType {
                 span: 10..15,
                 types: [
                     TypeRef(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-5.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"((A, B) => C) | D\")"
 ---
 Union(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-6.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"A & B & C\")"
 ---
 Intersection(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-7.snap
@@ -1,25 +1,25 @@
 ---
-source: crates/crochet_parser/src/types.rs
-expression: "parse_type(\"(A | B) & (C | D)\")"
+source: crates/crochet_parser/src/type_ann.rs
+expression: "parse_type(\"A & B | C & D\")"
 ---
-Intersection(
-    IntersectionType {
-        span: 0..17,
+Union(
+    UnionType {
+        span: 0..13,
         types: [
-            Union(
-                UnionType {
-                    span: 1..6,
+            Intersection(
+                IntersectionType {
+                    span: 0..5,
                     types: [
                         TypeRef(
                             TypeRef {
-                                span: 1..2,
+                                span: 0..1,
                                 name: "A",
                                 type_params: None,
                             },
                         ),
                         TypeRef(
                             TypeRef {
-                                span: 5..6,
+                                span: 4..5,
                                 name: "B",
                                 type_params: None,
                             },
@@ -27,20 +27,20 @@ Intersection(
                     ],
                 },
             ),
-            Union(
-                UnionType {
-                    span: 11..16,
+            Intersection(
+                IntersectionType {
+                    span: 8..13,
                     types: [
                         TypeRef(
                             TypeRef {
-                                span: 11..12,
+                                span: 8..9,
                                 name: "C",
                                 type_params: None,
                             },
                         ),
                         TypeRef(
                             TypeRef {
-                                span: 15..16,
+                                span: 12..13,
                                 name: "D",
                                 type_params: None,
                             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-8.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"(A) => B & C | D\")"
 ---
 Lam(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-9.snap
@@ -1,25 +1,25 @@
 ---
-source: crates/crochet_parser/src/types.rs
-expression: "parse_type(\"A & B | C & D\")"
+source: crates/crochet_parser/src/type_ann.rs
+expression: "parse_type(\"(A | B) & (C | D)\")"
 ---
-Union(
-    UnionType {
-        span: 0..13,
+Intersection(
+    IntersectionType {
+        span: 0..17,
         types: [
-            Intersection(
-                IntersectionType {
-                    span: 0..5,
+            Union(
+                UnionType {
+                    span: 1..6,
                     types: [
                         TypeRef(
                             TypeRef {
-                                span: 0..1,
+                                span: 1..2,
                                 name: "A",
                                 type_params: None,
                             },
                         ),
                         TypeRef(
                             TypeRef {
-                                span: 4..5,
+                                span: 5..6,
                                 name: "B",
                                 type_params: None,
                             },
@@ -27,20 +27,20 @@ Union(
                     ],
                 },
             ),
-            Intersection(
-                IntersectionType {
-                    span: 8..13,
+            Union(
+                UnionType {
+                    span: 11..16,
                     types: [
                         TypeRef(
                             TypeRef {
-                                span: 8..9,
+                                span: 11..12,
                                 name: "C",
                                 type_params: None,
                             },
                         ),
                         TypeRef(
                             TypeRef {
-                                span: 12..13,
+                                span: 15..16,
                                 name: "D",
                                 type_params: None,
                             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/crochet_parser/src/types.rs
+source: crates/crochet_parser/src/type_ann.rs
 expression: "parse_type(\"Promise<number>\")"
 ---
 TypeRef(


### PR DESCRIPTION
This PR make the following changes:
- enable parsing of array type annotations
- infer array types from array type annotations
- unify tuples with array types where each element in the tuple is a subtype of the array type's elements type
- codegens array types