### PR TITLE
Get rid of extra call stack entries that are introduced by `let`, `if-else`, and `match` in codegen

### DIFF
--- a/crates/crochet/tests/codegen_test.rs
+++ b/crates/crochet/tests/codegen_test.rs
@@ -118,21 +118,23 @@ fn variable_declaration_with_number_literal() {
 #[test]
 fn let_in_inside_declaration() {
     insta::assert_snapshot!(compile("let foo = {let x = 5; x}"), @r###"
-    export const foo = (()=>{
+    let $temp_0;
+    {
         const x = 5;
-        return x;
-    })();
+        $temp_0 = x;
+    }export const foo = $temp_0;
     "###);
 }
 
 #[test]
 fn nested_let_in_inside_declaration() {
     insta::assert_snapshot!(compile("let foo = {let x = 5; let y = 10; x + y}"), @r###"
-    export const foo = (()=>{
+    let $temp_0;
+    {
         const x = 5;
         const y = 10;
-        return x + y;
-    })();
+        $temp_0 = x + y;
+    }export const foo = $temp_0;
     "###);
 }
 
@@ -148,11 +150,12 @@ fn js_print_let_in() {
     let foo = {let x = 5; let y = 10; x + y}
     "#;
     insta::assert_snapshot!(compile(input), @r###"
-    export const foo = (()=>{
+    let $temp_0;
+    {
         const x = 5;
         const y = 10;
-        return x + y;
-    })();
+        $temp_0 = x + y;
+    }export const foo = $temp_0;
     "###);
 }
 
@@ -165,11 +168,12 @@ fn js_print_variable_shadowing() {
         x
     }"#;
     insta::assert_snapshot!(compile(input), @r###"
-    export const foo = (()=>{
+    let $temp_0;
+    {
         const x = 5;
         const x = 10;
-        return x;
-    })();
+        $temp_0 = x;
+    }export const foo = $temp_0;
     "###);
 }
 
@@ -216,14 +220,17 @@ fn js_print_nested_blocks() {
         };
         sum
     }"#), @r###"
-    export const result = (()=>{
-        const sum = (()=>{
+    let $temp_0;
+    {
+        let $temp_1;
+        {
             const x = 5;
             const y = 10;
-            return x + y;
-        })();
-        return sum;
-    })();
+            $temp_1 = x + y;
+        }
+        const sum = $temp_1;
+        $temp_0 = sum;
+    }export const result = $temp_0;
     "###);
 }
 

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -6,7 +6,7 @@ use crochet_infer::*;
 use crochet_parser::parser;
 
 fn infer(input: &str) -> String {
-    let mut ctx = Context::default();
+    let mut ctx = crochet_infer::Context::default();
     let prog = parser().parse(input).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = match stmt {
@@ -16,7 +16,7 @@ fn infer(input: &str) -> String {
     format!("{}", result.unwrap())
 }
 
-fn infer_prog(src: &str) -> (Program, Context) {
+fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
     let result = parser().parse(src);
     let prog = match result {
         Ok(prog) => prog,
@@ -375,13 +375,13 @@ fn codegen_if_else() {
     let js = codegen_js(&program);
     insta::assert_snapshot!(js, @r###"
     export const cond = true;
-    let temp;
+    let $temp_0;
     if (cond) {
-        temp = 5;
+        $temp_0 = 5;
     } else {
-        temp = 5;
+        $temp_0 = 5;
     }
-    export const result = temp;
+    export const result = $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -840,11 +840,12 @@ fn codegen_block_with_multiple_non_let_lines() {
     let js = codegen_js(&program);
 
     insta::assert_snapshot!(js, @r###"
-    export const result = (()=>{
+    let $temp_0;
+    {
         const x = 5;
         x + 0;
-        return x;
-    })();
+        $temp_0 = x;
+    }export const result = $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1255,10 +1256,11 @@ fn codegen_if_let() {
     };
     let $temp_0;
     const $temp_1 = p;
-    const { x , y  } = $temp_1;
-    x + y;
-    $temp_0 = undefined;
-    $temp_0;
+    {
+        const { x , y  } = $temp_1;
+        x + y;
+        $temp_0 = undefined;
+    }$temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1291,10 +1293,11 @@ fn codegen_if_let_with_rename() {
     };
     let $temp_0;
     const $temp_1 = p;
-    const { x: a , y: b  } = $temp_1;
-    a + b;
-    $temp_0 = undefined;
-    $temp_0;
+    {
+        const { x: a , y: b  } = $temp_1;
+        a + b;
+        $temp_0 = undefined;
+    }$temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -1253,11 +1253,12 @@ fn codegen_if_let() {
         x: 5,
         y: 10
     };
-    (()=>{
-        const { x , y  } = p;
-        x + y;
-        return undefined;
-    })();
+    let $temp_0;
+    const $temp_1 = p;
+    const { x , y  } = $temp_1;
+    x + y;
+    $temp_0 = undefined;
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1288,11 +1289,12 @@ fn codegen_if_let_with_rename() {
         x: 5,
         y: 10
     };
-    (()=>{
-        const { x: a , y: b  } = p;
-        a + b;
-        return undefined;
-    })();
+    let $temp_0;
+    const $temp_1 = p;
+    const { x: a , y: b  } = $temp_1;
+    a + b;
+    $temp_0 = undefined;
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1337,14 +1339,14 @@ fn infer_if_let_refutable_pattern_obj() {
         x: 5,
         y: 10
     };
-    (()=>{
-        const value = p;
-        if (value.x === 5) {
-            const { y  } = value;
-            y;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = p;
+    if ($temp_1.x === 5) {
+        const { y  } = $temp_1;
+        y;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1378,14 +1380,14 @@ fn infer_if_let_refutable_pattern_nested_obj() {
             y: 10
         }
     };
-    (()=>{
-        const value = action;
-        if (value.type === "moveto") {
-            const { point: { x , y  }  } = value;
-            x + y;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = action;
+    if ($temp_1.type === "moveto") {
+        const { point: { x , y  }  } = $temp_1;
+        x + y;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1420,14 +1422,14 @@ fn infer_if_let_refutable_pattern_with_disjoint_union() {
     ;
     ;
     ;
-    (()=>{
-        const value = action;
-        if (value.type === "moveto") {
-            const { point: { x , y  }  } = value;
-            x + y;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = action;
+    if ($temp_1.type === "moveto") {
+        const { point: { x , y  }  } = $temp_1;
+        x + y;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1468,14 +1470,14 @@ fn infer_if_let_refutable_pattern_array() {
         5,
         10
     ];
-    (()=>{
-        const value = p;
-        if (value[0] === 5) {
-            const [, y] = value;
-            y;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = p;
+    if ($temp_1[0] === 5) {
+        const [, y] = $temp_1;
+        y;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1506,14 +1508,14 @@ fn infer_if_let_refutable_pattern_nested_array() {
             10
         ]
     ];
-    (()=>{
-        const value = action;
-        if (value[0] === "moveto") {
-            const [, [x, y]] = value;
-            x + y;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = action;
+    if ($temp_1[0] === "moveto") {
+        const [, [x, y]] = $temp_1;
+        x + y;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1538,14 +1540,14 @@ fn codegen_if_let_with_is_prim() {
     let js = codegen_js(&program);
     insta::assert_snapshot!(js, @r###"
     ;
-    (()=>{
-        const value = b;
-        if (typeof value === "number") {
-            const a = value;
-            a + 5;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = b;
+    if (typeof $temp_1 === "number") {
+        const a = $temp_1;
+        a + 5;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
@@ -1603,14 +1605,14 @@ fn codegen_if_let_with_is_class() {
         constructor: ()=>bar
     };
     ;
-    (()=>{
-        const value = b;
-        if (value instanceof Foo) {
-            const a = value;
-            a.getNum() + 5;
-            return undefined;
-        }
-    })();
+    let $temp_0;
+    const $temp_1 = b;
+    if ($temp_1 instanceof Foo) {
+        const a = $temp_1;
+        a.getNum() + 5;
+        $temp_0 = undefined;
+    }
+    $temp_0;
     "###);
 }
 

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -375,13 +375,13 @@ fn codegen_if_else() {
     let js = codegen_js(&program);
     insta::assert_snapshot!(js, @r###"
     export const cond = true;
-    export const result = (()=>{
-        if (cond) {
-            return 5;
-        } else {
-            return 5;
-        }
-    })();
+    let temp;
+    if (cond) {
+        temp = 5;
+    } else {
+        temp = 5;
+    }
+    export const result = temp;
     "###);
 
     let result = codegen_d_ts(&program, &ctx);

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -439,10 +439,6 @@ pub fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>) -> Expr {
                     alt,
                 }));
 
-                // let body = BlockStmtOrExpr::BlockStmt(BlockStmt {
-                //     span: DUMMY_SP,
-                //     stmts,
-                // });
                 Expr::Ident(Ident {
                     span: DUMMY_SP,
                     sym: JsWord::from(String::from("temp")),
@@ -874,10 +870,12 @@ pub fn let_to_children(r#let: &ast::Let) -> Vec<Stmt> {
     }));
 
     // TODO:
-    // preprend children with the contents of `stmts`
+    // This works right now, but for more complicated blocks we'll
+    // want to intersperse stmts and children.
     println!("let_to_children - stmts = {stmts:#?}");
+    stmts.append(&mut children);
 
-    children
+    stmts
 }
 
 // TODO: have an intermediary from between the AST and what we used for

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -123,7 +123,7 @@ fn build_js(program: &ast::Program, ctx: &mut Context) -> Program {
     })
 }
 
-pub fn build_pattern(
+fn build_pattern(
     pattern: &ast::Pattern,
     stmts: &mut Vec<Stmt>,
     ctx: &mut Context,
@@ -199,24 +199,7 @@ pub fn build_pattern(
     }
 }
 
-pub fn build_return_block(body: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> BlockStmt {
-    match body {
-        // Avoids wrapping in an IIFE when it isn't necessary.
-        ast::Expr::Let(r#let) => BlockStmt {
-            span: DUMMY_SP,
-            stmts: let_to_children(r#let, ctx),
-        },
-        _ => BlockStmt {
-            span: DUMMY_SP,
-            stmts: vec![Stmt::Return(ReturnStmt {
-                span: DUMMY_SP,
-                arg: Some(Box::from(build_expr(body, stmts, ctx))),
-            })],
-        },
-    }
-}
-
-pub fn build_expr_in_new_scope(expr: &ast::Expr, temp_id: &Ident, ctx: &mut Context) -> BlockStmt {
+fn build_expr_in_new_scope(expr: &ast::Expr, temp_id: &Ident, ctx: &mut Context) -> BlockStmt {
     let mut stmts: Vec<Stmt> = vec![];
 
     let expr = if let ast::Expr::Let(r#let) = expr {
@@ -245,7 +228,7 @@ pub fn build_expr_in_new_scope(expr: &ast::Expr, temp_id: &Ident, ctx: &mut Cont
     }
 }
 
-pub fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Expr {
+fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Expr {
     match expr {
         ast::Expr::App(ast::App { lam, args, .. }) => {
             let callee = Callee::Expr(Box::from(build_expr(lam.as_ref(), stmts, ctx)));
@@ -779,31 +762,7 @@ fn build_arm(
     (cond, block)
 }
 
-// fn build_iife(body: BlockStmtOrExpr) -> Expr {
-//     let arrow = Expr::Arrow(ArrowExpr {
-//         span: DUMMY_SP,
-//         params: vec![],
-//         body,
-//         is_async: false,
-//         is_generator: false,
-//         type_params: None,
-//         return_type: None,
-//     });
-
-//     let callee = Callee::Expr(Box::from(Expr::Paren(ParenExpr {
-//         span: DUMMY_SP,
-//         expr: Box::from(arrow),
-//     })));
-
-//     Expr::Call(CallExpr {
-//         span: DUMMY_SP,
-//         callee,
-//         args: vec![],
-//         type_args: None,
-//     })
-// }
-
-pub fn build_jsx_element(
+fn build_jsx_element(
     elem: &ast::JSXElement,
     stmts: &mut Vec<Stmt>,
     ctx: &mut Context,
@@ -881,7 +840,7 @@ pub fn build_jsx_element(
     elem
 }
 
-pub fn build_lit(lit: &ast::Lit) -> Lit {
+fn build_lit(lit: &ast::Lit) -> Lit {
     match lit {
         ast::Lit::Num(n) => Lit::Num(Number {
             span: DUMMY_SP,
@@ -907,7 +866,7 @@ pub fn build_lit(lit: &ast::Lit) -> Lit {
 // TODO: have an intermediary from between the AST and what we used for
 // codegen that unwraps `Let` nodes into vectors before converting them
 // to statements.
-pub fn let_to_children(r#let: &ast::Let, ctx: &mut Context) -> Vec<Stmt> {
+fn let_to_children(r#let: &ast::Let, ctx: &mut Context) -> Vec<Stmt> {
     let mut stmts: Vec<Stmt> = vec![];
 
     let mut children: Vec<Stmt> = vec![let_to_child(r#let, &mut stmts, ctx)];
@@ -935,7 +894,7 @@ pub fn let_to_children(r#let: &ast::Let, ctx: &mut Context) -> Vec<Stmt> {
 // TODO: have an intermediary from between the AST and what we used for
 // codegen that unwraps `Let` nodes into vectors before converting them
 // to statements.
-pub fn let_to_children_no_return(
+fn let_to_children_no_return(
     r#let: &ast::Let,
     stmts: &mut Vec<Stmt>,
     ctx: &mut Context,

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -118,7 +118,7 @@ fn pattern_matching_multiple_catchall_panics() {
         _ => "bar",
     }
     "#;
-    
+
     compile(src);
 }
 
@@ -129,6 +129,31 @@ fn pattern_matching_no_arms_panics() {
     let result = match value {
     }
     "#;
-    
+
     compile(src);
+}
+
+#[test]
+fn simple_if_else() {
+    let src = r#"
+    let result = if cond {
+        console.log("true");
+        5
+    } else {
+        console.log("false");
+        10
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    let temp;
+    if (cond) {
+        console.log("true");
+        temp = 5;
+    } else {
+        console.log("false");
+        temp = 10;
+    }
+    export const result = temp;
+    "###);
 }

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -266,9 +266,10 @@ fn codegen_if_let_with_rename() {
         x: 5,
         y: 10
     };
-    const { x: a , y: b  } = $temp_1;
-    $temp_0 = a + b;
-    export const result = $temp_0;
+    {
+        const { x: a , y: b  } = $temp_1;
+        $temp_0 = a + b;
+    }export const result = $temp_0;
     "###);
 }
 
@@ -296,5 +297,19 @@ fn infer_if_let_refutable_pattern_nested_obj() {
         $temp_0 = x + y;
     }
     $temp_0;
+    "###);
+}
+
+#[test]
+fn codegen_block_with_multiple_non_let_lines() {
+    let src = "let result = {let x = 5; x + 0; x}";
+
+    insta::assert_snapshot!(compile(src), @r###"
+    let $temp_0;
+    {
+        const x = 5;
+        x + 0;
+        $temp_0 = x;
+    }export const result = $temp_0;
     "###);
 }

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -63,23 +63,22 @@ fn pattern_matching() {
     }
     "#;
     insta::assert_snapshot!(compile(src), @r###"
-    export const result = (()=>{
-        const value = count + 1;
-        if (value === 0) {
-            return "none";
-        } else if (value === 1) {
-            return "one";
-        } else if (value === 2) {
-            return "a couple";
-        } else if (n < 5) {
-            const n = value;
-            console.log(`n = ${n}`);
-            return "a few";
-        } else {
-            console.log("fallthrough");
-            return "many";
-        }
-    })();
+    const $temp_0 = count + 1;
+    if ($temp_0 === 0) {
+        $temp_0 = "none";
+    } else if ($temp_0 === 1) {
+        $temp_0 = "one";
+    } else if ($temp_0 === 2) {
+        $temp_0 = "a couple";
+    } else if (n < 5) {
+        const n = $temp_0;
+        console.log(`n = ${n}`);
+        $temp_0 = "a few";
+    } else {
+        console.log("fallthrough");
+        $temp_0 = "many";
+    }
+    export const result = $temp_0;
     "###);
 }
 
@@ -96,16 +95,15 @@ fn pattern_matching_with_disjoint_union() {
     insta::assert_snapshot!(compile(src), @r###"
     ;
     ;
-    export const result = (()=>{
-        const value = event;
-        if (value.type === "mousedown") {
-            const { x , y  } = value;
-            return `mousedown: (${x}, ${y})`;
-        } else if (value.type === "keydown" && key !== "Escape") {
-            const { key  } = value;
-            return key;
-        }
-    })();
+    const $temp_0 = event;
+    if ($temp_0.type === "mousedown") {
+        const { x , y  } = $temp_0;
+        $temp_0 = `mousedown: (${x}, ${y})`;
+    } else if ($temp_0.type === "keydown" && key !== "Escape") {
+        const { key  } = $temp_0;
+        $temp_0 = key;
+    }
+    export const result = $temp_0;
     "###);
 }
 

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -146,15 +146,15 @@ fn simple_if_else() {
     "#;
 
     insta::assert_snapshot!(compile(src), @r###"
-    let temp;
+    let $temp_0;
     if (cond) {
         console.log("true");
-        temp = 5;
+        $temp_0 = 5;
     } else {
         console.log("false");
-        temp = 10;
+        $temp_0 = 10;
     }
-    export const result = temp;
+    export const result = $temp_0;
     "###);
 }
 
@@ -175,15 +175,77 @@ fn simple_if_else_inside_fn() {
 
     insta::assert_snapshot!(compile(src), @r###"
     export const foo = ()=>{
-        let temp;
+        let $temp_0;
         if (cond) {
             console.log("true");
-            temp = 5;
+            $temp_0 = 5;
         } else {
             console.log("false");
-            temp = 10;
+            $temp_0 = 10;
         }
-        const result = temp;
+        const result = $temp_0;
+        return result;
+    };
+    "###);
+}
+
+#[test]
+fn nested_if_else() {
+    let src = r#"
+    let result = if c1 {
+        if c2 {
+            5
+        } else {
+            10
+        }
+    } else {
+        if c3 {
+            "hello"
+        } else {
+            "world"
+        }
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    let $temp_0;
+    if (c1) {
+        let $temp_1;
+        if (c2) {
+            $temp_1 = 5;
+        } else {
+            $temp_1 = 10;
+        }
+        $temp_0 = $temp_1;
+    } else {
+        let $temp_2;
+        if (c3) {
+            $temp_2 = "hello";
+        } else {
+            $temp_2 = "world";
+        }
+        $temp_0 = $temp_2;
+    }
+    export const result = $temp_0;
+    "###);
+}
+
+#[test]
+fn multiple_lets_inside_a_function() {
+    let src = r#"
+    let do_math = () => {
+        let x = 5;
+        let y = 10;
+        let result = x + y;
+        result
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    export const do_math = ()=>{
+        const x = 5;
+        const y = 10;
+        const result = x + y;
         return result;
     };
     "###);

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -157,3 +157,34 @@ fn simple_if_else() {
     export const result = temp;
     "###);
 }
+
+#[test]
+fn simple_if_else_inside_fn() {
+    let src = r#"
+    let foo = () => {
+        let result = if cond {
+            console.log("true");
+            5
+        } else {
+            console.log("false");
+            10
+        };
+        result
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    export const foo = ()=>{
+        let temp;
+        if (cond) {
+            console.log("true");
+            temp = 5;
+        } else {
+            console.log("false");
+            temp = 10;
+        }
+        const result = temp;
+        return result;
+    };
+    "###);
+}

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -190,6 +190,33 @@ fn simple_if_else_inside_fn() {
 }
 
 #[test]
+fn simple_if_else_inside_fn_as_expr() {
+    let src = r#"
+    let foo = () => if cond {
+        console.log("true");
+        5
+    } else {
+        console.log("false");
+        10
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    export const foo = ()=>{
+        let $temp_0;
+        if (cond) {
+            console.log("true");
+            $temp_0 = 5;
+        } else {
+            console.log("false");
+            $temp_0 = 10;
+        }
+        return $temp_0;
+    };
+    "###);
+}
+
+#[test]
 fn nested_if_else() {
     let src = r#"
     let result = if c1 {


### PR DESCRIPTION
In a number of places we were using IIFEs to handle expressions that are normally statements in JavaScript.  Unfortunately, this was introducing extra entries into the call stack which would undoubtedly lead to confusing later on when debugging code.  This removes the unnecessary IIFEs.