### PR TITLE
remove .frozen field from types

### DIFF
--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -224,9 +224,6 @@ fn infer_if_else_with_widening_of_top_level_vars() {
     let b = 10
     let x = if true { a } else { b }
     "#;
-    // Even though `a` and `b` have been frozen, we still allow
-    // clones of them to be widened when they're returned from an
-    // if-else.
     let (_, ctx) = infer_prog(src);
     let result = format!("{}", ctx.values.get("x").unwrap());
     assert_eq!(result, "5 | 10");
@@ -592,16 +589,6 @@ fn infer_widen_tuple_return() {
     assert_eq!(result, "(boolean) => [1, 2] | [true, false]");
 }
 
-// TODO: meditate on how to allow if-else to return a widened type
-// if both branches return a frozen type.
-// IDEA: we could make a copy of the type an unfreeze it.
-// When do we care about the frozeness of a type:
-// - assignment
-// - application
-// The problem is that the constraint solver doesn't know about these.
-// We should consider tagging constraints when we infer them.  We need
-// to do this anyways to handle subtyping of functions so that callbacks
-// are handled correctly.
 #[ignore]
 #[test]
 fn infer_widen_tuples_with_type_annotations() {
@@ -1160,17 +1147,6 @@ fn incorrect_args() {
     add("hello", "world")
     "#;
     infer_prog(src);
-}
-
-#[test]
-fn top_level_inferred_types_are_frozen() {
-    let src = r#"
-    let add = (a, b) => a + b
-    "#;
-    let (_, ctx) = infer_prog(src);
-
-    let add = ctx.values.get("add").unwrap();
-    assert!(add.ty.frozen);
 }
 
 #[test]

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -70,7 +70,6 @@ impl Context {
     pub fn fresh_var(&self) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Var,
         }
     }
@@ -78,7 +77,6 @@ impl Context {
     pub fn lam(&self, params: Vec<Type>, ret: Box<Type>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Lam(LamType {
                 params,
                 ret,
@@ -90,7 +88,6 @@ impl Context {
     pub fn prim(&self, prim: Primitive) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Prim(prim),
         }
     }
@@ -105,7 +102,6 @@ impl Context {
         };
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Lit(lit),
         }
     }
@@ -113,7 +109,6 @@ impl Context {
     pub fn lit_type(&self, lit: Lit) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Lit(lit),
         }
     }
@@ -121,7 +116,6 @@ impl Context {
     pub fn union(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Union(types),
         }
     }
@@ -129,7 +123,6 @@ impl Context {
     pub fn intersection(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Intersection(types),
         }
     }
@@ -137,7 +130,6 @@ impl Context {
     pub fn object(&self, props: Vec<TProp>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Object(props),
         }
     }
@@ -153,7 +145,6 @@ impl Context {
     pub fn alias(&self, name: &str, type_params: Option<Vec<Type>>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Alias(AliasType {
                 name: name.to_owned(),
                 type_params,
@@ -164,7 +155,6 @@ impl Context {
     pub fn tuple(&self, types: Vec<Type>) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Tuple(types),
         }
     }
@@ -172,7 +162,6 @@ impl Context {
     pub fn array(&self, t: Type) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Array(Box::from(t)),
         }
     }
@@ -180,7 +169,6 @@ impl Context {
     pub fn rest(&self, arg: Type) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Rest(Box::from(arg)),
         }
     }
@@ -188,7 +176,6 @@ impl Context {
     pub fn mem(&self, obj: Type, prop: &str) -> Type {
         Type {
             id: self.fresh_id(),
-            frozen: false,
             variant: Variant::Member(MemberType {
                 obj: Box::from(obj),
                 prop: prop.to_owned(),

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -5,7 +5,7 @@ use super::infer_expr::infer_expr as infer_expr_rec;
 use super::infer_pattern::*;
 use super::infer_type_ann::*;
 use super::substitutable::{Subst, Substitutable};
-use super::types::{freeze_scheme, Scheme, Type, TProp};
+use super::types::{Scheme, Type, TProp};
 use super::util::*;
 
 pub fn infer_prog(prog: &Program) -> Result<Context, String> {
@@ -47,7 +47,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
                                     Some(type_ann) => {
                                         let scheme = infer_scheme(type_ann, &ctx);
                                         ctx.values
-                                            .insert(id.name.to_owned(), freeze_scheme(scheme));
+                                            .insert(id.name.to_owned(), scheme);
                                     }
                                     None => {
                                         // A type annotation should always be provided when using `declare`
@@ -72,7 +72,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
                         // current context.
                         for (name, scheme) in pa {
                             let scheme = normalize(&scheme.apply(&s), &ctx);
-                            ctx.values.insert(name, freeze_scheme(scheme));
+                            ctx.values.insert(name, scheme);
                         }
                     }
                 };
@@ -84,7 +84,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
                 ..
             } => {
                 let scheme = infer_scheme_with_type_params(type_ann, type_params, &ctx);
-                ctx.types.insert(id.name.to_owned(), freeze_scheme(scheme));
+                ctx.types.insert(id.name.to_owned(), scheme);
             }
             Statement::Expr { expr, .. } => {
                 // We ignore the type that was inferred, we only care that

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -38,7 +38,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             // s3       <- unify (apply s2 t1) (TArr t2 tv)
             let call_type = Type {
                 id: ctx.fresh_id(),
-                frozen: false,
                 variant: Variant::Lam(types::LamType {
                     params: arg_types,
                     ret: Box::from(ret_type.clone()),
@@ -166,7 +165,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
                                 let call_type = Type {
                                     id: ctx.fresh_id(),
-                                    frozen: false,
                                     variant: Variant::Lam(types::LamType {
                                         params: vec![ctx.object(props)],
                                         ret: Box::from(ret_type.clone()),

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -4,7 +4,7 @@ use std::iter::Iterator;
 use crochet_ast::*;
 
 use super::context::Context;
-use super::types::{freeze, Scheme, TProp, Type};
+use super::types::{Scheme, TProp, Type};
 
 pub fn infer_scheme(type_ann: &TypeAnn, ctx: &Context) -> Scheme {
     match type_ann {
@@ -44,8 +44,7 @@ pub fn infer_scheme_with_type_params(
 }
 
 pub fn infer_type_ann(type_ann: &TypeAnn, ctx: &Context) -> Type {
-    let type_ann_ty = infer_type_ann_rec(type_ann, ctx, &HashMap::default());
-    freeze(type_ann_ty)
+    infer_type_ann_rec(type_ann, ctx, &HashMap::default())
 }
 
 pub fn infer_type_ann_with_params(
@@ -53,7 +52,7 @@ pub fn infer_type_ann_with_params(
     ctx: &Context,
     type_param_map: &HashMap<String, Type>,
 ) -> Type {
-    freeze(infer_type_ann_rec(type_ann, ctx, type_param_map))
+    infer_type_ann_rec(type_ann, ctx, type_param_map)
 }
 
 fn infer_type_ann_rec(

--- a/crates/crochet_infer/src/types/scheme.rs
+++ b/crates/crochet_infer/src/types/scheme.rs
@@ -1,7 +1,7 @@
 use itertools::join;
 use std::fmt;
 
-use crate::types::{Type, freeze};
+use crate::types::Type;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scheme {
@@ -48,12 +48,5 @@ impl fmt::Display for Scheme {
                 ty
             )
         }
-    }
-}
-
-pub fn freeze_scheme(scheme: Scheme) -> Scheme {
-    Scheme { 
-        ty: freeze(scheme.ty),
-        ..scheme
     }
 }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -20,7 +20,6 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                 key.to_owned(),
                 Type {
                     id: index as i32,
-                    frozen: false,
                     variant: Variant::Var,
                 },
             )


### PR DESCRIPTION
It isn't being used anywhere anymore.  infer_expr.rs generate union types when inferring `IfElse` and `Match` expressions by inferring the result type of each arm and computing the union of those types.