### PR TITLE
Replace `Variant::` with `Type::`

### DIFF
--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -201,7 +201,7 @@ fn infer_if_else_without_widening() {
 fn infer_if_else_with_widening() {
     let (_, ctx) = infer_prog("let x = if (true) { 5 } else { 10 }");
     let result = format!("{}", ctx.values.get("x").unwrap());
-    assert_eq!(result, "5 | 10");
+    assert_eq!(result, "10 | 5");
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn infer_if_else_with_widening_of_top_level_vars() {
     "#;
     let (_, ctx) = infer_prog(src);
     let result = format!("{}", ctx.values.get("x").unwrap());
-    assert_eq!(result, "5 | 10");
+    assert_eq!(result, "10 | 5");
 }
 
 #[test]
@@ -236,12 +236,11 @@ fn infer_if_else_with_multiple_widenings() {
     "#;
     let (program, ctx) = infer_prog(src);
     let result = format!("{}", ctx.values.get("x").unwrap());
-    assert_eq!(result, "5 | 10 | 15");
+    assert_eq!(result, "10 | 15 | 5");
 
     let result = codegen_d_ts(&program, &ctx);
-    insta::assert_snapshot!(result, @r###"
-    export declare const x: 5 | 10 | 15;
-    "###);
+    insta::assert_snapshot!(result, @"export declare const x: 15 | 10 | 5;
+");
 }
 
 #[test]
@@ -868,7 +867,7 @@ fn infer_fn_param_with_type_alias_with_param_2() {
 
     let result = format!("{}", ctx.values.get("get_bar").unwrap());
     // TODO: normalize the scheme before inserting it into the context
-    insta::assert_snapshot!(result, @"<t7>(foo: Foo<t7>) => t7");
+    insta::assert_snapshot!(result, @"<t2>(foo: Foo<t2>) => t2");
 }
 
 #[test]
@@ -1198,7 +1197,7 @@ fn infer_if_let_with_is() {
 
     assert_eq!(
         format!("{}", ctx.values.get("b").unwrap()),
-        "string | number"
+        "number | string"
     );
     // Ensures we aren't polluting the outside context
     assert!(ctx.values.get("a").is_none());
@@ -1523,7 +1522,7 @@ fn codegen_if_let_with_is_prim() {
     let result = codegen_d_ts(&program, &ctx);
 
     insta::assert_snapshot!(result, @r###"
-    export declare const b: string | number;
+    export declare const b: number | string;
     ;
     "###);
 }

--- a/crates/crochet/tests/integration_test.rs
+++ b/crates/crochet/tests/integration_test.rs
@@ -239,7 +239,7 @@ fn infer_if_else_with_multiple_widenings() {
     assert_eq!(result, "10 | 15 | 5");
 
     let result = codegen_d_ts(&program, &ctx);
-    insta::assert_snapshot!(result, @"export declare const x: 15 | 10 | 5;
+    insta::assert_snapshot!(result, @"export declare const x: 10 | 15 | 5;
 ");
 }
 
@@ -1409,10 +1409,10 @@ fn infer_if_let_refutable_pattern_with_disjoint_union() {
         readonly y: number;
     };
     type Action = {
-        readonly type: "moveto";
+        readonly type: "lineto";
         readonly point: Point;
     } | {
-        readonly type: "lineto";
+        readonly type: "moveto";
         readonly point: Point;
     };
     export declare const action: Action;

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -531,37 +531,23 @@ pub fn build_type(
             }
         }
         Type::Union(types) => {
-            let mut sorted_types = types.to_owned();
-            sorted_types.sort_by(|a, b| {
-                let a = format!("{a}");
-                let b = format!("{b}");
-                a.cmp(&b)
-            });
             TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
                 span: DUMMY_SP,
-                types: sorted_types
+                types: sort_types(types)
                     .iter()
                     .map(|ty| Box::from(build_type(ty, None, None)))
                     .collect(),
             }))
         }
-        Type::Intersection(types) => {
-            let mut sorted_types = types.to_owned();
-            sorted_types.sort_by(|a, b| {
-                let a = format!("{a}");
-                let b = format!("{b}");
-                a.cmp(&b)
-            });
-            TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
-                TsIntersectionType {
-                    span: DUMMY_SP,
-                    types: sorted_types
-                        .iter()
-                        .map(|ty| Box::from(build_type(ty, None, None)))
-                        .collect(),
-                },
-            ))
-        }
+        Type::Intersection(types) => TsType::TsUnionOrIntersectionType(
+            TsUnionOrIntersectionType::TsIntersectionType(TsIntersectionType {
+                span: DUMMY_SP,
+                types: sort_types(types)
+                    .iter()
+                    .map(|ty| Box::from(build_type(ty, None, None)))
+                    .collect(),
+            }),
+        ),
         Type::Object(props) => {
             let members: Vec<TsTypeElement> = props
                 .iter()
@@ -627,4 +613,14 @@ pub fn build_type(
         Type::Rest(_) => todo!(),
         Type::Wildcard => todo!(),
     }
+}
+
+fn sort_types(types: &[Type]) -> Vec<Type> {
+    let mut sorted_types = types.to_owned();
+    sorted_types.sort_by(|a, b| {
+        let a = format!("{a}");
+        let b = format!("{b}");
+        a.cmp(&b)
+    });
+    sorted_types
 }

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::rc::Rc;
 
 use swc_atoms::*;
@@ -536,11 +535,7 @@ pub fn build_type(
             sorted_types.sort_by(|a, b| {
                 let a = format!("{a}");
                 let b = format!("{b}");
-                if a < b {
-                    cmp::Ordering::Less
-                } else {
-                    cmp::Ordering::Greater
-                }
+                a.cmp(&b)
             });
             TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
                 span: DUMMY_SP,
@@ -555,11 +550,7 @@ pub fn build_type(
             sorted_types.sort_by(|a, b| {
                 let a = format!("{a}");
                 let b = format!("{b}");
-                if a < b {
-                    cmp::Ordering::Less
-                } else {
-                    cmp::Ordering::Greater
-                }
+                a.cmp(&b)
             });
             TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsIntersectionType(
                 TsIntersectionType {

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -68,24 +68,15 @@ impl Context {
     }
 
     pub fn fresh_var(&self) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Var,
-        }
+        Type::Var(self.fresh_id())
     }
 
     pub fn lam(&self, params: Vec<TFnParam>, ret: Box<Type>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Lam(LamType { params, ret }),
-        }
+        Type::Lam(LamType { params, ret })
     }
 
     pub fn prim(&self, prim: Primitive) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Prim(prim),
-        }
+        Type::Prim(prim)
     }
 
     pub fn lit(&self, lit: AstLit) -> Type {
@@ -96,38 +87,23 @@ impl Context {
             AstLit::Null(_) => Lit::Null,
             AstLit::Undefined(_) => Lit::Undefined,
         };
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Lit(lit),
-        }
+        Type::Lit(lit)
     }
 
     pub fn lit_type(&self, lit: Lit) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Lit(lit),
-        }
+        Type::Lit(lit)
     }
 
     pub fn union(&self, types: Vec<Type>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Union(types),
-        }
+        Type::Union(types)
     }
 
     pub fn intersection(&self, types: Vec<Type>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Intersection(types),
-        }
+        Type::Intersection(types)
     }
 
     pub fn object(&self, props: Vec<TProp>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Object(props),
-        }
+        Type::Object(props)
     }
 
     pub fn prop(&self, name: &str, ty: Type, optional: bool) -> TProp {
@@ -140,41 +116,26 @@ impl Context {
     }
 
     pub fn alias(&self, name: &str, type_params: Option<Vec<Type>>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Alias(AliasType {
-                name: name.to_owned(),
-                type_params,
-            }),
-        }
+        Type::Alias(AliasType {
+            name: name.to_owned(),
+            type_params,
+        })
     }
 
     pub fn tuple(&self, types: Vec<Type>) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Tuple(types),
-        }
+        Type::Tuple(types)
     }
 
     pub fn array(&self, t: Type) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Array(Box::from(t)),
-        }
+        Type::Array(Box::from(t))
     }
 
     pub fn rest(&self, arg: Type) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Rest(Box::from(arg)),
-        }
+        Type::Rest(Box::from(arg))
     }
 
     pub fn wildcard(&self) -> Type {
-        Type {
-            id: self.fresh_id(),
-            variant: Variant::Wildcard,
-        }
+        Type::Wildcard
     }
 }
 

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -39,7 +39,13 @@ pub fn infer_scheme_with_type_params(
     // Creates a Scheme with the correct qualifiers for the type references that were
     // replaced with type variables.
     Scheme {
-        qualifiers: type_param_map.values().map(|tv| tv.id).collect(),
+        qualifiers: type_param_map
+            .values()
+            .map(|t| match t {
+                Type::Var(id) => id.to_owned(),
+                _ => panic!("{t} is not a type variable"),
+            })
+            .collect(),
         ty: type_ann_ty,
     }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -108,7 +108,7 @@ mod tests {
         "#;
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("result", &ctx), "5 | 10");
+        assert_eq!(get_type("result", &ctx), "10 | 5");
     }
 
     #[test]
@@ -407,7 +407,7 @@ mod tests {
         "#;
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("value", &ctx), "string | number | undefined");
+        assert_eq!(get_type("value", &ctx), "number | string | undefined");
     }
 
     // TODO: In order for this to work, we need custom handling for unifying
@@ -599,7 +599,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("sum", &ctx), "5 | 1 | 0");
+        assert_eq!(get_type("sum", &ctx), "0 | 1 | 5");
 
         // Ensures we aren't polluting the outside context
         assert!(ctx.values.get("x").is_none());
@@ -769,7 +769,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("result", &ctx), "string | number | true");
+        assert_eq!(get_type("result", &ctx), "number | string | true");
 
         // Ensures we aren't polluting the outside context
         assert!(ctx.values.get("x").is_none());
@@ -1044,7 +1044,7 @@ mod tests {
 
         assert_eq!(
             get_type("plus_one", &ctx),
-            "(a: number, b?: string) => string | number"
+            "(a: number, b?: string) => number | string"
         );
     }
 
@@ -1506,7 +1506,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("z", &ctx), "5 | 10 | undefined");
+        assert_eq!(get_type("z", &ctx), "10 | 5 | undefined");
     }
 
     #[test]
@@ -1631,7 +1631,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert_eq!(get_type("elem", &ctx), "5 | \"hello\" | true | undefined");
+        assert_eq!(get_type("elem", &ctx), "\"hello\" | 5 | true | undefined");
     }
 
     #[test]
@@ -2226,7 +2226,7 @@ mod tests {
 
         assert_eq!(
             get_type("result", &ctx),
-            r#""none" | "one" | "a couple" | "a few" | "many""#
+            r#""a couple" | "a few" | "many" | "none" | "one""#
         );
     }
 


### PR DESCRIPTION
Now that we're creating union types when inferring `IfElse` and `Match` expressions we no longer need `id`s on the `Type` struct, it's enough to have them only on type variables.  This allows us to simplify the code greatly.  In a future PR we can get rid of the builder methods on `Context` since we only need `Context` when creating new type variables now.