### PR TITLE
Exclude all integration test files from coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.20.0'
-          args: '-- --test-threads 1'
+          args: '--exclude-files *_test.rs -- --test-threads 1'
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/crates/crochet/tests/fixture_test.rs
+++ b/crates/crochet/tests/fixture_test.rs
@@ -16,6 +16,7 @@ enum Mode {
     Write,
 }
 
+#[cfg(not(tarpaulin_include))]
 #[testing_macros::fixture("tests/pass/*.crochet")]
 fn pass(in_path: PathBuf) {
     let mode = match env::var("UPDATE") {

--- a/crates/crochet/tests/fixture_test.rs
+++ b/crates/crochet/tests/fixture_test.rs
@@ -16,7 +16,6 @@ enum Mode {
     Write,
 }
 
-#[cfg(not(tarpaulin_include))]
 #[testing_macros::fixture("tests/pass/*.crochet")]
 fn pass(in_path: PathBuf) {
     let mode = match env::var("UPDATE") {


### PR DESCRIPTION
I doesn't really make sense to compute coverage on test files.

TODO:
- [x] experiment with tarpaulin's `--exclude-files` option