### PR TITLE
Rework partial application to use placeholders

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -414,5 +414,6 @@ pub fn build_type(
         }),
         Variant::Rest(_) => todo!(),
         Variant::Member(_) => todo!(),
+        Variant::Placeholder(_) => todo!(),
     }
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -183,6 +183,13 @@ impl Context {
             }),
         }
     }
+
+    pub fn placeholder(&self) -> Type {
+        Type {
+            id: self.fresh_id(),
+            variant: Variant::Placeholder(false),
+        }
+    }
 }
 
 pub fn lookup_alias(ctx: &Context, alias: &AliasType) -> Result<Type, String> {
@@ -197,17 +204,18 @@ pub fn lookup_alias(ctx: &Context, alias: &AliasType) -> Result<Type, String> {
                         return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
                     }
                     ids.zip(type_params.iter().cloned()).collect()
-                },
+                }
                 None => {
                     if !scheme.qualifiers.is_empty() {
                         return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
                     }
-                    ids.zip(scheme.qualifiers.iter().map(|_| ctx.fresh_var())).collect()
-                },
+                    ids.zip(scheme.qualifiers.iter().map(|_| ctx.fresh_var()))
+                        .collect()
+                }
             };
 
             Ok(scheme.ty.apply(&subs))
-        },
+        }
         None => Err(String::from("Can't find alias '{name}' in context")),
     }
 }

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -62,7 +62,11 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
         }
         Expr::Ident(Ident { name, .. }) => {
             let s = Subst::default();
-            let t = ctx.lookup_value(name)?;
+            let t = if name == "_" { 
+                ctx.placeholder()
+            } else { 
+                ctx.lookup_value(name)?
+            };
             Ok((s, t))
         }
         Expr::IfElse(IfElse {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1205,6 +1205,18 @@ mod tests {
     }
 
     #[test]
+    fn partial_application_with_placeholder_rest() {
+        let src = r#"
+        declare let add: (a: number, b: number, c: number) => number
+        let add5 = add(5, ..._)
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("add5", &ctx), "(number, number) => number");
+    }
+
+    #[test]
     fn spread_multiple_param_tuples() {
         let src = r#"
         declare let add: (a: number, b: number) => number

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1010,39 +1010,86 @@ mod tests {
     }
 
     #[test]
-    fn call_lam_with_too_few_params_result_in_partial_application() {
+    #[should_panic = "Not enough params provided"]
+    fn call_lam_with_too_few_params() {
         let src = r#"
         declare let add: (a: number, b: number) => number
-        let add5 = add(5)
+        let sum = add(5)
         "#;
 
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("add5", &ctx), "(number) => number");
+        infer_prog(src);
     }
 
     #[test]
-    fn call_lam_with_too_few_params_result_in_partial_application_no_params() {
+    fn call_partially_applied_fn_immediately() {
         let src = r#"
         declare let add: (a: number, b: number) => number
-        let plus = add()
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("plus", &ctx), "(number, number) => number");
-    }
-
-    #[test]
-    fn call_lam_multiple_times_with_too_few_params() {
-        let src = r#"
-        declare let add: (a: number, b: number) => number
-        let sum = add(5)(10)
+        let sum = add(5, _)(10)
         "#;
 
         let ctx = infer_prog(src);
 
         assert_eq!(get_type("sum", &ctx), "number");
+    }
+
+    #[test]
+    fn partially_apply_first_param() {
+        let src = r#"
+        declare let foo: (a: number, b: string) => bool
+        let foo_num = foo(5, _)
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("foo_num", &ctx), "(string) => bool");
+    }
+
+    #[test]
+    fn partially_apply_second_param() {
+        let src = r#"
+        declare let foo: (a: number, b: string) => bool
+        let foo_str = foo(_, "hello")
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("foo_str", &ctx), "(number) => bool");
+    }
+
+    #[test]
+    fn partially_apply_multiple_params() {
+        let src = r#"
+        declare let foo: (a: number, b: string, c: bool) => undefined
+        let foo_bool = foo(5, "hello", _)
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("foo_bool", &ctx), "(bool) => undefined");
+    }
+
+    #[test]
+    fn multiple_placeholders() {
+        let src = r#"
+        declare let foo: (a: number, b: string, c: bool) => undefined
+        let foo_num_bool = foo(_, "hello", _)
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("foo_num_bool", &ctx), "(number, bool) => undefined");
+    }
+
+    #[test]
+    fn all_multiple_placeholders() {
+        let src = r#"
+        declare let foo: (a: number, b: string, c: bool) => undefined
+        let foo_num_str_bool = foo(_, _, _)
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type("foo_num_str_bool", &ctx), "(number, string, bool) => undefined");
     }
 
     #[test]
@@ -1143,16 +1190,18 @@ mod tests {
     }
 
     #[test]
-    fn spread_param_tuple_with_not_enough_elements_is_partial_application() {
+    fn spread_param_tuple_with_not_enough_elements_and_placeholder_is_partial_application() {
         let src = r#"
         declare let add: (a: number, b: number) => number
         let args = [5]
-        let result = add(...args)
+        let result1 = add(...args, _)
+        let result2 = add(_, ...args)
         "#;
 
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("result", &ctx), "(number) => number");
+        assert_eq!(get_type("result1", &ctx), "(number) => number");
+        assert_eq!(get_type("result2", &ctx), "(number) => number");
     }
 
     #[test]

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -24,6 +24,7 @@ impl Substitutable for Type {
                         params: lam.params.iter().map(|param| param.apply(sub)).collect(),
                         ret: Box::from(lam.ret.apply(sub)),
                     }),
+                    Variant::Placeholder(_) => self.variant.to_owned(),
                     Variant::Prim(_) => self.variant.to_owned(),
                     Variant::Lit(_) => self.variant.to_owned(),
                     Variant::Union(types) => Variant::Union(types.apply(sub)),
@@ -57,6 +58,7 @@ impl Substitutable for Type {
                 result.extend(ret.ftv());
                 result
             }
+            Variant::Placeholder(_) => HashSet::new(),
             Variant::Prim(_) => HashSet::new(),
             Variant::Lit(_) => HashSet::new(),
             Variant::Union(types) => types.ftv(),

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -53,7 +53,7 @@ impl Hash for VarType {
 
 #[derive(Clone, Debug, Eq)]
 pub struct LamType {
-    pub params: Vec<Type>, // TOOD: rename this params
+    pub params: Vec<Type>,
     pub ret: Box<Type>,
     pub is_call: bool,
 }
@@ -113,6 +113,9 @@ impl Hash for MemberType {
 pub enum Variant {
     Var,
     Lam(LamType),
+    // TODO: we may want to have different types of placeholders in the future,
+    // e.g. typed holes vs. placeholder args
+    Placeholder(bool),
     Prim(Primitive),
     Lit(Lit),
     Union(Vec<Type>),
@@ -159,6 +162,12 @@ impl fmt::Display for Type {
             }
             Variant::Lam(LamType { params, ret, .. }) => {
                 write!(f, "({}) => {}", join(params, ", "), ret)
+            }
+            Variant::Placeholder(spread) => {
+                match spread {
+                    true => write!(f, "..._"),
+                    false => write!(f, "_"),
+                }
             }
             Variant::Prim(prim) => write!(f, "{}", prim),
             Variant::Lit(lit) => write!(f, "{}", lit),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -24,22 +24,17 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         (Variant::Lam(lam1), Variant::Lam(lam2)) => {
             // NOTE: Any extra args (lam1.params) are ignored.
 
+            // TODO: work out how rest and spread should work together.
+            // args: (a1, a2, a_spread[0 to n]) -> 2 to 2 + n
+            // params: (p1, p2, p3, p_rest[0 to n]) -> 3 to 3 + n
+            // this means that a_spread must have a length of at least 1 in order 
+            // for the lower bounds to match.
+
             let mut s = Subst::new();
             // If `lam1` is a function call then we treat it differently.  Instead
-            // of checking if it's a subtype of `lam2`, we instead either:
+            // of checking if it's a subtype of `lam2`, we instead determine the types
+            // of all of its args and then try to unify those with the params.
             if lam1.is_call {
-                let mut params_1: Vec<Type> = vec![];
-                for param in &lam1.params {
-                    match &param.variant {
-                        Variant::Rest(rest) => {
-                            match &rest.as_ref().variant {
-                                Variant::Tuple(types) => params_1.extend(types.to_owned()),
-                                _ => return Err(format!("spread of type {rest} not allowed")),
-                            }
-                        },
-                        _ => params_1.push(param.to_owned())
-                    }
-                }
                 let last_param_2 = lam2.params.last();
                 let maybe_rest_param = if let Some(param) = last_param_2 {
                     match &param.variant {
@@ -50,14 +45,42 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     None
                 };
 
+                let param_count_low_bound = match maybe_rest_param {
+                    Some(_) => lam2.params.len() - 1,
+                    None => lam2.params.len()
+                };
+
+                // NOTE: placeholder spreads must come last because we don't know they're
+                // length.  This will also be true for spreading arrays, but in the case
+                // of array spreads, they also need to come after the start of a rest param.
+
+                let mut args: Vec<Type> = vec![];
+                for (i, arg) in lam1.params.iter().enumerate() {
+                    let is_last = i == lam1.params.len() - 1;
+                    match &arg.variant {
+                        Variant::Rest(spread) => {
+                            match &spread.as_ref().variant {
+                                Variant::Placeholder(_) => {
+                                    if is_last {
+                                        let spread_count = param_count_low_bound - args.len();
+                                        for _ in 0..spread_count {
+                                            args.push(ctx.placeholder());
+                                        }
+                                    } else {
+                                        return Err(String::from("Placeholder spread must appear last"));
+                                    }
+                                }
+                                Variant::Tuple(types) => args.extend(types.to_owned()),
+                                _ => return Err(format!("spread of type {spread} not allowed")),
+                            }
+                        },
+                        _ => args.push(arg.to_owned())
+                    }
+                }
+
                 // TODO: add a `variadic` boolean to the Lambda type as a convenience
                 // so that we don't have to search through all the params for the rest
                 // param.
-
-                // TODO: handle placeholder rest params, e.g.
-                // let add = (a, b, c) => a + b + c;
-                // let add5 = add(5, ..._); // (number, number) => number
-                // NOTE: eventually we'd like to use '...' instead of '..._' for "placeholder rest"
                 if let Some(rest_param) = maybe_rest_param {
                     let regular_param_count = lam2.params.len() - 1;
                     
@@ -84,21 +107,17 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     let s2 = unify(&lam1.ret.apply(&s), &lam2.ret.apply(&s), ctx)?;
 
                     Ok(compose_subs(&s2, &s1))
-                } else if params_1.len() < lam2.params.len() {
+                } else if args.len() < lam2.params.len() {
                     Err(String::from("Not enough params provided"))
                 } else {
-                    // TODO:
-                    // - if any of the args are placeholders then we need to partial
-                    //   application here
-                    // TODO: rename `params_1` to `args`
-                    let partial = params_1.iter().any(|param| {
+                    let partial = args.iter().any(|param| {
                         matches!(param.variant, Variant::Placeholder(_))
                     });
 
                     if partial {
                         // Partial Application
                         let mut partial_params: Vec<Type> = vec![];
-                        for (arg, param) in params_1.iter().zip(&lam2.params) {
+                        for (arg, param) in args.iter().zip(&lam2.params) {
                             match arg.variant {
                                 Variant::Placeholder(_) => {
                                     partial_params.push(param.to_owned());
@@ -118,7 +137,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         Ok(compose_subs(&s, &s1))
                     } else {
                         // Regular Application
-                        for (p1, p2) in params_1.iter().zip(&lam2.params) {
+                        for (p1, p2) in args.iter().zip(&lam2.params) {
                             // Each argument must be a subtype of the corresponding param.
                             let arg = p1.apply(&s);
                             let param = p2.apply(&s);
@@ -133,6 +152,8 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 // If `lam1` isn't being applied then it's okay if has fewer params
                 // than `lam2`.  This is because functions can be passed extra params
                 // meaning that any place `lam2` is used, `lam1` can be used as well.
+                //
+                // TODO: figure what this means for lambdas with rest params.
                 for (p1, p2) in lam1.params.iter().zip(&lam2.params) {
                     // NOTE: The order of params is reverse.  This allows a callback
                     // whose params can accept more values (are supertypes) than the

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -44,6 +44,7 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     ..ty.to_owned()
                 }
             }
+            Variant::Placeholder(_) => ty.to_owned(),
             Variant::Prim(_) => ty.to_owned(),
             Variant::Lit(_) => ty.to_owned(),
             Variant::Union(types) => {

--- a/crates/crochet_parser/src/pattern.rs
+++ b/crates/crochet_parser/src/pattern.rs
@@ -34,7 +34,6 @@ pub fn pattern_parser() -> BoxedParser<'static, char, Pattern, Simple<char>> {
         .padded_by(comment.repeated());
 
     let parser = recursive(|pat| {
-        println!("pattern parser");
         let wildcard_pat =
             just_with_padding("_").map_with_span(|_, span| Pattern::Wildcard(WildcardPat { span }));
 


### PR DESCRIPTION
This allows us to pass `_` as args to function calls.  This results in args not being passed for those params and the result of the call the partial application of the non-`_` params, e.g.
```
let add = (a, b, c) => a + b + c;
let add_mid_5 = add(_, 5, _); // equivalent to (a, c) => a + 5 + c;
```
