### PR TITLE
Remove type flags

### DIFF
--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -72,17 +72,10 @@ impl Context {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Var,
-            flag: None,
         }
     }
 
     pub fn lam(&self, params: Vec<Type>, ret: Box<Type>) -> Type {
-        self.lam_with_option_flag(params, ret, None)
-    }
-    pub fn lam_with_flag(&self, params: Vec<Type>, ret: Box<Type>, flag: Flag) -> Type {
-        self.lam_with_option_flag(params, ret, Some(flag))
-    }
-    fn lam_with_option_flag(&self, params: Vec<Type>, ret: Box<Type>, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
@@ -91,32 +84,18 @@ impl Context {
                 ret,
                 is_call: false,
             }),
-            flag,
         }
     }
 
     pub fn prim(&self, prim: Primitive) -> Type {
-        self.prim_with_option_flag(prim, None)
-    }
-    pub fn prim_with_flag(&self, prim: Primitive, flag: Flag) -> Type {
-        self.prim_with_option_flag(prim, Some(flag))
-    }
-    fn prim_with_option_flag(&self, prim: Primitive, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Prim(prim),
-            flag,
         }
     }
 
     pub fn lit(&self, lit: AstLit) -> Type {
-        self.lit_with_option_flag(lit, None)
-    }
-    pub fn lit_with_flag(&self, lit: AstLit, flag: Flag) -> Type {
-        self.lit_with_option_flag(lit, Some(flag))
-    }
-    fn lit_with_option_flag(&self, lit: AstLit, flag: Option<Flag>) -> Type {
         let lit = match lit {
             AstLit::Num(n) => Lit::Num(n.value),
             AstLit::Bool(b) => Lit::Bool(b.value),
@@ -128,7 +107,6 @@ impl Context {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Lit(lit),
-            flag,
         }
     }
 
@@ -137,52 +115,30 @@ impl Context {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Lit(lit),
-            flag: None,
         }
     }
 
     pub fn union(&self, types: Vec<Type>) -> Type {
-        self.union_with_option_flag(types, None)
-    }
-    pub fn union_with_flag(&self, types: Vec<Type>, flag: Flag) -> Type {
-        self.union_with_option_flag(types, Some(flag))
-    }
-    fn union_with_option_flag(&self, types: Vec<Type>, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Union(types),
-            flag,
         }
     }
 
     pub fn intersection(&self, types: Vec<Type>) -> Type {
-        self.intersection_with_option_flag(types, None)
-    }
-    pub fn intersection_with_flag(&self, types: Vec<Type>, flag: Flag) -> Type {
-        self.intersection_with_option_flag(types, Some(flag))
-    }
-    fn intersection_with_option_flag(&self, types: Vec<Type>, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Intersection(types),
-            flag,
         }
     }
 
     pub fn object(&self, props: Vec<TProp>) -> Type {
-        self.object_with_option_flag(props, None)
-    }
-    pub fn object_with_flag(&self, props: Vec<TProp>, flag: Flag) -> Type {
-        self.object_with_option_flag(props, Some(flag))
-    }
-    fn object_with_option_flag(&self, props: Vec<TProp>, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Object(props),
-            flag,
         }
     }
 
@@ -195,17 +151,6 @@ impl Context {
     }
 
     pub fn alias(&self, name: &str, type_params: Option<Vec<Type>>) -> Type {
-        self.alias_with_option_flag(name, type_params, None)
-    }
-    pub fn alias_with_flag(&self, name: &str, type_params: Option<Vec<Type>>, flag: Flag) -> Type {
-        self.alias_with_option_flag(name, type_params, Some(flag))
-    }
-    fn alias_with_option_flag(
-        &self,
-        name: &str,
-        type_params: Option<Vec<Type>>,
-        flag: Option<Flag>,
-    ) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
@@ -213,62 +158,34 @@ impl Context {
                 name: name.to_owned(),
                 type_params,
             }),
-            flag,
         }
     }
 
     pub fn tuple(&self, types: Vec<Type>) -> Type {
-        self.tuple_with_option_flag(types, None)
-    }
-    pub fn tuple_with_flag(&self, types: Vec<Type>, flag: Flag) -> Type {
-        self.tuple_with_option_flag(types, Some(flag))
-    }
-    fn tuple_with_option_flag(&self, types: Vec<Type>, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Tuple(types),
-            flag,
         }
     }
 
     pub fn array(&self, t: Type) -> Type {
-        self.array_with_option_flag(t, None)
-    }
-    pub fn array_with_flag(&self, t: Type, flag: Flag) -> Type {
-        self.array_with_option_flag(t, Some(flag))
-    }
-    fn array_with_option_flag(&self, t: Type, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Array(Box::from(t)),
-            flag,
         }
     }
 
     pub fn rest(&self, arg: Type) -> Type {
-        self.rest_with_option_flag(arg, None)
-    }
-    pub fn rest_with_flag(&self, arg: Type, flag: Flag) -> Type {
-        self.rest_with_option_flag(arg, Some(flag))
-    }
-    fn rest_with_option_flag(&self, arg: Type, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
             variant: Variant::Rest(Box::from(arg)),
-            flag,
         }
     }
 
     pub fn mem(&self, obj: Type, prop: &str) -> Type {
-        self.mem_with_option_flag(obj, prop, None)
-    }
-    pub fn mem_with_flag(&self, obj: Type, prop: &str, flag: Flag) -> Type {
-        self.mem_with_option_flag(obj, prop, Some(flag))
-    }
-    fn mem_with_option_flag(&self, obj: Type, prop: &str, flag: Option<Flag>) -> Type {
         Type {
             id: self.fresh_id(),
             frozen: false,
@@ -276,7 +193,6 @@ impl Context {
                 obj: Box::from(obj),
                 prop: prop.to_owned(),
             }),
-            flag,
         }
     }
 }

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -44,7 +44,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                     ret: Box::from(ret_type.clone()),
                     is_call: true,
                 }),
-                flag: None,
             };
             let s3 = unify(&call_type, &lam_type, ctx)?;
 
@@ -173,7 +172,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                                         ret: Box::from(ret_type.clone()),
                                         is_call: true,
                                     }),
-                                    flag: None,
                                 };
 
                                 let s1 = compose_many_subs(&ss);

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -22,7 +22,6 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     id: index as i32,
                     frozen: false,
                     variant: Variant::Var,
-                    flag: None,
                 },
             )
         })


### PR DESCRIPTION
This isn't being used right now.  It's used in #162, but we can add something to `Variant::Object(...)` directly to track if an object type was generated from a member access.