### PR TITLE
Introduce TParam and use it maintain original param names in types

### DIFF
--- a/crates/crochet/tests/pass/combinators.d.ts
+++ b/crates/crochet/tests/pass/combinators.d.ts
@@ -1,4 +1,4 @@
 export declare const i: <A>(x: A) => A;
-export declare const k: <A, B>(x: A) => (arg0: B) => A;
-export declare const s: <A, B, C>(f: (arg0: A) => (arg0: B) => C) => (arg0: (arg0: A) => B) => (arg0: A) => C;
-export declare const skk: <A>(arg0: A) => A;
+export declare const k: <A, B>(x: A) => (y: B) => A;
+export declare const s: <A, B, C>(f: (arg0: A) => (arg0: B) => C) => (g: (arg0: A) => B) => (x: A) => C;
+export declare const skk: <A>(x: A) => A;

--- a/crates/crochet_ast/src/pattern.rs
+++ b/crates/crochet_ast/src/pattern.rs
@@ -29,6 +29,13 @@ impl Pattern {
             Pattern::Wildcard(wc) => wc.span.to_owned(),
         }
     }
+
+    pub fn get_name(&self, index: &usize) -> String {
+        match self {
+            Pattern::Ident(BindingIdent { id, .. }) => id.name.to_owned(),
+            _ => format!("arg{index}"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -74,7 +74,7 @@ impl Context {
         }
     }
 
-    pub fn lam(&self, params: Vec<Type>, ret: Box<Type>) -> Type {
+    pub fn lam(&self, params: Vec<TParam>, ret: Box<Type>) -> Type {
         Type {
             id: self.fresh_id(),
             variant: Variant::Lam(LamType {

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -93,6 +93,18 @@ impl Substitutable for TProp {
     }
 }
 
+impl Substitutable for TParam {
+    fn apply(&self, sub: &Subst) -> TParam {
+        TParam {
+            ty: self.ty.apply(sub),
+            ..self.to_owned()
+        }
+    }
+    fn ftv(&self) -> HashSet<i32> {
+        self.ty.ftv()
+    }
+}
+
 impl Substitutable for Scheme {
     fn apply(&self, sub: &Subst) -> Scheme {
         Scheme {

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -57,9 +57,38 @@ pub struct AppType {
     pub ret: Box<Type>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TParam {
+    pub name: String,
+    pub optional: bool,
+    pub mutable: bool,
+    pub ty: Type,
+}
+
+impl TParam {
+    pub fn get_type(&self, ctx: &Context) -> Type {
+        match self.optional {
+            true => ctx.union(vec![self.ty.to_owned(), ctx.prim(Primitive::Undefined)]),
+            false => self.ty.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for TParam {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { name, optional, mutable, ty } = self;
+        match (optional, mutable) {
+            (false, false) => write!(f, "{name}: {ty}"),
+            (true, false) => write!(f, "{name}?: {ty}"),
+            (false, true) => write!(f, "mut {name}: {ty}"),
+            (true, true) => write!(f, "mut {name}?: {ty}"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq)]
 pub struct LamType {
-    pub params: Vec<Type>,
+    pub params: Vec<TParam>,
     pub ret: Box<Type>,
 }
 

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -44,7 +44,12 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
             Variant::Lam(lam) => {
                 let params: Vec<_> = lam.params
                     .iter()
-                    .map(|param| norm_type(param, mapping, ctx))
+                    .map(|param| {
+                        TParam { 
+                            ty: norm_type(&param.ty, mapping, ctx),
+                            ..param.to_owned()
+                        }
+                    })
                     .collect();
                 let ret = Box::from(norm_type(&lam.ret, mapping, ctx));
                 Type {


### PR DESCRIPTION
TODO:
- [ ] ~don't set param names for object and array patterns, e.g.~ I'll do this in a separate PR
```
let bar = ([x, y]: [number, number]) => x + y;
let baz = ({x, y}: {x: number, y: number}) => x + y;
```