### PR TITLE
Parse some parts of .d.ts files and infer appropriate Crochet types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'yarn'
 
       - name: Install node_modules
-        run: npm ci  
+        run: yarn install --frozen-lockfile
 
       - name: Cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Install node_modules
+        run: yarn install --frozen-lockfile
+
       - name: Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
         uses: actions/cache@v3
@@ -32,7 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install node_modules
+        run: npm ci  
 
       - name: Cache
         uses: actions/cache@v3
@@ -55,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache
         uses: actions/cache@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "ast_node"
-version = "0.7.7"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4c00309ed1c8104732df4a5fa9acc3b796b6f8531dfbd5ce0078c86f997244"
+checksum = "1a36288803cd1605bc4f0e3189970a0db8e602bb01a39f8133889f35ece7ddde"
 dependencies = [
  "darling",
  "pmutil",
@@ -221,6 +221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crochet_dts"
+version = "0.1.0"
+dependencies = [
+ "memoize",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "crochet_infer"
 version = "0.1.0"
 dependencies = [
@@ -270,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -280,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -294,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -435,6 +447,15 @@ name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ident_case"
@@ -634,6 +655,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8ac914af411755d49b6bab6276195ff57f2c5d944698f79c3bfc33f2a162cd"
+dependencies = [
+ "lazy_static",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217a1e7f586ba063a4dc87a2dfb26f7700e150c9b378cb2aef511cd42013f8a3"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1068,25 +1121,28 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.11"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8735ce37e421749498e038955abc1135eec6a4af0b54a173e55d2e5542d472"
+checksum = "66e252fe697709a0fc8710b5b9dee2d72fd9852d3f5fd1a057ce808b6987ccba"
 dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
  "string_cache",
  "string_cache_codegen",
 ]
 
 [[package]]
 name = "swc_common"
-version = "0.18.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14c5d15a47c404bc1e1597f4412643d293aed2c3143c9c4a9c20abe879a934b"
+checksum = "f7b3ce2fcc4e51ffb3e0556f04bf50e6cdeaaab9b019282f68acb2311c4b75f8"
 dependencies = [
  "ahash 0.7.6",
  "ast_node",
@@ -1101,6 +1157,7 @@ dependencies = [
  "serde",
  "siphasher",
  "string_cache",
+ "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
  "tracing",
@@ -1136,12 +1193,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.78.0"
+version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed68ad13e4489f309ffed9d302337d7c8bde11d00b8b275b7aa7fda4da035bf"
+checksum = "8e5cfd9a8757b634f899c5585e9059cf368ec3708b57294d6b3ea0167dc6ebee"
 dependencies = [
+ "bitflags",
  "is-macro",
  "num-bigint",
+ "scoped-tls",
  "serde",
  "string_enum",
  "swc_atoms",
@@ -1151,15 +1210,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.108.2"
+version = "0.120.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012de8d3583c4cce8ce08891dc6317136730f87ba53937d5f0eb3b86bca31048"
+checksum = "8c9392272e5793822b888b271db3b3abe0d6dbe4ff8cbed628a731354760610d"
 dependencies = [
- "bitflags",
  "memchr",
  "num-bigint",
  "once_cell",
  "rustc-hash",
+ "serde",
  "sourcemap",
  "swc_atoms",
  "swc_common",
@@ -1170,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59949619b2ef45eedb6c399d05f2c3c7bc678b5074b3103bb670f9e05bb99042"
+checksum = "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1183,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.104.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb97dc6efc95313dedc5158055cc811da77395ef7b54be61948b5ad097a3671"
+checksum = "12740be040fa5635ac73bb38fd7340887d6b5f36e0daf4eaec662838398dd4eb"
 dependencies = [
  "either",
  "enum_kind",
@@ -1198,16 +1257,17 @@ dependencies = [
  "swc_ecma_ast",
  "tracing",
  "typed-arena",
- "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.85.0"
+version = "0.102.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8262876d5387887776f23c4894fbddff26e5f184edadf2375f3dc19fca2b42a4"
+checksum = "05b1c1cac18cc14264aea1525d2a218497e720b4a7f11e5518508cd7ef3fa9aa"
 dependencies = [
  "better_scoped_tls",
+ "bitflags",
+ "num_cpus",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -1224,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18712e4aab969c6508dff3540ade6358f1e013464aa58b3d30da2ab2d9fcbbed"
+checksum = "ebf907935ec5492256b523ae7935a824d9fdc0368dcadc41375bad0dca91cd8b"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1237,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.114.1"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbfcd197ebeb0547b59dee39a164633bcf4fb0edbae886f8046e471e6a10502"
+checksum = "bcfba7f0dcf32d4e82c89759bd1ff851e1bfa32493271e93d34ae7fbb583ff4d"
 dependencies = [
  "ahash 0.7.6",
  "base64 0.13.0",
@@ -1263,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.85.0"
+version = "0.98.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9d469b284a48317a695a81346a9609d04ce3a31da4493aac508e0d48a4257"
+checksum = "062b89033c83876252bf2a6d9fe87f5c10c3f66609de91bf9915afff95fb1346"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -1274,13 +1334,14 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
+ "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.64.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d3783a0dd1e301ae2945ab1241405f913427f9512ec62756d3d2072f7c21bb"
+checksum = "5e1efa6716523365a6b947388cca7e4b3b59da046fd1d0200efc02bc3395e7f4"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1304,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dca3f08d02da4684c3373150f7c045128f81ea00f0c434b1b012bc65a6cce3"
+checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1316,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c639379dd2a8a0221fa1e12fafbdd594ba53a0cace6560054da52409dfcc1a"
+checksum = "ce1b826c9d4c0416bbed55d245c853bc1a60da55bf92f8b00dd22b37baf72080"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1326,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.3.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9b72892df873972549838bf84d6c56234c7502148a7e23b5a3da6e0fedfb8"
+checksum = "9fda2daf67d99e8bc63d61b12818994863f65b7bcf52d4faab338154c7058546"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,9 @@ dependencies = [
 name = "crochet_dts"
 version = "0.1.0"
 dependencies = [
+ "crochet_ast",
+ "crochet_infer",
+ "defaultmap",
  "memoize",
  "swc_atoms",
  "swc_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/crochet",
     "crates/crochet_ast",
     "crates/crochet_codegen",
+    "crates/crochet_dts",
     "crates/crochet_infer",
     "crates/crochet_parser",
 ]

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -406,8 +406,8 @@ fn codegen_object() {
 
     insta::assert_snapshot!(result, @r###"
     export declare const point: {
-        x: 5;
-        y: 10;
+        readonly x: 5;
+        readonly y: 10;
     };
     "###);
 }
@@ -693,8 +693,8 @@ fn codegen_code_with_type_delcarations() {
 
     insta::assert_snapshot!(result, @r###"
     type Point = {
-        x: number;
-        y: number;
+        readonly x: number;
+        readonly y: number;
     };
     export declare const point: Point;
     "###);
@@ -790,8 +790,8 @@ fn codegen_object_type_with_optional_property() {
 
     insta::assert_snapshot!(result, @r###"
     type Point = {
-        x?: number;
-        y: number;
+        readonly x?: number;
+        readonly y: number;
     };
     export declare const point: Point;
     "###);
@@ -1243,8 +1243,8 @@ fn codegen_if_let() {
 
     insta::assert_snapshot!(result, @r###"
     export declare const p: {
-        x: 5;
-        y: 10;
+        readonly x: 5;
+        readonly y: 10;
     };
     ;
     "###);
@@ -1280,8 +1280,8 @@ fn codegen_if_let_with_rename() {
 
     insta::assert_snapshot!(result, @r###"
     export declare const p: {
-        x: 5;
-        y: 10;
+        readonly x: 5;
+        readonly y: 10;
     };
     ;
     "###);
@@ -1332,8 +1332,8 @@ fn infer_if_let_refutable_pattern_obj() {
 
     insta::assert_snapshot!(result, @r###"
     export declare const p: {
-        x: 5;
-        y: 10;
+        readonly x: 5;
+        readonly y: 10;
     };
     ;
     "###);
@@ -1373,10 +1373,10 @@ fn infer_if_let_refutable_pattern_nested_obj() {
 
     insta::assert_snapshot!(result, @r###"
     export declare const action: {
-        type: "moveto";
-        point: {
-            x: 5;
-            y: 10;
+        readonly type: "moveto";
+        readonly point: {
+            readonly x: 5;
+            readonly y: 10;
         };
     };
     ;
@@ -1415,15 +1415,15 @@ fn infer_if_let_refutable_pattern_with_disjoint_union() {
 
     insta::assert_snapshot!(result, @r###"
     type Point = {
-        x: number;
-        y: number;
+        readonly x: number;
+        readonly y: number;
     };
     type Action = {
-        type: "moveto";
-        point: Point;
+        readonly type: "moveto";
+        readonly point: Point;
     } | {
-        type: "lineto";
-        point: Point;
+        readonly type: "lineto";
+        readonly point: Point;
     };
     export declare const action: Action;
     ;

--- a/crates/crochet_ast/src/literal.rs
+++ b/crates/crochet_ast/src/literal.rs
@@ -1,4 +1,4 @@
-use swc_atoms::JsWord;
+use swc_atoms::{JsWord, Atom};
 use swc_common::source_map::DUMMY_SP;
 use swc_ecma_ast;
 
@@ -91,7 +91,7 @@ impl From<&Lit> for swc_ecma_ast::Expr {
                     value: n.value.parse().unwrap(),
                     // Use `None` value only for transformations to avoid recalculate
                     // characters in number literal
-                    raw: Some(JsWord::from(n.value.clone())),
+                    raw: Some(Atom::new(n.value.clone())),
                 });
                 swc_ecma_ast::Expr::Lit(lit)
             }

--- a/crates/crochet_ast/src/types.rs
+++ b/crates/crochet_ast/src/types.rs
@@ -48,6 +48,7 @@ pub struct TProp {
     pub span: Span,
     pub name: String,
     pub optional: bool,
+    pub mutable: bool,
     pub type_ann: Box<TypeAnn>,
 }
 

--- a/crates/crochet_codegen/Cargo.toml
+++ b/crates/crochet_codegen/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 [dependencies]
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 crochet_infer = { version = "0.1.0", path = "../crochet_infer" }
-swc_atoms = "0.2.11"
-swc_ecma_ast = "0.78.0"
-swc_common = "0.18.2"
-swc_ecma_codegen = "0.108.2"
-swc_ecma_transforms_react = "0.114.1"
-swc_ecma_visit = "0.64.0"
+swc_atoms = "0.3.0"
+swc_ecma_ast = "0.89.1"
+swc_common = "0.26.0"
+swc_ecma_codegen = "0.120.3"
+swc_ecma_transforms_react = "0.139.0"
+swc_ecma_visit = "0.75.0"
 
 [dev-dependencies]
 crochet_parser = { version = "0.1.0", path = "../crochet_parser" }

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -356,7 +356,7 @@ pub fn build_type(
                 .map(|prop| {
                     TsTypeElement::TsPropertySignature(TsPropertySignature {
                         span: DUMMY_SP,
-                        readonly: false,
+                        readonly: !prop.mutable,
                         key: Box::from(Expr::from(Ident {
                             span: DUMMY_SP,
                             sym: JsWord::from(prop.name.to_owned()),

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -210,7 +210,7 @@ pub fn build_type(
                 crochet_infer::types::Lit::Num(n) => TsLit::Number(Number {
                     span: DUMMY_SP,
                     value: n.parse().unwrap(),
-                    raw: Some(JsWord::from(n.to_owned())),
+                    raw: Some(Atom::new(n.to_owned())),
                 }),
                 crochet_infer::types::Lit::Bool(b) => TsLit::Bool(Bool {
                     span: DUMMY_SP,

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -739,8 +739,8 @@ fn build_jsx_element(
                     ast::JSXElementChild::JSXText(ast::JSXText { value, .. }) => {
                         JSXElementChild::JSXText(JSXText {
                             span: DUMMY_SP,
-                            value: JsWord::from(value.to_owned()),
-                            raw: JsWord::from(value.to_owned()),
+                            value: Atom::new(value.to_owned()),
+                            raw: Atom::new(value.to_owned()),
                         })
                     }
                     ast::JSXElementChild::JSXExprContainer(ast::JSXExprContainer {
@@ -886,8 +886,8 @@ fn build_template_literal(
                 };
                 TplElement {
                     span: DUMMY_SP,
-                    cooked: Some(JsWord::from(cooked.to_owned())),
-                    raw: JsWord::from(raw.to_owned()),
+                    cooked: Some(Atom::new(cooked.to_owned())),
+                    raw: Atom::new(raw.to_owned()),
                     tail: false, // TODO: set this to `true` if it's the last quasi
                 }
             })

--- a/crates/crochet_dts/Cargo.toml
+++ b/crates/crochet_dts/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
-name = "crochet_ast"
+name = "crochet_dts"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# TODO: hide these behind a feature and then only use that feature in the codegen crate
-swc_atoms = "0.3.1"
-swc_common = "0.26.0"
+swc_atoms = "0.3.0"
 swc_ecma_ast = "0.89.1"
+swc_ecma_parser = "0.116.0"
+swc_common = "0.26.0"
+swc_ecma_visit = "0.75.0"
+memoize = "0.3.0"

--- a/crates/crochet_dts/Cargo.toml
+++ b/crates/crochet_dts/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+defaultmap = "0.5.0"
 swc_atoms = "0.3.0"
 swc_ecma_ast = "0.89.1"
 swc_ecma_parser = "0.116.0"
 swc_common = "0.26.0"
 swc_ecma_visit = "0.75.0"
 memoize = "0.3.0"
+crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
+crochet_infer = { version = "0.1.0", path = "../crochet_infer" }

--- a/crates/crochet_dts/src/lib.rs
+++ b/crates/crochet_dts/src/lib.rs
@@ -8,8 +8,13 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let dts = parse_dts(LIB_ES5_D_TS);
+        let dts = parse_dts(LIB_ES5_D_TS).unwrap();
 
-        println!("{dts:#?}");
+        for (name, interface) in dts.interfaces.iter() {
+            println!("{name}");
+            for (name, value) in interface {
+                println!("- {name}: {value}");
+            }
+        }
     }
 }

--- a/crates/crochet_dts/src/lib.rs
+++ b/crates/crochet_dts/src/lib.rs
@@ -10,11 +10,9 @@ mod tests {
     fn it_works() {
         let dts = parse_dts(LIB_ES5_D_TS).unwrap();
 
-        for (name, interface) in dts.interfaces.iter() {
-            println!("{name}");
-            for (name, value) in interface {
-                println!("- {name}: {value}");
-            }
+        for name in dts.interfaces.keys() {
+            let t = dts.get_interface(name);
+            println!("{name} = {t}")
         }
     }
 }

--- a/crates/crochet_dts/src/lib.rs
+++ b/crates/crochet_dts/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod parse_dts;
+
+#[cfg(test)]
+mod tests {
+    use crate::parse_dts::parse_dts;
+
+    static LIB_ES5_D_TS: &str = "../../node_modules/typescript/lib/lib.es5.d.ts";
+
+    #[test]
+    fn it_works() {
+        let dts = parse_dts(LIB_ES5_D_TS);
+
+        println!("{dts:#?}");
+    }
+}

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -1,18 +1,138 @@
-use std::collections::HashMap;
-use std::{path::Path, sync::Arc};
+use defaultmap::*;
 use memoize::memoize;
+use std::collections::{HashMap, HashSet};
+use std::{path::Path, sync::Arc};
 
-use swc_atoms::{js_word, JsWord};
-use swc_common::{BytePos, SourceMap};
+use swc_common::SourceMap;
 use swc_ecma_ast::*;
 use swc_ecma_parser::{error::Error, parse_file_as_module, Syntax, TsConfig};
 use swc_ecma_visit::*;
 
+// TODO: have crochet_infer re-export Lit
+use crochet_ast::{Lit, Primitive};
+use crochet_infer::{Context, Type};
+
+type Interface = HashMap<String, Type>;
+
 #[derive(Debug, Clone)]
 pub struct InterfaceCollector {
-    names: HashMap<BytePos, JsWord>,
-    current_interface: Option<JsWord>,
-    array_methods: Vec<JsWord>,
+    pub ctx: Context,
+    pub current_interface: Option<String>,
+    pub to_parse: HashSet<String>,
+    pub interfaces: DefaultHashMap<String, Interface>,
+}
+
+fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
+    match type_ann {
+        TsType::TsKeywordType(keyword) => match &keyword.kind {
+            TsKeywordTypeKind::TsAnyKeyword => ctx.fresh_var(),
+            TsKeywordTypeKind::TsUnknownKeyword => todo!(),
+            TsKeywordTypeKind::TsNumberKeyword => ctx.prim(Primitive::Num),
+            TsKeywordTypeKind::TsObjectKeyword => todo!(),
+            TsKeywordTypeKind::TsBooleanKeyword => ctx.prim(Primitive::Bool),
+            TsKeywordTypeKind::TsBigIntKeyword => todo!(),
+            TsKeywordTypeKind::TsStringKeyword => ctx.prim(Primitive::Str),
+            TsKeywordTypeKind::TsSymbolKeyword => todo!(),
+            TsKeywordTypeKind::TsVoidKeyword => todo!(),
+            TsKeywordTypeKind::TsUndefinedKeyword => ctx.prim(Primitive::Undefined),
+            TsKeywordTypeKind::TsNullKeyword => ctx.prim(Primitive::Null),
+            TsKeywordTypeKind::TsNeverKeyword => todo!(),
+            TsKeywordTypeKind::TsIntrinsicKeyword => todo!(),
+        },
+        TsType::TsThisType(_) => todo!(),
+        TsType::TsFnOrConstructorType(fn_or_constructor) => {
+            match &fn_or_constructor {
+                TsFnOrConstructorType::TsFnType(fn_type) => {
+                    let params: Vec<_> = fn_type
+                        .params
+                        .iter()
+                        .filter_map(|param| match param {
+                            TsFnParam::Ident(ident) => {
+                                let type_ann = ident.type_ann.clone().unwrap();
+                                Some(infer_ts_type_ann(&type_ann.type_ann, ctx))
+                            }
+                            TsFnParam::Array(_) => {
+                                println!("skipping TsFnParam::Array(_)");
+                                None
+                            }
+                            TsFnParam::Rest(rest) => {
+                                let type_ann = rest.type_ann.clone().unwrap();
+                                let t = infer_ts_type_ann(&type_ann.type_ann, ctx);
+                                Some(ctx.rest(t))
+                            }
+                            TsFnParam::Object(_) => {
+                                println!("skipping TsFnParam::Object(_)");
+                                None
+                            }
+                        })
+                        .collect();
+                    let ret = infer_ts_type_ann(&fn_type.type_ann.type_ann, ctx);
+                    ctx.lam(params, Box::from(ret))
+                },
+                TsFnOrConstructorType::TsConstructorType(_) => todo!(),
+            }
+        },
+        TsType::TsTypeRef(ref_type) => {
+            let name = match &ref_type.type_name {
+                TsEntityName::Ident(name) => name.sym.to_string(),
+                TsEntityName::TsQualifiedName(q_name) => {
+                    // TODO: handle qualified names properly
+                    let id = &q_name.as_ref().right;
+                    id.sym.to_string()
+                },
+            };
+            let type_params = ref_type.type_params.as_ref().map(|type_params| {
+                type_params
+                    .params
+                    .iter()
+                    .map(|t| infer_ts_type_ann(t, ctx))
+                    .collect()
+            });
+            ctx.alias(&name, type_params)
+        }
+        TsType::TsTypeQuery(_) => todo!(),
+        TsType::TsTypeLit(_) => todo!(),
+        TsType::TsArrayType(array) => {
+            let elem_type = infer_ts_type_ann(&array.elem_type, ctx);
+            ctx.array(elem_type)
+        }
+        TsType::TsTupleType(_) => todo!(),
+        TsType::TsOptionalType(_) => todo!(),
+        TsType::TsRestType(_) => todo!(),
+        TsType::TsUnionOrIntersectionType(union_or_intersection) => match union_or_intersection {
+            TsUnionOrIntersectionType::TsUnionType(union) => {
+                let types: Vec<_> = union
+                    .types
+                    .iter()
+                    .map(|ts_type| infer_ts_type_ann(ts_type, ctx))
+                    .collect();
+                ctx.union(types)
+            }
+            TsUnionOrIntersectionType::TsIntersectionType(intersection) => {
+                let types: Vec<_> = intersection
+                    .types
+                    .iter()
+                    .map(|ts_type| infer_ts_type_ann(ts_type, ctx))
+                    .collect();
+                ctx.intersection(types)
+            }
+        },
+        TsType::TsConditionalType(_) => todo!(),
+        TsType::TsInferType(_) => todo!(),
+        TsType::TsParenthesizedType(_) => todo!(),
+        TsType::TsTypeOperator(_) => todo!(),
+        TsType::TsIndexedAccessType(_) => todo!(),
+        TsType::TsMappedType(_) => todo!(),
+        TsType::TsLitType(lit) => match &lit.lit {
+            TsLit::Number(num) => ctx.lit(Lit::num(format!("{}", num.value), 0..0)),
+            TsLit::Str(str) => ctx.lit(Lit::str(str.value.to_string(), 0..0)),
+            TsLit::Bool(b) => ctx.lit(Lit::bool(b.value, 0..0)),
+            TsLit::BigInt(_) => todo!(),
+            TsLit::Tpl(_) => todo!(),
+        },
+        TsType::TsTypePredicate(_) => todo!(),
+        TsType::TsImportType(_) => todo!(),
+    }
 }
 
 impl Visit for InterfaceCollector {
@@ -24,59 +144,85 @@ impl Visit for InterfaceCollector {
     // }
 
     fn visit_ts_interface_decl(&mut self, decl: &TsInterfaceDecl) {
-        self.names.insert(decl.id.span.lo, decl.id.sym.clone());
-        self.current_interface = Some(decl.id.sym.clone());
+        self.current_interface = Some(decl.id.sym.to_string());
         decl.visit_children_with(self);
         self.current_interface = None;
     }
 
     fn visit_ts_type_element(&mut self, elem: &TsTypeElement) {
-        if let Some(word) = &self.current_interface {
-            if word == &js_word!("Array") {
-                match elem {
-                    TsTypeElement::TsCallSignatureDecl(_decl) => {}
-                    TsTypeElement::TsConstructSignatureDecl(_decl) => {}
-                    TsTypeElement::TsPropertySignature(_sig) => {}
-                    TsTypeElement::TsGetterSignature(_sig) => {}
-                    TsTypeElement::TsSetterSignature(_sig) => {}
-                    TsTypeElement::TsMethodSignature(sig) => {
-                        if sig.computed {
-                            panic!("unexpected computed property in TypElement")
-                        }
-                        if let Expr::Ident(Ident {sym, ..}) = sig.key.as_ref() {
-                            self.array_methods.push(sym.clone())
-                        };
-                        println!("key: {:#?}", sig.key.as_ref());
-                        // TODO: convert sig.params to crochet type
-                        for param in &sig.params {
-                            match param {
-                                TsFnParam::Ident(ident) => {
-                                    let word = &ident.id.sym;
-                                    let type_ann = ident.type_ann.clone().unwrap();
-                                    println!("{word}: {:?}", type_ann);
-                                },
-                                TsFnParam::Array(_) => todo!(),
-                                TsFnParam::Rest(_) => todo!(),
-                                TsFnParam::Object(_) => todo!(),
-                            }
-                        }
-                    }
-                    TsTypeElement::TsIndexSignature(_sig) => {}
+        let name = if let Some(name) = &self.current_interface {
+            if !self.to_parse.contains(name) {
+                return;
+            } else {
+                name.clone()
+            }
+        } else {
+            // This can happen when visiting types like Awaited<T>
+            // that aren't interfaces
+            return;
+        };
+        match elem {
+            TsTypeElement::TsCallSignatureDecl(_decl) => {}
+            TsTypeElement::TsConstructSignatureDecl(_decl) => {}
+            TsTypeElement::TsPropertySignature(_sig) => {}
+            TsTypeElement::TsGetterSignature(_sig) => {}
+            TsTypeElement::TsSetterSignature(_sig) => {}
+            TsTypeElement::TsMethodSignature(sig) => {
+                let t = self.infer_method_sig(sig);
+                if let Expr::Ident(Ident { sym, .. }) = sig.key.as_ref() {
+                    self.interfaces[name].insert(sym.to_string(), t);
                 }
             }
+            TsTypeElement::TsIndexSignature(_sig) => {}
         }
+    }
+}
+
+impl InterfaceCollector {
+    fn infer_method_sig(&mut self, sig: &TsMethodSignature) -> Type {
+        if sig.computed {
+            panic!("unexpected computed property in TypElement")
+        }
+
+        let params: Vec<_> = sig
+            .params
+            .iter()
+            .filter_map(|param| match param {
+                TsFnParam::Ident(ident) => {
+                    let type_ann = ident.type_ann.clone().unwrap();
+                    Some(infer_ts_type_ann(&type_ann.type_ann, &self.ctx))
+                }
+                TsFnParam::Array(_) => {
+                    println!("skipping TsFnParam::Array(_)");
+                    None
+                }
+                TsFnParam::Rest(rest) => {
+                    let type_ann = rest.type_ann.clone().unwrap();
+                    let t = infer_ts_type_ann(&type_ann.type_ann, &self.ctx);
+                    Some(self.ctx.rest(t))
+                }
+                TsFnParam::Object(_) => {
+                    println!("skipping TsFnParam::Object(_)");
+                    None
+                }
+            })
+            .collect();
+        let ret = match &sig.type_ann {
+            Some(type_ann) => infer_ts_type_ann(&type_ann.type_ann, &self.ctx),
+            None => panic!("method has no return type"),
+        };
+        // TODO: maintain param names
+        self.ctx.lam(params, Box::from(ret))
     }
 }
 
 #[memoize]
 pub fn parse_dts(dts: &'static str) -> Result<InterfaceCollector, Error> {
     let cm = Arc::<SourceMap>::default();
-     let fm = cm
-         .load_file(Path::new(dts))
-         .expect("failed to load file");
+    let fm = cm.load_file(Path::new(dts)).expect("failed to load file");
 
     let mut errors: Vec<Error> = vec![];
-    
+
     let module = parse_file_as_module(
         &fm,
         Syntax::Typescript(TsConfig {
@@ -90,10 +236,13 @@ pub fn parse_dts(dts: &'static str) -> Result<InterfaceCollector, Error> {
         &mut errors,
     )?;
 
+    // TODO: add more items from lib.es5.d.ts
+    let to_parse = HashSet::from([String::from("Math"), String::from("String")]);
     let mut collector = InterfaceCollector {
-        names: Default::default(),
+        ctx: Context::default(),
         current_interface: None,
-        array_methods: vec![],
+        to_parse,
+        interfaces: defaulthashmap!(),
     };
     module.visit_with(&mut collector);
 

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+use std::{path::Path, sync::Arc};
+use memoize::memoize;
+
+use swc_atoms::{js_word, JsWord};
+use swc_common::{BytePos, SourceMap};
+use swc_ecma_ast::*;
+use swc_ecma_parser::{error::Error, parse_file_as_module, Syntax, TsConfig};
+use swc_ecma_visit::*;
+
+#[derive(Debug, Clone)]
+pub struct InterfaceCollector {
+    names: HashMap<BytePos, JsWord>,
+    current_interface: Option<JsWord>,
+    array_methods: Vec<JsWord>,
+}
+
+impl Visit for InterfaceCollector {
+    // call this if we don't want to visit TypeScript type nodes
+    // noop_visit_type!();
+
+    // fn visit_ident(&mut self, ident: &Ident) {
+    //     self.names.insert(ident.span.lo, ident.sym.clone());
+    // }
+
+    fn visit_ts_interface_decl(&mut self, decl: &TsInterfaceDecl) {
+        self.names.insert(decl.id.span.lo, decl.id.sym.clone());
+        self.current_interface = Some(decl.id.sym.clone());
+        decl.visit_children_with(self);
+        self.current_interface = None;
+    }
+
+    fn visit_ts_type_element(&mut self, elem: &TsTypeElement) {
+        if let Some(word) = &self.current_interface {
+            if word == &js_word!("Array") {
+                match elem {
+                    TsTypeElement::TsCallSignatureDecl(_decl) => {}
+                    TsTypeElement::TsConstructSignatureDecl(_decl) => {}
+                    TsTypeElement::TsPropertySignature(_sig) => {}
+                    TsTypeElement::TsGetterSignature(_sig) => {}
+                    TsTypeElement::TsSetterSignature(_sig) => {}
+                    TsTypeElement::TsMethodSignature(sig) => {
+                        if sig.computed {
+                            panic!("unexpected computed property in TypElement")
+                        }
+                        if let Expr::Ident(Ident {sym, ..}) = sig.key.as_ref() {
+                            self.array_methods.push(sym.clone())
+                        };
+                        println!("key: {:#?}", sig.key.as_ref());
+                        // TODO: convert sig.params to crochet type
+                        for param in &sig.params {
+                            match param {
+                                TsFnParam::Ident(ident) => {
+                                    let word = &ident.id.sym;
+                                    let type_ann = ident.type_ann.clone().unwrap();
+                                    println!("{word}: {:?}", type_ann);
+                                },
+                                TsFnParam::Array(_) => todo!(),
+                                TsFnParam::Rest(_) => todo!(),
+                                TsFnParam::Object(_) => todo!(),
+                            }
+                        }
+                    }
+                    TsTypeElement::TsIndexSignature(_sig) => {}
+                }
+            }
+        }
+    }
+}
+
+#[memoize]
+pub fn parse_dts(dts: &'static str) -> Result<InterfaceCollector, Error> {
+    let cm = Arc::<SourceMap>::default();
+     let fm = cm
+         .load_file(Path::new(dts))
+         .expect("failed to load file");
+
+    let mut errors: Vec<Error> = vec![];
+    
+    let module = parse_file_as_module(
+        &fm,
+        Syntax::Typescript(TsConfig {
+            tsx: false,
+            dts: true,
+            decorators: false,
+            no_early_errors: false,
+        }),
+        EsVersion::Es2020,
+        None, // comments
+        &mut errors,
+    )?;
+
+    let mut collector = InterfaceCollector {
+        names: Default::default(),
+        current_interface: None,
+        array_methods: vec![],
+    };
+    module.visit_with(&mut collector);
+
+    Ok(collector)
+}

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -246,5 +246,7 @@ pub fn parse_dts(dts: &'static str) -> Result<InterfaceCollector, Error> {
     };
     module.visit_with(&mut collector);
 
+    // TODO: convert each interface into an object type
+
     Ok(collector)
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -138,6 +138,7 @@ impl Context {
         TProp {
             name: name.to_owned(),
             optional,
+            mutable: false,
             ty,
         }
     }

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -16,6 +16,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
     let promise_scheme = Scheme::from(ctx.object(vec![TProp {
         name: String::from("_name"),
         optional: false,
+        mutable: false,
         ty: ctx.lit(Lit::str(String::from("Promise"), 0..0)),
     }]));
     ctx.types.insert(String::from("Promise"), promise_scheme);
@@ -25,6 +26,7 @@ pub fn infer_prog(prog: &Program) -> Result<Context, String> {
     let jsx_element_scheme = Scheme::from(ctx.object(vec![TProp {
         name: String::from("_name"),
         optional: false,
+        mutable: false,
         ty: ctx.lit(Lit::str(String::from("JSXElement"), 0..0)),
     }]));
     ctx.types

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -156,6 +156,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                                     let prop = types::TProp {
                                         name: attr.ident.name.to_owned(),
                                         optional: false,
+                                        mutable: false,
                                         ty: t,
                                     };
                                     props.push(prop);

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -136,6 +136,7 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
                             Some(types::TProp {
                                 name: key.name.to_owned(),
                                 optional: false,
+                                mutable: false,
                                 ty: value_type,
                             })
                         }
@@ -153,6 +154,7 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
                             Some(types::TProp {
                                 name: key.name.to_owned(),
                                 optional: false,
+                                mutable: false,
                                 ty: tv,
                             })
                         }

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -91,6 +91,7 @@ fn infer_type_ann_rec(
                 .map(|prop| TProp {
                     name: prop.name.to_owned(),
                     optional: prop.optional,
+                    mutable: prop.mutable,
                     ty: infer_type_ann_rec(prop.type_ann.as_ref(), ctx, type_param_map),
                 })
                 .collect();

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -11,6 +11,7 @@ pub mod types;
 
 pub use context::*;
 pub use infer::*;
+pub use types::{Lit, Type};
 
 #[cfg(test)]
 mod tests {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -11,7 +11,7 @@ pub mod types;
 
 pub use context::*;
 pub use infer::*;
-pub use types::{Lit, Type};
+pub use types::{Lit, Type, TProp};
 
 #[cfg(test)]
 mod tests {

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -9,6 +9,7 @@ use crate::types::{Lit, Primitive};
 pub struct TProp {
     pub name: String,
     pub optional: bool,
+    pub mutable: bool,
     pub ty: Type,
 }
 
@@ -23,10 +24,12 @@ impl TProp {
 
 impl fmt::Display for TProp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Self { name, optional, ty } = self;
-        match optional {
-            false => write!(f, "{name}: {ty}"),
-            true => write!(f, "{name}?: {ty}"),
+        let Self { name, optional, mutable, ty } = self;
+        match (optional, mutable) {
+            (false, false) => write!(f, "{name}: {ty}"),
+            (true, false) => write!(f, "{name}?: {ty}"),
+            (false, true) => write!(f, "mut {name}: {ty}"),
+            (true, true) => write!(f, "mut {name}?: {ty}"),
         }
     }
 }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -429,17 +429,20 @@ mod tests {
             types::TProp {
                 name: String::from("foo"),
                 optional: false,
+                mutable: false,
                 ty: ctx.lit(num("5")),
             },
             types::TProp {
                 name: String::from("bar"),
                 optional: false,
+                mutable: false,
                 ty: ctx.lit(bool(&true)),
             },
             // Having extra properties is okay
             types::TProp {
                 name: String::from("baz"),
                 optional: false,
+                mutable: false,
                 ty: ctx.prim(Primitive::Str),
             },
         ]);
@@ -448,11 +451,13 @@ mod tests {
             types::TProp {
                 name: String::from("foo"),
                 optional: false,
+                mutable: false,
                 ty: ctx.prim(Primitive::Num),
             },
             types::TProp {
                 name: String::from("bar"),
                 optional: true,
+                mutable: false,
                 ty: ctx.prim(Primitive::Bool),
             },
             // It's okay for qux to not appear in the subtype since
@@ -460,6 +465,7 @@ mod tests {
             types::TProp {
                 name: String::from("qux"),
                 optional: true,
+                mutable: false,
                 ty: ctx.prim(Primitive::Str),
             },
         ]);

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -67,6 +67,7 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     .map(|prop| TProp {
                         name: prop.name.clone(),
                         optional: prop.optional,
+                        mutable: prop.mutable,
                         // NOTE: we don't use prop.get_type(ctx) here because we're tracking
                         // the optionality of the property in the TProp that's returned.
                         ty: norm_type(&prop.ty, mapping, ctx),
@@ -170,6 +171,7 @@ pub fn simplify_intersection(in_types: &[Type], ctx: &Context) -> Type {
                 // the same name.  This should only be optional if all of
                 // the TProps with the current name are optional.
                 optional: false,
+                mutable: false,
                 ty,
             }
         })

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
@@ -56,6 +56,7 @@ Program {
                                                         span: 20..29,
                                                         name: "a",
                                                         optional: false,
+                                                        mutable: false,
                                                         type_ann: Prim(
                                                             PrimType {
                                                                 span: 23..29,
@@ -67,6 +68,7 @@ Program {
                                                         span: 31..40,
                                                         name: "b",
                                                         optional: false,
+                                                        mutable: false,
                                                         type_ann: Prim(
                                                             PrimType {
                                                                 span: 34..40,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-2.snap
@@ -19,6 +19,7 @@ Program {
                             span: 14..23,
                             name: "x",
                             optional: false,
+                            mutable: false,
                             type_ann: Prim(
                                 PrimType {
                                     span: 17..23,
@@ -30,6 +31,7 @@ Program {
                             span: 25..34,
                             name: "y",
                             optional: false,
+                            mutable: false,
                             type_ann: Prim(
                                 PrimType {
                                     span: 28..34,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-3.snap
@@ -19,6 +19,7 @@ Program {
                             span: 15..21,
                             name: "bar",
                             optional: false,
+                            mutable: false,
                             type_ann: TypeRef(
                                 TypeRef {
                                     span: 20..21,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-4.snap
@@ -19,6 +19,7 @@ Program {
                             span: 30..36,
                             name: "bar",
                             optional: false,
+                            mutable: false,
                             type_ann: TypeRef(
                                 TypeRef {
                                     span: 35..36,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-5.snap
@@ -19,6 +19,7 @@ Program {
                             span: 23..29,
                             name: "bar",
                             optional: false,
+                            mutable: false,
                             type_ann: TypeRef(
                                 TypeRef {
                                     span: 28..29,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-6.snap
@@ -19,6 +19,7 @@ Program {
                             span: 38..44,
                             name: "bar",
                             optional: false,
+                            mutable: false,
                             type_ann: TypeRef(
                                 TypeRef {
                                     span: 43..44,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__misc_type_annotations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__type_ann__tests__misc_type_annotations-2.snap
@@ -10,6 +10,7 @@ Object(
                 span: 1..10,
                 name: "x",
                 optional: false,
+                mutable: false,
                 type_ann: Prim(
                     PrimType {
                         span: 4..10,
@@ -21,6 +22,7 @@ Object(
                 span: 12..21,
                 name: "y",
                 optional: false,
+                mutable: false,
                 type_ann: Prim(
                     PrimType {
                         span: 15..21,

--- a/crates/crochet_parser/src/type_ann.rs
+++ b/crates/crochet_parser/src/type_ann.rs
@@ -44,6 +44,9 @@ pub fn type_ann_parser() -> BoxedParser<'static, char, TypeAnn, Simple<char>> {
                 span,
                 name,
                 optional: optional.is_some(),
+                // TODO: properties are immutable by default, add a `mut` keyword
+                // to make them mutable
+                mutable: false,
                 type_ann: Box::from(type_ann),
             });
 


### PR DESCRIPTION
This PR makes the following changes:
- updates swc_* dependencies
- adds `mutable` field to `TProp`
- parses properties and methods on some interfaces from lib.es5.d.ts (String, Number, Boolean, etc.)

I'll continue filling in the gaps in future PRs.