### PR TITLE
Fix crochet_dts test coverage reporting

### DIFF
--- a/crates/crochet_ast/src/lib.rs
+++ b/crates/crochet_ast/src/lib.rs
@@ -15,12 +15,3 @@ pub use pattern::*;
 pub use span::*;
 pub use types::*;
 pub use prim::*;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/crates/crochet_dts/src/lib.rs
+++ b/crates/crochet_dts/src/lib.rs
@@ -7,7 +7,7 @@ mod tests {
     static LIB_ES5_D_TS: &str = "../../node_modules/typescript/lib/lib.es5.d.ts";
 
     #[test]
-    fn it_works() {
+    fn parsing_lib_es5_d_ts() {
         let dts = parse_dts(LIB_ES5_D_TS).unwrap();
 
         for name in dts.interfaces.keys() {


### PR DESCRIPTION
Two tests had the same name so tarpaulin was only reporting coverage from one of those test case.