### PR TITLE
Add tests for codegen of (tagged) template literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,14 +205,19 @@ dependencies = [
 name = "crochet_codegen"
 version = "0.1.0"
 dependencies = [
+ "chumsky",
  "crochet_ast",
  "crochet_infer",
+ "crochet_parser",
+ "insta",
+ "pretty_assertions",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_transforms_react",
  "swc_ecma_visit",
+ "testing_macros",
 ]
 
 [[package]]

--- a/crates/crochet_codegen/Cargo.toml
+++ b/crates/crochet_codegen/Cargo.toml
@@ -14,3 +14,10 @@ swc_common = "0.18.2"
 swc_ecma_codegen = "0.108.2"
 swc_ecma_transforms_react = "0.114.1"
 swc_ecma_visit = "0.64.0"
+
+[dev-dependencies]
+crochet_parser = { version = "0.1.0", path = "../crochet_parser" }
+chumsky = "0.8.0"
+insta = "1.13.0"
+pretty_assertions = "1.2.1"
+testing_macros = "0.2.5"

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -1,0 +1,43 @@
+use chumsky::prelude::*;
+
+use crochet_codegen::js::codegen_js;
+use crochet_parser::parser;
+
+fn compile(input: &str) -> String {
+    let program = parser().parse(input).unwrap();
+    codegen_js(&program)
+}
+
+#[test]
+fn js_print_multiple_decls() {
+    insta::assert_snapshot!(compile("let foo = \"hello\"\nlet bar = \"world\""), @r###"
+    export const foo = "hello";
+    export const bar = "world";
+    "###);
+}
+
+#[test]
+fn template_literals() {
+    let src = r#"
+    let a = `hello, world`
+    let p = {x: 5, y: 10}
+    console.log(`p = (${p.x}, ${p.y})`)
+    "#;
+    insta::assert_snapshot!(compile(src), @r###"
+    export const a = `hello, world`;
+    export const p = {
+        x: 5,
+        y: 10
+    };
+    console.log(`p = (${p.x}, ${p.y})`);
+    "###);
+}
+
+#[test]
+fn tagged_template_literals() {
+    let src = r#"
+    let query = sql`SELECT * FROM users WHERE id = "12345"`
+    "#;
+    insta::assert_snapshot!(compile(src), @r###"export const query = sql`SELECT * FROM users WHERE id = "12345"`;
+"###);
+}

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -36,8 +36,11 @@ fn template_literals() {
 #[test]
 fn tagged_template_literals() {
     let src = r#"
-    let query = sql`SELECT * FROM users WHERE id = "12345"`
+    let id = "12345"
+    let query = sql`SELECT * FROM users WHERE id = "${id}"`
     "#;
-    insta::assert_snapshot!(compile(src), @r###"export const query = sql`SELECT * FROM users WHERE id = "12345"`;
-"###);
+    insta::assert_snapshot!(compile(src), @r###"
+    export const id = "12345";
+    export const query = sql`SELECT * FROM users WHERE id = "${id}"`;
+    "###);
 }


### PR DESCRIPTION
I've started adding codegen tests within the `crochet_codegen` crate.  In a future PR, I'll migrate all codegen tests out of the `crochet` crate into `crochet_codegen`.