### PR TITLE
Connect parse_dts() to infer_prog()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,12 @@ dependencies = [
 name = "crochet_dts"
 version = "0.1.0"
 dependencies = [
+ "chumsky",
  "crochet_ast",
  "crochet_infer",
+ "crochet_parser",
  "defaultmap",
+ "insta",
  "memoize",
  "swc_atoms",
  "swc_common",

--- a/crates/crochet/src/lib.rs
+++ b/crates/crochet/src/lib.rs
@@ -29,7 +29,8 @@ pub fn compile(input: &str) -> Result<CompileResult, String> {
     let js = crochet_codegen::js::codegen_js(&program);
 
     // TODO: return errors as part of CompileResult
-    let ctx = infer_prog(&program)?;
+    let mut ctx: Context = Context::default();
+    let ctx = infer_prog(&program, &mut ctx)?;
     let dts = crochet_codegen::d_ts::codegen_d_ts(&program, &ctx);
 
     Ok(CompileResult { js, dts })

--- a/crates/crochet/tests/fixture_test.rs
+++ b/crates/crochet/tests/fixture_test.rs
@@ -44,7 +44,8 @@ fn pass(in_path: PathBuf) {
         }
     }
 
-    let ctx = infer_prog(&program).unwrap();
+    let mut ctx = crochet_infer::Context::default();
+    let ctx = infer_prog(&program, &mut ctx).unwrap();
     let d_ts_output = codegen_d_ts(&program, &ctx);
     match mode {
         Mode::Check => {

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -26,8 +26,8 @@ fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
         }
     };
     // println!("prog = {:#?}", &prog);
-    // let prog = token_parser(&spans).parse(tokens).unwrap();
-    let ctx = crochet_infer::infer_prog(&prog).unwrap();
+    let mut ctx = crochet_infer::Context::default();
+    let ctx = crochet_infer::infer_prog(&prog, &mut ctx).unwrap();
 
     (prog, ctx)
 }

--- a/crates/crochet_dts/Cargo.toml
+++ b/crates/crochet_dts/Cargo.toml
@@ -15,3 +15,8 @@ swc_ecma_visit = "0.75.0"
 memoize = "0.3.0"
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 crochet_infer = { version = "0.1.0", path = "../crochet_infer" }
+
+[dev-dependencies]
+chumsky = "0.8.0"
+insta = "1.13.0"
+crochet_parser = { version = "0.1.0", path = "../crochet_parser" }

--- a/crates/crochet_dts/src/lib.rs
+++ b/crates/crochet_dts/src/lib.rs
@@ -8,11 +8,10 @@ mod tests {
 
     #[test]
     fn parsing_lib_es5_d_ts() {
-        let dts = parse_dts(LIB_ES5_D_TS).unwrap();
+        let ctx = parse_dts(LIB_ES5_D_TS).unwrap();
 
-        for name in dts.interfaces.keys() {
-            let t = dts.get_interface(name);
-            println!("{name} = {t}")
+        for (name, scheme) in ctx.types {
+            println!("{name} = {scheme}")
         }
     }
 }

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -1,7 +1,6 @@
 use chumsky::prelude::*;
 
 use crochet_ast::Program;
-use crochet_infer::*;
 use crochet_parser::parser;
 
 use crochet_dts::parse_dts::*;
@@ -9,13 +8,7 @@ use crochet_dts::parse_dts::*;
 static LIB_ES5_D_TS: &str = "../../node_modules/typescript/lib/lib.es5.d.ts";
 
 fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
-    let dts = parse_dts(LIB_ES5_D_TS).unwrap();
-    let mut ctx = Context::default();
-
-    for name in dts.interfaces.keys() {
-        let t = dts.get_interface(name);
-        ctx.types.insert(name.to_owned(), types::Scheme::from(t));
-    }
+    let mut ctx = parse_dts(LIB_ES5_D_TS).unwrap();
 
     let result = parser().parse(src);
     let prog = match result {

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -1,0 +1,42 @@
+use chumsky::prelude::*;
+
+use crochet_ast::Program;
+use crochet_infer::*;
+use crochet_parser::parser;
+
+use crochet_dts::parse_dts::*;
+
+static LIB_ES5_D_TS: &str = "../../node_modules/typescript/lib/lib.es5.d.ts";
+
+fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
+    let dts = parse_dts(LIB_ES5_D_TS).unwrap();
+    let mut ctx = Context::default();
+
+    for name in dts.interfaces.keys() {
+        let t = dts.get_interface(name);
+        ctx.types.insert(name.to_owned(), types::Scheme::from(t));
+    }
+
+    let result = parser().parse(src);
+    let prog = match result {
+        Ok(prog) => prog,
+        Err(err) => {
+            println!("err = {:?}", err);
+            panic!("Error parsing expression");
+        }
+    };
+    let ctx = crochet_infer::infer_prog(&prog, &mut ctx).unwrap();
+
+    (prog, ctx)
+}
+
+#[test]
+fn infer_adding_variables() {
+    let src = r#"
+    let msg = "Hello, world!"
+    let len = msg.length.toString(10) // radix is required b/c we don't support optional params yet
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let result = format!("{}", ctx.values.get("len").unwrap());
+    assert_eq!(result, "string");
+}

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -501,7 +501,45 @@ fn infer_property_type(
             let t = lookup_alias(ctx, alias)?;
             infer_property_type(&t, prop, ctx)
         }
-        _ => todo!("Unhandled {obj_t} in infer_property_type"),
+        Variant::Lit(lit) => {
+            match lit {
+                crate::Lit::Num(_) => {
+                    let t = ctx.lookup_type("Number")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                crate::Lit::Bool(_) => {
+                    let t = ctx.lookup_type("Boolean")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                crate::Lit::Str(_) => {
+                    let t = ctx.lookup_type("String")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                crate::Lit::Null => todo!(),
+                crate::Lit::Undefined => todo!(),
+            }
+        }
+        Variant::Prim(prim) => {
+            match prim {
+                Primitive::Num => {
+                    let t = ctx.lookup_type("Number")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                Primitive::Bool => {
+                    let t = ctx.lookup_type("Boolean")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                Primitive::Str => {
+                    let t = ctx.lookup_type("String")?;
+                    infer_property_type(&t, prop, ctx)
+                },
+                Primitive::Undefined => todo!(),
+                Primitive::Null => todo!(),
+            }
+        }
+        _ => {
+            todo!("Unhandled {obj_t:#?} in infer_property_type")
+        },
     }
 }
 

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -30,7 +30,8 @@ mod tests {
 
     fn infer_prog(input: &str) -> Context {
         let prog = parser().parse(input).unwrap();
-        infer::infer_prog(&prog).unwrap()
+        let mut ctx: Context = Context::default();
+        infer::infer_prog(&prog, &mut ctx).unwrap()
     }
 
     fn get_type(name: &str, ctx: &Context) -> String {


### PR DESCRIPTION
`parse_dts` returns a Context and `infer_prog()` now takes a Context as parameter instead of creating its own.