### PR TITLE
Require param names for function type annotations

### DIFF
--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -475,7 +475,7 @@ fn infer_expr_using_declared_var() {
 #[test]
 fn infer_app_of_declared_fn() {
     let src = r#"
-    declare let add: (number, number) => number
+    declare let add: (a: number, b: number) => number
     let sum = add(5, 10)
     "#;
     let (_, ctx) = infer_prog(src);
@@ -487,7 +487,7 @@ fn infer_app_of_declared_fn() {
 #[test]
 fn infer_app_of_declared_fn_with_obj_param() {
     let src = r#"
-    declare let mag: ({x: number, y: number}) => number
+    declare let mag: (p: {x: number, y: number}) => number
     let result = mag({x: 5, y: 10})
     "#;
     let (_, ctx) = infer_prog(src);
@@ -499,7 +499,7 @@ fn infer_app_of_declared_fn_with_obj_param() {
 #[test]
 fn calling_a_fn_with_an_obj_subtype() {
     let src = r#"
-    declare let mag: ({x: number, y: number}) => number
+    declare let mag: (p: {x: number, y: number}) => number
     let result = mag({x: 5, y: 10, z: 15})
     "#;
     let (_, ctx) = infer_prog(src);
@@ -512,7 +512,7 @@ fn calling_a_fn_with_an_obj_subtype() {
 #[should_panic = "Unification failure"]
 fn calling_a_fn_with_an_obj_missing_a_property() {
     let src = r#"
-    declare let mag: ({x: number, y: number}) => number
+    declare let mag: (p: {x: number, y: number}) => number
     let result = mag({x: 5})
     "#;
     infer_prog(src);
@@ -761,7 +761,7 @@ fn infer_assigning_an_obj_lit_with_extra_props() {
 #[test]
 fn infer_function_overloading() {
     let src = r#"
-    declare let add: ((number, number) => number) & ((string, string) => string)
+    declare let add: ((a: number, b: number) => number) & ((a: string, b: string) => string)
     let num = add(5, 10)
     let str = add("hello, ", "world")
     "#;
@@ -777,7 +777,7 @@ fn infer_function_overloading() {
 #[should_panic = "Couldn't unify lambda with intersection"]
 fn infer_function_overloading_with_incorrect_args() {
     let src = r#"
-    declare let add: ((number, number) => number) & ((string, string) => string)
+    declare let add: ((a: number, b: number) => number) & ((a: string, b: string) => string)
     let bool = add(true, false)
     "#;
     infer_prog(src);
@@ -883,7 +883,7 @@ fn infer_fn_param_with_type_alias_with_param() {
 fn infer_fn_param_with_type_alias_with_param_2() {
     let src = r#"
     type Foo<T> = {bar: T}
-    declare let get_bar: <T>(Foo<T>) => T
+    declare let get_bar: <T>(foo: Foo<T>) => T
     "#;
     let (_, ctx) = infer_prog(src);
 
@@ -896,7 +896,7 @@ fn infer_fn_param_with_type_alias_with_param_2() {
 fn infer_fn_param_with_type_alias_with_param_3() {
     let src = r#"
     type Foo<T> = {bar: T}
-    declare let get_bar: <T>(Foo<T>) => T
+    declare let get_bar: <T>(foo: Foo<T>) => T
     let bar = get_bar({bar: "hello"})
     "#;
     let (_, ctx) = infer_prog(src);

--- a/crates/crochet_ast/src/types.rs
+++ b/crates/crochet_ast/src/types.rs
@@ -1,3 +1,4 @@
+use crate::pattern::{BindingIdent, RestPat};
 use crate::span::Span;
 use crate::literal::Lit;
 use crate::ident::Ident;
@@ -6,9 +7,15 @@ use crate::prim::Primitive;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LamType {
     pub span: Span,
-    pub params: Vec<TypeAnn>,
+    pub params: Vec<FnParam>,
     pub ret: Box<TypeAnn>,
     pub type_params: Option<Vec<TypeParam>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FnParam {
+    Ident(BindingIdent),
+    Rest(RestPat),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -65,7 +65,21 @@ fn infer_type_ann_rec(
         TypeAnn::Lam(LamType { params, ret, .. }) => {
             let params: Vec<_> = params
                 .iter()
-                .map(|arg| infer_type_ann_rec(arg, ctx, type_param_map))
+                .map(|arg| {
+                    match &arg {
+                        FnParam::Ident(ident) => {
+                            // TODO: Update the AST to remove need for .unwrap() here
+                            let type_ann = ident.type_ann.clone().unwrap();
+                            infer_type_ann_rec(&type_ann, ctx, type_param_map)
+                        }
+                        FnParam::Rest(rest) => {
+                            // TODO: Update the AST to remove need for .unwrap() here
+                            let type_ann = rest.type_ann.clone().unwrap();
+                            let t = infer_type_ann_rec(&type_ann, ctx, type_param_map);
+                            ctx.rest(t)
+                        },
+                    }
+                })
                 .collect();
             let ret = Box::from(infer_type_ann_rec(ret.as_ref(), ctx, type_param_map));
             ctx.lam(params, ret)

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -965,7 +965,7 @@ mod tests {
     #[test]
     fn call_lam_with_subtypes() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let sum = add(5, 10)
         "#;
 
@@ -978,7 +978,7 @@ mod tests {
     #[should_panic = "Unification failure"]
     fn call_lam_with_wrong_types() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let sum = add("hello", true)
         "#;
 
@@ -988,7 +988,7 @@ mod tests {
     #[test]
     fn call_lam_with_extra_params() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let sum = add(5, 10, "hello")
         "#;
 
@@ -1000,7 +1000,7 @@ mod tests {
     #[test]
     fn call_lam_with_too_few_params_result_in_partial_application() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let add5 = add(5)
         "#;
 
@@ -1012,7 +1012,7 @@ mod tests {
     #[test]
     fn call_lam_with_too_few_params_result_in_partial_application_no_params() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let plus = add()
         "#;
 
@@ -1024,7 +1024,7 @@ mod tests {
     #[test]
     fn call_lam_multiple_times_with_too_few_params() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let sum = add(5)(10)
         "#;
 
@@ -1036,7 +1036,7 @@ mod tests {
     #[test]
     fn pass_callback_with_too_few_params() {
         let src = r#"
-        declare let fold_num: ((number, number) => boolean, number) => number
+        declare let fold_num: (cb: (a: number, b: number) => boolean, seed: number) => number
         let result = fold_num((x) => true, 0)
         "#;
 
@@ -1048,7 +1048,7 @@ mod tests {
     #[test]
     fn pass_callback_whose_params_are_supertypes_of_expected_callback() {
         let src = r#"
-        declare let fold_num: ((5, 10) => boolean, number) => number
+        declare let fold_num: (cb: (a: 5, b: 10) => boolean, seed: number) => number
         let result = fold_num((x: number, y: number) => true, 0)
         "#;
 
@@ -1067,7 +1067,7 @@ mod tests {
         // calback results in correct function, allowing this in the type checker
         // is bound to result in confusing and hard to understand code.
         let src = r#"
-        declare let fold_num: ((number, number) => boolean, number) => number
+        declare let fold_num: (cb: (a: number, b: number) => boolean, seed: number) => number
         let result = fold_num((x, y, z) => true, 0)
         "#;
 
@@ -1079,7 +1079,7 @@ mod tests {
     #[ignore]
     fn call_generic_lam_with_subtypes() {
         let src = r#"
-        declare let add: <T>(T, T) => T
+        declare let add: <T>(a: T, b: T) => T
         let sum = add(5, 10)
         "#;
 
@@ -1107,7 +1107,7 @@ mod tests {
     #[test]
     fn spread_param_tuple() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let args = [5, 10]
         let result = add(...args)
         "#;
@@ -1120,7 +1120,7 @@ mod tests {
     #[test]
     fn spread_param_tuple_with_extra_elements() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let args = [5, 10, 15]
         let result = add(...args)
         "#;
@@ -1133,7 +1133,7 @@ mod tests {
     #[test]
     fn spread_param_tuple_with_not_enough_elements_is_partial_application() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let args = [5]
         let result = add(...args)
         "#;
@@ -1146,7 +1146,7 @@ mod tests {
     #[test]
     fn spread_multiple_param_tuples() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let args1 = [5]
         let args2 = [10]
         let result = add(...args1, ...args2)
@@ -1161,7 +1161,7 @@ mod tests {
     #[should_panic="Unification failure"]
     fn spread_param_tuples_with_incorrect_types() {
         let src = r#"
-        declare let add: (number, number) => number
+        declare let add: (a: number, b: number) => number
         let args = ["hello", true]
         let result = add(...args)
         "#;
@@ -1178,6 +1178,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
+        assert_eq!(get_type("fst", &ctx), "(number, ...number[]) => number");
         assert_eq!(get_type("result", &ctx), "number");
     }
 
@@ -1232,12 +1233,10 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn rest_param_decl() {
-        // TODO: update the parser to handle this test case
         let src = r#"
-        declare let add: (number, ...number[]) => number
-        let result = add(5, 10)
+        declare let add: (a: number, ...b: number[]) => number
+        let result = add(5, 10, 15)
         "#;
 
         let ctx = infer_prog(src);
@@ -1394,7 +1393,7 @@ mod tests {
     fn infer_obj_from_spread() {
         let src = r#"
         type Point = {x: number, y: number, z: number}
-        declare let mag: (Point) => number
+        declare let mag: (p: Point) => number
         let mag_2d = (p) => {
             mag({...p, z: 0})
         }
@@ -1412,7 +1411,7 @@ mod tests {
     fn infer_obj_from_spread_undecidable() {
         let src = r#"
         type Point = {x: number, y: number, z: number}
-        declare let mag: (Point) => number
+        declare let mag: (p: Point) => number
         let mag_2d = (p, q) => {
             mag({...p, ...q, z: 0})
         }
@@ -1590,7 +1589,7 @@ mod tests {
     #[test]
     fn call_overloaded_function() {
         let src = r#"
-        declare let add: ((number, number) => number) & ((string, string) => string)
+        declare let add: ((a: number, b: number) => number) & ((a: string, b: string) => string)
         let str = add("hello", "world")
         let num = add(5, 10)
         "#;
@@ -1604,7 +1603,7 @@ mod tests {
     #[should_panic = "Couldn't unify lambda with intersection"]
     fn call_overloaded_function_with_wrong_params() {
         let src = r#"
-        declare let add: ((number, number) => number) & ((string, string) => string)
+        declare let add: ((a: number, b: number) => number) & ((a: string, b: string) => string)
         add("hello", 10)
         "#;
 
@@ -1841,7 +1840,7 @@ mod tests {
     #[test]
     fn pass_tuple_as_array_param() {
         let src = r#"
-        declare let concat: (string[]) => string
+        declare let concat: (str_arr: string[]) => string
         let result = concat(["hello", "world"])
         "#;
         let ctx = infer_prog(src);

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn types() {
         insta::assert_debug_snapshot!(parse("let get_bar = <T>(foo: Foo<T>) => foo.bar"));
-        insta::assert_debug_snapshot!(parse("declare let get_bar: (Foo) => T"));
+        insta::assert_debug_snapshot!(parse("declare let get_bar: (foo: Foo) => T"));
         insta::assert_debug_snapshot!(parse("let str_arr: string[] = []"));
         insta::assert_debug_snapshot!(parse("let thunk_arr: (() => undefined)[] = []"));
         insta::assert_debug_snapshot!(parse("let arr: string[] | number[] = []"));

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-2.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"declare let get_bar: (Foo) => T\")"
+expression: "parse(\"declare let get_bar: (foo: Foo) => T\")"
 ---
 Program {
     body: [
         VarDecl {
-            span: 0..31,
+            span: 0..36,
             pattern: Ident(
                 BindingIdent {
-                    span: 12..31,
+                    span: 12..36,
                     id: Ident {
                         span: 12..19,
                         name: "get_bar",
@@ -16,19 +16,30 @@ Program {
                     type_ann: Some(
                         Lam(
                             LamType {
-                                span: 21..31,
+                                span: 21..36,
                                 params: [
-                                    TypeRef(
-                                        TypeRef {
-                                            span: 22..25,
-                                            name: "Foo",
-                                            type_params: None,
+                                    Ident(
+                                        BindingIdent {
+                                            span: 22..30,
+                                            id: Ident {
+                                                span: 22..25,
+                                                name: "foo",
+                                            },
+                                            type_ann: Some(
+                                                TypeRef(
+                                                    TypeRef {
+                                                        span: 27..30,
+                                                        name: "Foo",
+                                                        type_params: None,
+                                                    },
+                                                ),
+                                            ),
                                         },
                                     ),
                                 ],
                                 ret: TypeRef(
                                     TypeRef {
-                                        span: 30..31,
+                                        span: 35..36,
                                         name: "T",
                                         type_params: None,
                                     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
@@ -20,14 +20,7 @@ Program {
                                 elem_type: Lam(
                                     LamType {
                                         span: 16..31,
-                                        params: [
-                                            Intersection(
-                                                IntersectionType {
-                                                    span: 17..17,
-                                                    types: [],
-                                                },
-                                            ),
-                                        ],
+                                        params: [],
                                         ret: Prim(
                                             PrimType {
                                                 span: 22..31,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-10.snap
@@ -1,40 +1,62 @@
 ---
 source: crates/crochet_parser/src/type_ann.rs
-expression: "parse_type(\"(A, B) => C & D\")"
+expression: "parse_type(\"(a: A, b: B) => C & D\")"
 ---
 Lam(
     LamType {
-        span: 0..15,
+        span: 0..21,
         params: [
-            TypeRef(
-                TypeRef {
-                    span: 1..2,
-                    name: "A",
-                    type_params: None,
+            Ident(
+                BindingIdent {
+                    span: 1..5,
+                    id: Ident {
+                        span: 1..2,
+                        name: "a",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 4..5,
+                                name: "A",
+                                type_params: None,
+                            },
+                        ),
+                    ),
                 },
             ),
-            TypeRef(
-                TypeRef {
-                    span: 4..5,
-                    name: "B",
-                    type_params: None,
+            Ident(
+                BindingIdent {
+                    span: 7..11,
+                    id: Ident {
+                        span: 7..8,
+                        name: "b",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 10..11,
+                                name: "B",
+                                type_params: None,
+                            },
+                        ),
+                    ),
                 },
             ),
         ],
         ret: Intersection(
             IntersectionType {
-                span: 10..15,
+                span: 16..21,
                 types: [
                     TypeRef(
                         TypeRef {
-                            span: 10..11,
+                            span: 16..17,
                             name: "C",
                             type_params: None,
                         },
                     ),
                     TypeRef(
                         TypeRef {
-                            span: 14..15,
+                            span: 20..21,
                             name: "D",
                             type_params: None,
                         },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-11.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-11.snap
@@ -1,0 +1,63 @@
+---
+source: crates/crochet_parser/src/type_ann.rs
+expression: "parse_type(\"(a: number, ...b: string[]) => boolean\")"
+---
+Lam(
+    LamType {
+        span: 0..38,
+        params: [
+            Ident(
+                BindingIdent {
+                    span: 1..10,
+                    id: Ident {
+                        span: 1..2,
+                        name: "a",
+                    },
+                    type_ann: Some(
+                        Prim(
+                            PrimType {
+                                span: 4..10,
+                                prim: Num,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            Rest(
+                RestPat {
+                    span: 12..26,
+                    arg: Ident(
+                        BindingIdent {
+                            span: 15..16,
+                            id: Ident {
+                                span: 15..16,
+                                name: "b",
+                            },
+                            type_ann: None,
+                        },
+                    ),
+                    type_ann: Some(
+                        Array(
+                            ArrayType {
+                                span: 0..0,
+                                elem_type: Prim(
+                                    PrimType {
+                                        span: 18..24,
+                                        prim: Str,
+                                    },
+                                ),
+                            },
+                        ),
+                    ),
+                },
+            ),
+        ],
+        ret: Prim(
+            PrimType {
+                span: 31..38,
+                prim: Bool,
+            },
+        ),
+        type_params: None,
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-2.snap
@@ -1,27 +1,49 @@
 ---
 source: crates/crochet_parser/src/type_ann.rs
-expression: "parse_type(\"(number, string) => boolean\")"
+expression: "parse_type(\"(a: number, b: string) => boolean\")"
 ---
 Lam(
     LamType {
-        span: 0..27,
+        span: 0..33,
         params: [
-            Prim(
-                PrimType {
-                    span: 1..7,
-                    prim: Num,
+            Ident(
+                BindingIdent {
+                    span: 1..10,
+                    id: Ident {
+                        span: 1..2,
+                        name: "a",
+                    },
+                    type_ann: Some(
+                        Prim(
+                            PrimType {
+                                span: 4..10,
+                                prim: Num,
+                            },
+                        ),
+                    ),
                 },
             ),
-            Prim(
-                PrimType {
-                    span: 9..15,
-                    prim: Str,
+            Ident(
+                BindingIdent {
+                    span: 12..21,
+                    id: Ident {
+                        span: 12..13,
+                        name: "b",
+                    },
+                    type_ann: Some(
+                        Prim(
+                            PrimType {
+                                span: 15..21,
+                                prim: Str,
+                            },
+                        ),
+                    ),
                 },
             ),
         ],
         ret: Prim(
             PrimType {
-                span: 20..27,
+                span: 26..33,
                 prim: Bool,
             },
         ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-4.snap
@@ -1,40 +1,62 @@
 ---
 source: crates/crochet_parser/src/type_ann.rs
-expression: "parse_type(\"(A, B) => C | D\")"
+expression: "parse_type(\"(a: A, b: B) => C | D\")"
 ---
 Lam(
     LamType {
-        span: 0..15,
+        span: 0..21,
         params: [
-            TypeRef(
-                TypeRef {
-                    span: 1..2,
-                    name: "A",
-                    type_params: None,
+            Ident(
+                BindingIdent {
+                    span: 1..5,
+                    id: Ident {
+                        span: 1..2,
+                        name: "a",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 4..5,
+                                name: "A",
+                                type_params: None,
+                            },
+                        ),
+                    ),
                 },
             ),
-            TypeRef(
-                TypeRef {
-                    span: 4..5,
-                    name: "B",
-                    type_params: None,
+            Ident(
+                BindingIdent {
+                    span: 7..11,
+                    id: Ident {
+                        span: 7..8,
+                        name: "b",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 10..11,
+                                name: "B",
+                                type_params: None,
+                            },
+                        ),
+                    ),
                 },
             ),
         ],
         ret: Union(
             UnionType {
-                span: 10..15,
+                span: 16..21,
                 types: [
                     TypeRef(
                         TypeRef {
-                            span: 10..11,
+                            span: 16..17,
                             name: "C",
                             type_params: None,
                         },
                     ),
                     TypeRef(
                         TypeRef {
-                            span: 14..15,
+                            span: 20..21,
                             name: "D",
                             type_params: None,
                         },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-5.snap
@@ -1,33 +1,55 @@
 ---
 source: crates/crochet_parser/src/type_ann.rs
-expression: "parse_type(\"((A, B) => C) | D\")"
+expression: "parse_type(\"((a: A, b: B) => C) | D\")"
 ---
 Union(
     UnionType {
-        span: 0..17,
+        span: 0..23,
         types: [
             Lam(
                 LamType {
-                    span: 1..12,
+                    span: 1..18,
                     params: [
-                        TypeRef(
-                            TypeRef {
-                                span: 2..3,
-                                name: "A",
-                                type_params: None,
+                        Ident(
+                            BindingIdent {
+                                span: 2..6,
+                                id: Ident {
+                                    span: 2..3,
+                                    name: "a",
+                                },
+                                type_ann: Some(
+                                    TypeRef(
+                                        TypeRef {
+                                            span: 5..6,
+                                            name: "A",
+                                            type_params: None,
+                                        },
+                                    ),
+                                ),
                             },
                         ),
-                        TypeRef(
-                            TypeRef {
-                                span: 5..6,
-                                name: "B",
-                                type_params: None,
+                        Ident(
+                            BindingIdent {
+                                span: 8..12,
+                                id: Ident {
+                                    span: 8..9,
+                                    name: "b",
+                                },
+                                type_ann: Some(
+                                    TypeRef(
+                                        TypeRef {
+                                            span: 11..12,
+                                            name: "B",
+                                            type_params: None,
+                                        },
+                                    ),
+                                ),
                             },
                         ),
                     ],
                     ret: TypeRef(
                         TypeRef {
-                            span: 11..12,
+                            span: 17..18,
                             name: "C",
                             type_params: None,
                         },
@@ -37,7 +59,7 @@ Union(
             ),
             TypeRef(
                 TypeRef {
-                    span: 16..17,
+                    span: 22..23,
                     name: "D",
                     type_params: None,
                 },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__type_annotations-8.snap
@@ -1,37 +1,48 @@
 ---
 source: crates/crochet_parser/src/type_ann.rs
-expression: "parse_type(\"(A) => B & C | D\")"
+expression: "parse_type(\"(a: A) => B & C | D\")"
 ---
 Lam(
     LamType {
-        span: 0..16,
+        span: 0..19,
         params: [
-            TypeRef(
-                TypeRef {
-                    span: 1..2,
-                    name: "A",
-                    type_params: None,
+            Ident(
+                BindingIdent {
+                    span: 1..5,
+                    id: Ident {
+                        span: 1..2,
+                        name: "a",
+                    },
+                    type_ann: Some(
+                        TypeRef(
+                            TypeRef {
+                                span: 4..5,
+                                name: "A",
+                                type_params: None,
+                            },
+                        ),
+                    ),
                 },
             ),
         ],
         ret: Union(
             UnionType {
-                span: 7..16,
+                span: 10..19,
                 types: [
                     Intersection(
                         IntersectionType {
-                            span: 7..12,
+                            span: 10..15,
                             types: [
                                 TypeRef(
                                     TypeRef {
-                                        span: 7..8,
+                                        span: 10..11,
                                         name: "B",
                                         type_params: None,
                                     },
                                 ),
                                 TypeRef(
                                     TypeRef {
-                                        span: 11..12,
+                                        span: 14..15,
                                         name: "C",
                                         type_params: None,
                                     },
@@ -41,7 +52,7 @@ Lam(
                     ),
                     TypeRef(
                         TypeRef {
-                            span: 15..16,
+                            span: 18..19,
                             name: "D",
                             type_params: None,
                         },

--- a/crates/crochet_parser/src/type_ann.rs
+++ b/crates/crochet_parser/src/type_ann.rs
@@ -115,15 +115,15 @@ pub fn type_ann_parser() -> BoxedParser<'static, char, TypeAnn, Simple<char>> {
                 .delimited_by(just_with_padding("("), just_with_padding(")")),
         ));
 
-        let atom_with_suffix = atom
-            .clone()
-            .then(just_with_padding("[]").repeated())
-            .foldl(|accum, _| {
-                TypeAnn::Array(ArrayType {
-                    span: 0..0, // FIXME
-                    elem_type: Box::from(accum),
-                })
-            });
+        let atom_with_suffix =
+            atom.clone()
+                .then(just_with_padding("[]").repeated())
+                .foldl(|accum, _| {
+                    TypeAnn::Array(ArrayType {
+                        span: 0..0, // FIXME
+                        elem_type: Box::from(accum),
+                    })
+                });
 
         // We have to use `atom` here instead of `type_ann` to avoid a stack
         // overflow.
@@ -142,9 +142,41 @@ pub fn type_ann_parser() -> BoxedParser<'static, char, TypeAnn, Simple<char>> {
                 _ => TypeAnn::Union(UnionType { span, types }),
             });
 
-        // TODO: support optional lambda param names
-        let lam_params = type_ann
-            .clone()
+        let ident = text::ident().map_with_span(|name, span: Span| Ident {
+            span,
+            name,
+        });
+
+        let ident_param = ident
+            .then_ignore(just_with_padding(":"))
+            .then(type_ann.clone())
+            .map_with_span(|(ident, type_ann), span: Span| {
+                FnParam::Ident(BindingIdent {
+                    id: ident,
+                    span,
+                    type_ann: Some(type_ann),
+                })
+            });
+
+        let rest_param = just_with_padding("...")
+            .ignore_then(ident.map_with_span(|id, span: Span| {
+                Pattern::Ident(BindingIdent {
+                    id,
+                    span,
+                    type_ann: None,
+                })
+            }))
+            .then_ignore(just_with_padding(":"))
+            .then(type_ann.clone())
+            .map_with_span(|(ident, type_ann), span: Span| {
+                FnParam::Rest(RestPat {
+                    span,
+                    arg: Box::from(ident),
+                    type_ann: Some(type_ann),
+                })
+            });
+
+        let lam_params = choice((ident_param, rest_param))
             .separated_by(just_with_padding(","))
             .allow_trailing()
             .delimited_by(just_with_padding("("), just_with_padding(")"));
@@ -165,7 +197,7 @@ pub fn type_ann_parser() -> BoxedParser<'static, char, TypeAnn, Simple<char>> {
 
         choice((
             // lambda types have higher precedence than union types so that
-            // `(A, B) => C | D` parse as lambda type with a return type that
+            // `(a: A, b: B) => C | D` parse as lambda type with a return type that
             // happens to be a union.
             lam, union, atom,
         ))
@@ -185,14 +217,15 @@ mod tests {
     #[test]
     fn type_annotations() {
         insta::assert_debug_snapshot!(parse_type("Promise<number>"));
-        insta::assert_debug_snapshot!(parse_type("(number, string) => boolean"));
+        insta::assert_debug_snapshot!(parse_type("(a: number, b: string) => boolean"));
         insta::assert_debug_snapshot!(parse_type("{x: number, y: number}"));
-        insta::assert_debug_snapshot!(parse_type("(A, B) => C | D"));
-        insta::assert_debug_snapshot!(parse_type("((A, B) => C) | D"));
+        insta::assert_debug_snapshot!(parse_type("(a: A, b: B) => C | D"));
+        insta::assert_debug_snapshot!(parse_type("((a: A, b: B) => C) | D"));
         insta::assert_debug_snapshot!(parse_type("A & B & C"));
         insta::assert_debug_snapshot!(parse_type("A & B | C & D"));
-        insta::assert_debug_snapshot!(parse_type("(A) => B & C | D"));
+        insta::assert_debug_snapshot!(parse_type("(a: A) => B & C | D"));
         insta::assert_debug_snapshot!(parse_type("(A | B) & (C | D)"));
-        insta::assert_debug_snapshot!(parse_type("(A, B) => C & D"));
+        insta::assert_debug_snapshot!(parse_type("(a: A, b: B) => C & D"));
+        insta::assert_debug_snapshot!(parse_type("(a: number, ...b: string[]) => boolean"));
     }
 }


### PR DESCRIPTION
TypeScript requires params in function types to be named so we're going to do the same.

This PR also adds support for rest params in function types.