### PR TITLE
Fix if let else codegen

### DIFF
--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -383,7 +383,7 @@ fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Exp
         }
         ast::Expr::UnaryExpr(ast::UnaryExpr { arg, op, .. }) => {
             let op = match op {
-                ast::UnaryOp::Minus => UnaryOp::Minus
+                ast::UnaryOp::Minus => UnaryOp::Minus,
             };
 
             Expr::Unary(UnaryExpr {
@@ -391,7 +391,7 @@ fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Exp
                 op,
                 arg: Box::from(build_expr(arg, stmts, ctx)),
             })
-        },
+        }
         ast::Expr::Fix(ast::Fix { expr, .. }) => match expr.as_ref() {
             ast::Expr::Lambda(ast::Lambda { body, .. }) => build_expr(body, stmts, ctx),
             _ => panic!("Fix should only wrap a lambda"),
@@ -402,7 +402,9 @@ fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Exp
             alternate,
             ..
         }) => match cond.as_ref() {
-            ast::Expr::LetExpr(let_expr) => build_let_expr(let_expr, consequent, stmts, ctx),
+            ast::Expr::LetExpr(let_expr) => {
+                build_let_expr(let_expr, consequent, alternate, stmts, ctx)
+            }
             _ => {
                 // let $temp_n;
                 let temp_id = ctx.new_ident();
@@ -593,6 +595,7 @@ fn build_expr(expr: &ast::Expr, stmts: &mut Vec<Stmt>, ctx: &mut Context) -> Exp
 fn build_let_expr(
     let_expr: &ast::LetExpr,
     consequent: &ast::Expr,
+    alternate: &Option<Box<ast::Expr>>,
     stmts: &mut Vec<Stmt>,
     ctx: &mut Context,
 ) -> Expr {
@@ -618,11 +621,19 @@ fn build_let_expr(
 
     match cond {
         Some(cond) => {
+            let alt = alternate.as_ref().map(|alt| {
+                Box::from(Stmt::Block(build_expr_in_new_scope(
+                    alt.as_ref(),
+                    &ret_id,
+                    ctx,
+                )))
+            });
+            println!("alt = {alt:#?}");
             let if_else = Stmt::If(IfStmt {
                 span: DUMMY_SP,
                 test: Box::from(cond),
                 cons: Box::from(Stmt::Block(block)),
-                alt: None, // TODO: handle chaining of if-let with else
+                alt,
             });
             stmts.push(if_else);
         }

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -628,7 +628,6 @@ fn build_let_expr(
                     ctx,
                 )))
             });
-            println!("alt = {alt:#?}");
             let if_else = Stmt::If(IfStmt {
                 span: DUMMY_SP,
                 test: Box::from(cond),

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -311,7 +311,7 @@ fn codegen_if_let_with_rename() {
 }
 
 #[test]
-fn infer_if_let_refutable_pattern_nested_obj() {
+fn codegen_if_let_refutable_pattern_nested_obj() {
     let src = r#"
     let action = {type: "moveto", point: {x: 5, y: 10}}
     if let {type: "moveto", point: {x, y}} = action {
@@ -334,6 +334,41 @@ fn infer_if_let_refutable_pattern_nested_obj() {
         $temp_0 = x + y;
     }
     $temp_0;
+    "###);
+}
+
+#[test]
+fn codegen_if_let_with_else() {
+    let src = r#"
+    declare let a: string | number
+    let result = if let x is number = a {
+        x + 5
+    } else if let y is string = a {
+        y
+    } else {
+        true
+    }
+    "#;
+
+    insta::assert_snapshot!(compile(src), @r###"
+    ;
+    let $temp_0;
+    const $temp_1 = a;
+    if (typeof $temp_1 === "number") {
+        const x = $temp_1;
+        $temp_0 = x + 5;
+    } else {
+        let $temp_2;
+        const $temp_3 = a;
+        if (typeof $temp_3 === "string") {
+            const y = $temp_3;
+            $temp_2 = y;
+        } else {
+            $temp_2 = true;
+        }
+        $temp_0 = $temp_2;
+    }
+    export const result = $temp_0;
     "###);
 }
 


### PR DESCRIPTION
Codegen for `LetExpr` was ignoring the `alt` field.  This PR fixes that along with an issue where some of the temp variables were being used incorrectly.