### PR TITLE
Remove most of the builder methods from Context

### DIFF
--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -159,9 +159,9 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
         TsType::TsIndexedAccessType(_) => todo!(),
         TsType::TsMappedType(_) => todo!(),
         TsType::TsLitType(lit) => match &lit.lit {
-            TsLit::Number(num) => ctx.lit(Lit::num(format!("{}", num.value), 0..0)),
-            TsLit::Str(str) => ctx.lit(Lit::str(str.value.to_string(), 0..0)),
-            TsLit::Bool(b) => ctx.lit(Lit::bool(b.value, 0..0)),
+            TsLit::Number(num) => Type::from(Lit::num(format!("{}", num.value), 0..0)),
+            TsLit::Str(str) => Type::from(Lit::str(str.value.to_string(), 0..0)),
+            TsLit::Bool(b) => Type::from(Lit::bool(b.value, 0..0)),
             TsLit::BigInt(_) => todo!(),
             TsLit::Tpl(_) => todo!(),
         },

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -30,7 +30,7 @@ pub struct InterfaceCollector {
 impl InterfaceCollector {
     pub fn get_interface(&self, name: &str) -> Type {
         let props = &self.interfaces[name.to_owned()];
-        self.ctx.object(props.to_owned())
+        Type::Object(props.to_owned())
     }
 }
 
@@ -39,15 +39,15 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
         TsType::TsKeywordType(keyword) => match &keyword.kind {
             TsKeywordTypeKind::TsAnyKeyword => ctx.fresh_var(),
             TsKeywordTypeKind::TsUnknownKeyword => todo!(),
-            TsKeywordTypeKind::TsNumberKeyword => ctx.prim(Primitive::Num),
+            TsKeywordTypeKind::TsNumberKeyword => Type::Prim(Primitive::Num),
             TsKeywordTypeKind::TsObjectKeyword => todo!(),
-            TsKeywordTypeKind::TsBooleanKeyword => ctx.prim(Primitive::Bool),
+            TsKeywordTypeKind::TsBooleanKeyword => Type::Prim(Primitive::Bool),
             TsKeywordTypeKind::TsBigIntKeyword => todo!(),
-            TsKeywordTypeKind::TsStringKeyword => ctx.prim(Primitive::Str),
+            TsKeywordTypeKind::TsStringKeyword => Type::Prim(Primitive::Str),
             TsKeywordTypeKind::TsSymbolKeyword => todo!(),
             TsKeywordTypeKind::TsVoidKeyword => todo!(),
-            TsKeywordTypeKind::TsUndefinedKeyword => ctx.prim(Primitive::Undefined),
-            TsKeywordTypeKind::TsNullKeyword => ctx.prim(Primitive::Null),
+            TsKeywordTypeKind::TsUndefinedKeyword => Type::Prim(Primitive::Undefined),
+            TsKeywordTypeKind::TsNullKeyword => Type::Prim(Primitive::Null),
             TsKeywordTypeKind::TsNeverKeyword => todo!(),
             TsKeywordTypeKind::TsIntrinsicKeyword => todo!(),
         },
@@ -100,7 +100,10 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     })
                     .collect();
                 let ret = infer_ts_type_ann(&fn_type.type_ann.type_ann, ctx);
-                ctx.lam(params, Box::from(ret))
+                Type::Lam(types::LamType {
+                    params,
+                    ret: Box::from(ret),
+                })
             }
             TsFnOrConstructorType::TsConstructorType(_) => todo!(),
         },
@@ -120,13 +123,13 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     .map(|t| infer_ts_type_ann(t, ctx))
                     .collect()
             });
-            ctx.alias(&name, type_params)
+            Type::Alias(types::AliasType { name, type_params })
         }
         TsType::TsTypeQuery(_) => todo!(),
         TsType::TsTypeLit(_) => todo!(),
         TsType::TsArrayType(array) => {
             let elem_type = infer_ts_type_ann(&array.elem_type, ctx);
-            ctx.array(elem_type)
+            Type::Array(Box::from(elem_type))
         }
         TsType::TsTupleType(_) => todo!(),
         TsType::TsOptionalType(_) => todo!(),
@@ -138,7 +141,7 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     .iter()
                     .map(|ts_type| infer_ts_type_ann(ts_type, ctx))
                     .collect();
-                ctx.union(types)
+                Type::Union(types)
             }
             TsUnionOrIntersectionType::TsIntersectionType(intersection) => {
                 let types: Vec<_> = intersection
@@ -146,7 +149,7 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     .iter()
                     .map(|ts_type| infer_ts_type_ann(ts_type, ctx))
                     .collect();
-                ctx.intersection(types)
+                Type::Intersection(types)
             }
         },
         TsType::TsConditionalType(_) => todo!(),
@@ -289,7 +292,10 @@ impl InterfaceCollector {
             None => panic!("method has no return type"),
         };
         // TODO: maintain param names
-        self.ctx.lam(params, Box::from(ret))
+        Type::Lam(types::LamType {
+            params,
+            ret: Box::from(ret),
+        })
     }
 }
 

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -1,8 +1,6 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 
-use crochet_ast::literal::Lit as AstLit;
-
 use super::substitutable::*;
 use super::types::*;
 
@@ -44,6 +42,7 @@ impl Context {
             .ok_or(format!("Can't find type: {name}"))?;
         Ok(self.instantiate(scheme))
     }
+
     // TODO: Make this return a Result<Type, String>
     pub fn lookup_type(&self, name: &str) -> Result<Type, String> {
         let scheme = self
@@ -51,6 +50,34 @@ impl Context {
             .get(name)
             .ok_or(format!("Can't find type: {name}"))?;
         Ok(self.instantiate(scheme))
+    }
+
+    pub fn lookup_alias(&self, alias: &AliasType) -> Result<Type, String> {
+        match self.types.get(&alias.name) {
+            Some(scheme) => {
+                // Replaces qualifiers in the scheme with the corresponding type params
+                // from the alias type.
+                let ids = scheme.qualifiers.iter().map(|id| id.to_owned());
+                let subs: Subst = match &alias.type_params {
+                    Some(type_params) => {
+                        if scheme.qualifiers.len() != type_params.len() {
+                            return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
+                        }
+                        ids.zip(type_params.iter().cloned()).collect()
+                    }
+                    None => {
+                        if !scheme.qualifiers.is_empty() {
+                            return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
+                        }
+                        ids.zip(scheme.qualifiers.iter().map(|_| self.fresh_var()))
+                            .collect()
+                    }
+                };
+
+                Ok(scheme.ty.apply(&subs))
+            }
+            None => Err(String::from("Can't find alias '{name}' in context")),
+        }
     }
 
     pub fn instantiate(&self, scheme: &Scheme) -> Type {
@@ -69,57 +96,5 @@ impl Context {
 
     pub fn fresh_var(&self) -> Type {
         Type::Var(self.fresh_id())
-    }
-
-    pub fn lit(&self, lit: AstLit) -> Type {
-        let lit = match lit {
-            AstLit::Num(n) => Lit::Num(n.value),
-            AstLit::Bool(b) => Lit::Bool(b.value),
-            AstLit::Str(s) => Lit::Str(s.value),
-            AstLit::Null(_) => Lit::Null,
-            AstLit::Undefined(_) => Lit::Undefined,
-        };
-        Type::Lit(lit)
-    }
-
-    pub fn lit_type(&self, lit: Lit) -> Type {
-        Type::Lit(lit)
-    }
-
-    pub fn prop(&self, name: &str, ty: Type, optional: bool) -> TProp {
-        TProp {
-            name: name.to_owned(),
-            optional,
-            mutable: false,
-            ty,
-        }
-    }
-}
-
-pub fn lookup_alias(ctx: &Context, alias: &AliasType) -> Result<Type, String> {
-    match ctx.types.get(&alias.name) {
-        Some(scheme) => {
-            // Replaces qualifiers in the scheme with the corresponding type params
-            // from the alias type.
-            let ids = scheme.qualifiers.iter().map(|id| id.to_owned());
-            let subs: Subst = match &alias.type_params {
-                Some(type_params) => {
-                    if scheme.qualifiers.len() != type_params.len() {
-                        return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
-                    }
-                    ids.zip(type_params.iter().cloned()).collect()
-                }
-                None => {
-                    if !scheme.qualifiers.is_empty() {
-                        return Err(String::from("mismatch between number of qualifiers in scheme and number of type params"));
-                    }
-                    ids.zip(scheme.qualifiers.iter().map(|_| ctx.fresh_var()))
-                        .collect()
-                }
-            };
-
-            Ok(scheme.ty.apply(&subs))
-        }
-        None => Err(String::from("Can't find alias '{name}' in context")),
     }
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -71,14 +71,6 @@ impl Context {
         Type::Var(self.fresh_id())
     }
 
-    pub fn lam(&self, params: Vec<TFnParam>, ret: Box<Type>) -> Type {
-        Type::Lam(LamType { params, ret })
-    }
-
-    pub fn prim(&self, prim: Primitive) -> Type {
-        Type::Prim(prim)
-    }
-
     pub fn lit(&self, lit: AstLit) -> Type {
         let lit = match lit {
             AstLit::Num(n) => Lit::Num(n.value),
@@ -94,18 +86,6 @@ impl Context {
         Type::Lit(lit)
     }
 
-    pub fn union(&self, types: Vec<Type>) -> Type {
-        Type::Union(types)
-    }
-
-    pub fn intersection(&self, types: Vec<Type>) -> Type {
-        Type::Intersection(types)
-    }
-
-    pub fn object(&self, props: Vec<TProp>) -> Type {
-        Type::Object(props)
-    }
-
     pub fn prop(&self, name: &str, ty: Type, optional: bool) -> TProp {
         TProp {
             name: name.to_owned(),
@@ -113,29 +93,6 @@ impl Context {
             mutable: false,
             ty,
         }
-    }
-
-    pub fn alias(&self, name: &str, type_params: Option<Vec<Type>>) -> Type {
-        Type::Alias(AliasType {
-            name: name.to_owned(),
-            type_params,
-        })
-    }
-
-    pub fn tuple(&self, types: Vec<Type>) -> Type {
-        Type::Tuple(types)
-    }
-
-    pub fn array(&self, t: Type) -> Type {
-        Type::Array(Box::from(t))
-    }
-
-    pub fn rest(&self, arg: Type) -> Type {
-        Type::Rest(Box::from(arg))
-    }
-
-    pub fn wildcard(&self) -> Type {
-        Type::Wildcard
     }
 }
 

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -17,7 +17,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
         name: String::from("_name"),
         optional: false,
         mutable: false,
-        ty: ctx.lit(Lit::str(String::from("Promise"), 0..0)),
+        ty: Type::from(Lit::str(String::from("Promise"), 0..0)),
     }]));
     ctx.types.insert(String::from("Promise"), promise_scheme);
     // TODO: replace with Class type once it exists
@@ -27,7 +27,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
         name: String::from("_name"),
         optional: false,
         mutable: false,
-        ty: ctx.lit(Lit::str(String::from("JSXElement"), 0..0)),
+        ty: Type::from(Lit::str(String::from("JSXElement"), 0..0)),
     }]));
     ctx.types
         .insert(String::from("JSXElement"), jsx_element_scheme);

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -13,7 +13,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
     // TODO: replace with Class type once it exists
     // We use {_name: "Promise"} to differentiate it from other
     // object types.
-    let promise_scheme = Scheme::from(ctx.object(vec![TProp {
+    let promise_scheme = Scheme::from(Type::Object(vec![TProp {
         name: String::from("_name"),
         optional: false,
         mutable: false,
@@ -23,7 +23,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
     // TODO: replace with Class type once it exists
     // We use {_name: "JSXElement"} to differentiate it from other
     // object types.
-    let jsx_element_scheme = Scheme::from(ctx.object(vec![TProp {
+    let jsx_element_scheme = Scheme::from(Type::Object(vec![TProp {
         name: String::from("_name"),
         optional: false,
         mutable: false,

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -26,7 +26,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                 if arg.spread.is_some() {
                     match arg_t {
                         Type::Tuple(types) => arg_types.extend(types.to_owned()),
-                        _ => arg_types.push(ctx.rest(arg_t)),
+                        _ => arg_types.push(Type::Rest(Box::from(arg_t))),
                     }
                 } else {
                     arg_types.push(arg_t);
@@ -62,13 +62,20 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                 ty: tv.clone(),
                 optional: false,
             };
-            let s2 = unify(&ctx.lam(vec![param], Box::from(tv.clone())), &t, ctx)?;
+            let s2 = unify(
+                &Type::Lam(types::LamType {
+                    params: vec![param],
+                    ret: Box::from(tv.clone()),
+                }),
+                &t,
+                ctx,
+            )?;
             Ok((compose_subs(&s2, &s1), tv.apply(&s2)))
         }
         Expr::Ident(Ident { name, .. }) => {
             let s = Subst::default();
             let t = if name == "_" {
-                ctx.wildcard()
+                Type::Wildcard
             } else {
                 ctx.lookup_value(name)?
             };
@@ -89,17 +96,17 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                         let (s2, t2) = infer_expr(ctx, alternate)?;
 
                         let s = compose_many_subs(&[s1, s2]);
-                        let t = union_types(&t1, &t2, ctx);
+                        let t = union_types(&t1, &t2);
                         Ok((s, t))
                     }
                     _ => {
                         let (s1, t1) = infer_expr(ctx, cond)?;
                         let (s2, t2) = infer_expr(ctx, consequent)?;
                         let (s3, t3) = infer_expr(ctx, alternate)?;
-                        let s4 = unify(&t1, &ctx.prim(Primitive::Bool), ctx)?;
+                        let s4 = unify(&t1, &Type::Prim(Primitive::Bool), ctx)?;
 
                         let s = compose_many_subs(&[s1, s2, s3, s4]);
-                        let t = union_types(&t2, &t3, ctx);
+                        let t = union_types(&t2, &t3);
                         Ok((s, t))
                     }
                 }
@@ -108,7 +115,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                 Expr::LetExpr(LetExpr { pat, expr, .. }) => {
                     let (s1, t1) =
                         infer_let(pat, &None, expr, consequent, ctx, &PatternUsage::Match)?;
-                    let s2 = match unify(&t1, &ctx.prim(Primitive::Undefined), ctx) {
+                    let s2 = match unify(&t1, &Type::Prim(Primitive::Undefined), ctx) {
                         Ok(s) => Ok(s),
                         Err(_) => Err(String::from(
                             "Consequent for 'if' without 'else' must not return a value",
@@ -122,8 +129,8 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                 _ => {
                     let (s1, t1) = infer_expr(ctx, cond)?;
                     let (s2, t2) = infer_expr(ctx, consequent)?;
-                    let s3 = unify(&t1, &ctx.prim(Primitive::Bool), ctx)?;
-                    let s4 = match unify(&t2, &ctx.prim(Primitive::Undefined), ctx) {
+                    let s3 = unify(&t1, &Type::Prim(Primitive::Bool), ctx)?;
+                    let s4 = match unify(&t2, &Type::Prim(Primitive::Undefined), ctx) {
                         Ok(s) => Ok(s),
                         Err(_) => Err(String::from(
                             "Consequent for 'if' without 'else' must not return a value",
@@ -173,10 +180,13 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                                     props.push(prop);
                                 }
 
-                                let ret_type = ctx.alias("JSXElement", None);
+                                let ret_type = Type::Alias(types::AliasType {
+                                    name: String::from("JSXElement"),
+                                    type_params: None,
+                                });
 
                                 let call_type = Type::App(types::AppType {
-                                    args: vec![ctx.object(props)],
+                                    args: vec![Type::Object(props)],
                                     ret: Box::from(ret_type.clone()),
                                 });
 
@@ -196,7 +206,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
             let s = Subst::default();
             // TODO: check props on JSXInstrinsics
-            let t = ctx.alias("JSXElement", None);
+            let t = Type::Alias(types::AliasType {
+                name: String::from("JSXElement"),
+                type_params: None,
+            });
 
             Ok((s, t))
         }
@@ -242,7 +255,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             ctx.state.count.set(new_ctx.state.count.get());
 
             let rt = if *is_async && !is_promise(&rt) {
-                ctx.alias("Promise", Some(vec![rt]))
+                Type::Alias(types::AliasType {
+                    name: String::from("Promise"),
+                    type_params: Some(vec![rt]),
+                })
             } else {
                 rt
             };
@@ -255,7 +271,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
                 )?,
                 None => Subst::default(),
             };
-            let t = ctx.lam(t_params, Box::from(rt));
+            let t = Type::Lam(types::LamType {
+                params: t_params,
+                ret: Box::from(rt),
+            });
             let s = compose_subs(&s, &compose_subs(&rs, &compose_many_subs(&ss)));
             let t = t.apply(&s);
 
@@ -293,27 +312,27 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             // time and set the result to be appropriate number literal.
             let (s1, t1) = infer_expr(ctx, left)?;
             let (s2, t2) = infer_expr(ctx, right)?;
-            let s3 = unify(&t1, &ctx.prim(Primitive::Num), ctx)?;
-            let s4 = unify(&t2, &ctx.prim(Primitive::Num), ctx)?;
+            let s3 = unify(&t1, &Type::Prim(Primitive::Num), ctx)?;
+            let s4 = unify(&t2, &Type::Prim(Primitive::Num), ctx)?;
             let t = match op {
-                BinOp::Add => ctx.prim(Primitive::Num),
-                BinOp::Sub => ctx.prim(Primitive::Num),
-                BinOp::Mul => ctx.prim(Primitive::Num),
-                BinOp::Div => ctx.prim(Primitive::Num),
-                BinOp::EqEq => ctx.prim(Primitive::Bool),
-                BinOp::NotEq => ctx.prim(Primitive::Bool),
-                BinOp::Gt => ctx.prim(Primitive::Bool),
-                BinOp::GtEq => ctx.prim(Primitive::Bool),
-                BinOp::Lt => ctx.prim(Primitive::Bool),
-                BinOp::LtEq => ctx.prim(Primitive::Bool),
+                BinOp::Add => Type::Prim(Primitive::Num),
+                BinOp::Sub => Type::Prim(Primitive::Num),
+                BinOp::Mul => Type::Prim(Primitive::Num),
+                BinOp::Div => Type::Prim(Primitive::Num),
+                BinOp::EqEq => Type::Prim(Primitive::Bool),
+                BinOp::NotEq => Type::Prim(Primitive::Bool),
+                BinOp::Gt => Type::Prim(Primitive::Bool),
+                BinOp::GtEq => Type::Prim(Primitive::Bool),
+                BinOp::Lt => Type::Prim(Primitive::Bool),
+                BinOp::LtEq => Type::Prim(Primitive::Bool),
             };
             Ok((compose_many_subs(&[s1, s2, s3, s4]), t))
         }
         Expr::UnaryExpr(UnaryExpr { op, arg, .. }) => {
             let (s1, t1) = infer_expr(ctx, arg)?;
-            let s2 = unify(&t1, &ctx.prim(Primitive::Num), ctx)?;
+            let s2 = unify(&t1, &Type::Prim(Primitive::Num), ctx)?;
             let t = match op {
-                UnaryOp::Minus => ctx.prim(Primitive::Num),
+                UnaryOp::Minus => Type::Prim(Primitive::Num),
             };
             Ok((compose_many_subs(&[s1, s2]), t))
         }
@@ -348,12 +367,12 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
             let s = compose_many_subs(&ss);
             if spread_types.is_empty() {
-                let t = ctx.object(ps);
+                let t = Type::Object(ps);
                 Ok((s, t))
             } else {
                 let mut all_types = spread_types;
-                all_types.push(ctx.object(ps));
-                let t = simplify_intersection(&all_types, ctx);
+                all_types.push(Type::Object(ps));
+                let t = simplify_intersection(&all_types);
                 Ok((s, t))
             }
         }
@@ -364,7 +383,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
             let (s1, t1) = infer_expr(ctx, expr)?;
             let wrapped_type = ctx.fresh_var();
-            let promise_type = ctx.alias("Promise", Some(vec![wrapped_type.clone()]));
+            let promise_type = Type::Alias(types::AliasType {
+                name: String::from("Promise"),
+                type_params: Some(vec![wrapped_type.clone()]),
+            });
 
             let s2 = unify(&t1, &promise_type, ctx)?;
 
@@ -402,7 +424,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             }
 
             let s = compose_many_subs(&ss);
-            let t = ctx.tuple(ts);
+            let t = Type::Tuple(ts);
             Ok((s, t))
         }
         Expr::Member(Member { obj, prop, .. }) => {
@@ -415,14 +437,14 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             Ok((s, t))
         }
         Expr::Empty(_) => {
-            let t = ctx.prim(Primitive::Undefined);
+            let t = Type::Prim(Primitive::Undefined);
             let s = Subst::default();
             Ok((s, t))
         }
         Expr::TemplateLiteral(TemplateLiteral {
             exprs, quasis: _, ..
         }) => {
-            let t = ctx.prim(Primitive::Str);
+            let t = Type::Prim(Primitive::Str);
             let result: Result<Vec<(Subst, Type)>, String> =
                 exprs.iter().map(|expr| infer_expr(ctx, expr)).collect();
             // We ignore the types of expressions if there are any because any expression
@@ -456,7 +478,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             }
 
             let s = compose_many_subs(&ss);
-            let t = union_many_types(&ts, ctx);
+            let t = union_many_types(&ts);
 
             Ok((s, t))
         }
@@ -513,7 +535,7 @@ fn infer_property_type(
             MemberProp::Ident(Ident { name, .. }) => {
                 let prop = props.iter().find(|prop| prop.name == *name);
                 match prop {
-                    Some(prop) => Ok((Subst::default(), prop.get_type(ctx))),
+                    Some(prop) => Ok((Subst::default(), prop.get_type())),
                     None => Err(format!("Object type doesn't contain key {name}.")),
                 }
             }
@@ -525,8 +547,8 @@ fn infer_property_type(
                         Primitive::Str => {
                             let mut value_types: Vec<Type> =
                                 props.iter().map(|prop| prop.ty.to_owned()).collect();
-                            value_types.push(ctx.prim(Primitive::Undefined));
-                            let t = ctx.union(value_types);
+                            value_types.push(Type::Prim(Primitive::Undefined));
+                            let t = Type::Union(value_types);
                             Ok((prop_s, t))
                         }
                         _ => Err(format!("{prim} is an invalid key for object types")),
@@ -535,7 +557,7 @@ fn infer_property_type(
                         crate::Lit::Str(key) => {
                             let prop = props.iter().find(|prop| prop.name == key);
                             match prop {
-                                Some(prop) => Ok((Subst::default(), prop.get_type(ctx))),
+                                Some(prop) => Ok((Subst::default(), prop.get_type())),
                                 None => Err(format!("Object type doesn't contain key {key}.")),
                             }
                         }
@@ -593,8 +615,8 @@ fn infer_property_type(
                             Primitive::Num => {
                                 // TODO: remove duplicate types
                                 let mut elem_types = elem_types.to_owned();
-                                elem_types.push(ctx.prim(Primitive::Undefined));
-                                let t = ctx.union(elem_types);
+                                elem_types.push(Type::Prim(Primitive::Undefined));
+                                let t = Type::Union(elem_types);
                                 Ok((prop_s, t))
                             }
                             _ => Err(format!("{prim} is an invalid indexer for tuple types")),

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -62,7 +62,7 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
             let tv = ctx.fresh_var();
             Ok(tv)
         }
-        Pattern::Lit(LitPat { lit, .. }) => Ok(ctx.lit(lit.to_owned())),
+        Pattern::Lit(LitPat { lit, .. }) => Ok(Type::from(lit.to_owned())),
         Pattern::Is(IsPat { id, is_id, .. }) => {
             let ty = match is_id.name.as_str() {
                 "string" => Type::Prim(types::Primitive::Str),

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -80,7 +80,7 @@ fn infer_type_ann_rec(
             let ret = Box::from(infer_type_ann_rec(ret.as_ref(), ctx, type_param_map));
             Type::Lam(types::LamType { params, ret })
         }
-        TypeAnn::Lit(lit) => ctx.lit(lit.to_owned()),
+        TypeAnn::Lit(lit) => Type::from(lit.to_owned()),
         TypeAnn::Prim(PrimType { prim, .. }) => Type::Prim(prim.to_owned()),
         TypeAnn::Object(ObjectType { props, .. }) => {
             let props: Vec<_> = props

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -2,6 +2,8 @@ use itertools::{join, Itertools};
 use std::fmt;
 use std::hash::Hash;
 
+use crochet_ast::literal::Lit as AstLit;
+
 use crate::types::{Lit, Primitive};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -251,6 +253,24 @@ pub enum Type {
     Tuple(Vec<Type>),
     Array(Box<Type>),
     Rest(Box<Type>), // TODO: rename this to Spread
+}
+
+impl From<AstLit> for Type {
+    fn from(ast_lit: AstLit) -> Self {
+        Type::Lit(match ast_lit {
+            AstLit::Num(n) => Lit::Num(n.value),
+            AstLit::Bool(b) => Lit::Bool(b.value),
+            AstLit::Str(s) => Lit::Str(s.value),
+            AstLit::Null(_) => Lit::Null,
+            AstLit::Undefined(_) => Lit::Undefined,
+        })
+    }
+}
+
+impl From<Lit> for Type {
+    fn from(lit: Lit) -> Self {
+        Type::Lit(lit)
+    }
 }
 
 impl fmt::Display for Type {

--- a/crates/crochet_infer/src/types/type.rs
+++ b/crates/crochet_infer/src/types/type.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::hash::Hash;
 
 use crate::types::{Lit, Primitive};
-use crate::Context;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TProp {
@@ -14,9 +13,9 @@ pub struct TProp {
 }
 
 impl TProp {
-    pub fn get_type(&self, ctx: &Context) -> Type {
+    pub fn get_type(&self) -> Type {
         match self.optional {
-            true => ctx.union(vec![self.ty.to_owned(), ctx.prim(Primitive::Undefined)]),
+            true => Type::Union(vec![self.ty.to_owned(), Type::Prim(Primitive::Undefined)]),
             false => self.ty.to_owned(),
         }
     }
@@ -53,9 +52,9 @@ pub struct TFnParam {
 }
 
 impl TFnParam {
-    pub fn get_type(&self, ctx: &Context) -> Type {
+    pub fn get_type(&self) -> Type {
         match self.optional {
-            true => ctx.union(vec![self.ty.to_owned(), ctx.prim(Primitive::Undefined)]),
+            true => Type::Union(vec![self.ty.to_owned(), Type::Prim(Primitive::Undefined)]),
             false => self.ty.to_owned(),
         }
     }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -2,7 +2,7 @@ use crochet_ast::Primitive;
 use std::cmp;
 use std::collections::HashSet;
 
-use super::context::{lookup_alias, Context};
+use super::context::Context;
 use super::substitutable::{Subst, Substitutable};
 use super::types::{self, TFnParam, Type};
 use super::util::*;
@@ -432,11 +432,11 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
             }
         }
         (_, Type::Alias(alias)) => {
-            let alias_t = lookup_alias(ctx, alias)?;
+            let alias_t = ctx.lookup_alias(alias)?;
             unify(t1, &alias_t, ctx)
         }
         (Type::Alias(alias), _) => {
-            let alias_t = lookup_alias(ctx, alias)?;
+            let alias_t = ctx.lookup_alias(alias)?;
             unify(&alias_t, t2, ctx)
         }
         (Type::Array(array_arg), Type::Rest(rest_arg)) => {
@@ -526,13 +526,13 @@ mod tests {
     fn literals_are_subtypes_of_corresponding_primitives() {
         let ctx = Context::default();
 
-        let result = unify(&ctx.lit(num("5")), &Type::Prim(Primitive::Num), &ctx);
+        let result = unify(&Type::from(num("5")), &Type::Prim(Primitive::Num), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&ctx.lit(str("hello")), &Type::Prim(Primitive::Str), &ctx);
+        let result = unify(&Type::from(str("hello")), &Type::Prim(Primitive::Str), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&ctx.lit(bool(&true)), &Type::Prim(Primitive::Bool), &ctx);
+        let result = unify(&Type::from(bool(&true)), &Type::Prim(Primitive::Bool), &ctx);
         assert_eq!(result, Ok(Subst::default()));
     }
 
@@ -545,13 +545,13 @@ mod tests {
                 name: String::from("foo"),
                 optional: false,
                 mutable: false,
-                ty: ctx.lit(num("5")),
+                ty: Type::from(num("5")),
             },
             types::TProp {
                 name: String::from("bar"),
                 optional: false,
                 mutable: false,
-                ty: ctx.lit(bool(&true)),
+                ty: Type::from(bool(&true)),
             },
             // Having extra properties is okay
             types::TProp {
@@ -595,7 +595,7 @@ mod tests {
     fn failure_case() {
         let ctx = Context::default();
 
-        let result = unify(&Type::Prim(Primitive::Num), &ctx.lit(num("5")), &ctx);
+        let result = unify(&Type::Prim(Primitive::Num), &Type::from(num("5")), &ctx);
 
         assert_eq!(result, Err(String::from("Unification failure")))
     }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -57,11 +57,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     // NOTE: The order of params is reversed.  This allows a callback
                     // whose params can accept more values (are supertypes) than the
                     // function will pass to the callback.
-                    let s1 = unify(
-                        &p2.get_type(ctx).apply(&s),
-                        &p1.get_type(ctx).apply(&s),
-                        ctx,
-                    )?;
+                    let s1 = unify(&p2.get_type().apply(&s), &p1.get_type().apply(&s), ctx)?;
                     s = compose_subs(&s, &s1);
                 }
                 let s1 = unify(&lam1.ret.apply(&s), &lam2.ret.apply(&s), ctx)?;
@@ -118,7 +114,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                             if is_last {
                                 let spread_count = param_count_low_bound - args.len();
                                 for _ in 0..spread_count {
-                                    args.push(ctx.wildcard());
+                                    args.push(Type::Wildcard);
                                 }
                             } else {
                                 return Err(String::from("Placeholder spread must appear last"));
@@ -140,7 +136,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
 
                 let mut args = app.args.clone();
                 let regular_args: Vec<_> = args.drain(0..regular_arg_count).collect();
-                let rest_arg = ctx.tuple(args);
+                let rest_arg = Type::Tuple(args);
 
                 let mut params = lam.params.clone();
                 let regular_params: Vec<_> = params.drain(0..regular_arg_count).collect();
@@ -150,7 +146,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     // Each argument must be a subtype of the corresponding param.
                     let arg = p1.apply(&s);
                     let param = p2.apply(&s);
-                    let s1 = unify(&arg, &param.get_type(ctx), ctx)?;
+                    let s1 = unify(&arg, &param.get_type(), ctx)?;
                     s = compose_subs(&s, &s1);
                 }
 
@@ -175,13 +171,16 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                             _ => {
                                 let arg = arg.apply(&s);
                                 let param = param.apply(&s);
-                                let s1 = unify(&arg, &param.get_type(ctx), ctx)?;
+                                let s1 = unify(&arg, &param.get_type(), ctx)?;
                                 s = compose_subs(&s, &s1);
                             }
                         };
                     }
 
-                    let partial_ret = ctx.lam(partial_params, lam.ret.clone());
+                    let partial_ret = Type::Lam(types::LamType {
+                        params: partial_params,
+                        ret: lam.ret.clone(),
+                    });
                     let s1 = unify(&app.ret.apply(&s), &partial_ret, ctx)?;
 
                     Ok(compose_subs(&s, &s1))
@@ -190,7 +189,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     for (p1, p2) in args.iter().zip(&lam.params) {
                         // Each argument must be a subtype of the corresponding param.
                         let arg = p1.apply(&s);
-                        let param = p2.get_type(ctx).apply(&s);
+                        let param = p2.get_type().apply(&s);
                         let s1 = unify(&arg, &param, ctx)?;
                         s = compose_subs(&s, &s1);
                     }
@@ -219,7 +218,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     let mut ss = vec![];
                     for prop1 in props1.iter() {
                         if prop1.name == prop2.name {
-                            if let Ok(s) = unify(&prop1.get_type(ctx), &prop2.get_type(ctx), ctx) {
+                            if let Ok(s) = unify(&prop1.get_type(), &prop2.get_type(), ctx) {
                                 b = true;
                                 ss.push(s);
                             }
@@ -289,7 +288,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 let rest1: Vec<_> = types1.drain(0..rest_len).collect();
                 let after1: Vec<_> = types1;
 
-                let s = unify(&ctx.tuple(rest1), &rest2, ctx)?;
+                let s = unify(&Type::Tuple(rest1), &rest2, ctx)?;
                 ss.push(s);
 
                 for (t1, t2) in after1.iter().zip(after2.iter()) {
@@ -318,7 +317,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         (Type::Union(types), _) => {
             let result: Result<Vec<_>, _> = types.iter().map(|t1| unify(t1, t2, ctx)).collect();
             let ss = result?; // This is only okay if all calls to is_subtype are okay
-            Ok(compose_many_subs_with_context(&ss, ctx))
+            Ok(compose_many_subs_with_context(&ss))
         }
         (_, Type::Union(types)) => {
             let mut b = false;
@@ -348,7 +347,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 .collect();
             // TODO: check for other variants, if there are we should error
 
-            let obj_type = simplify_intersection(&obj_types, ctx);
+            let obj_type = simplify_intersection(&obj_types);
 
             match rest_types.len() {
                 0 => unify(t1, &obj_type, ctx),
@@ -363,10 +362,10 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         .cloned()
                         .partition(|p| all_obj_props.iter().any(|op| op.name == p.name));
 
-                    let s1 = unify(&ctx.object(obj_props), &obj_type, ctx)?;
+                    let s1 = unify(&Type::Object(obj_props), &obj_type, ctx)?;
 
                     let rest_type = rest_types.get(0).unwrap();
-                    let s2 = unify(&ctx.object(rest_props), rest_type, ctx)?;
+                    let s2 = unify(&Type::Object(rest_props), rest_type, ctx)?;
 
                     let s = compose_subs(&s2, &s1);
                     Ok(s)
@@ -387,7 +386,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 .collect();
             // TODO: check for other variants, if there are we should error
 
-            let obj_type = simplify_intersection(&obj_types, ctx);
+            let obj_type = simplify_intersection(&obj_types);
 
             match rest_types.len() {
                 0 => unify(&obj_type, t2, ctx),
@@ -402,10 +401,10 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         .cloned()
                         .partition(|p| all_obj_props.iter().any(|op| op.name == p.name));
 
-                    let s_obj = unify(&obj_type, &ctx.object(obj_props), ctx)?;
+                    let s_obj = unify(&obj_type, &Type::Object(obj_props), ctx)?;
 
                     let rest_type = rest_types.get(0).unwrap();
-                    let s_rest = unify(rest_type, &ctx.object(rest_props), ctx)?;
+                    let s_rest = unify(rest_type, &Type::Object(rest_props), ctx)?;
 
                     let s = compose_subs(&s_rest, &s_obj);
                     Ok(s)
@@ -423,7 +422,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                             .map(|(t1, t2)| unify(t1, t2, ctx))
                             .collect();
                         let ss = result?; // This is only okay if all calls to is_subtype are okay
-                        Ok(compose_many_subs_with_context(&ss, ctx))
+                        Ok(compose_many_subs_with_context(&ss))
                     }
                     (None, None) => Ok(Subst::default()),
                     _ => Err(String::from("Alias type mismatch")),
@@ -527,13 +526,13 @@ mod tests {
     fn literals_are_subtypes_of_corresponding_primitives() {
         let ctx = Context::default();
 
-        let result = unify(&ctx.lit(num("5")), &ctx.prim(Primitive::Num), &ctx);
+        let result = unify(&ctx.lit(num("5")), &Type::Prim(Primitive::Num), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&ctx.lit(str("hello")), &ctx.prim(Primitive::Str), &ctx);
+        let result = unify(&ctx.lit(str("hello")), &Type::Prim(Primitive::Str), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&ctx.lit(bool(&true)), &ctx.prim(Primitive::Bool), &ctx);
+        let result = unify(&ctx.lit(bool(&true)), &Type::Prim(Primitive::Bool), &ctx);
         assert_eq!(result, Ok(Subst::default()));
     }
 
@@ -541,7 +540,7 @@ mod tests {
     fn object_subtypes() {
         let ctx = Context::default();
 
-        let t1 = ctx.object(vec![
+        let t1 = Type::Object(vec![
             types::TProp {
                 name: String::from("foo"),
                 optional: false,
@@ -559,22 +558,22 @@ mod tests {
                 name: String::from("baz"),
                 optional: false,
                 mutable: false,
-                ty: ctx.prim(Primitive::Str),
+                ty: Type::Prim(Primitive::Str),
             },
         ]);
 
-        let t2 = ctx.object(vec![
+        let t2 = Type::Object(vec![
             types::TProp {
                 name: String::from("foo"),
                 optional: false,
                 mutable: false,
-                ty: ctx.prim(Primitive::Num),
+                ty: Type::Prim(Primitive::Num),
             },
             types::TProp {
                 name: String::from("bar"),
                 optional: true,
                 mutable: false,
-                ty: ctx.prim(Primitive::Bool),
+                ty: Type::Prim(Primitive::Bool),
             },
             // It's okay for qux to not appear in the subtype since
             // it's an optional property.
@@ -582,7 +581,7 @@ mod tests {
                 name: String::from("qux"),
                 optional: true,
                 mutable: false,
-                ty: ctx.prim(Primitive::Str),
+                ty: Type::Prim(Primitive::Str),
             },
         ]);
 
@@ -596,7 +595,7 @@ mod tests {
     fn failure_case() {
         let ctx = Context::default();
 
-        let result = unify(&ctx.prim(Primitive::Num), &ctx.lit(num("5")), &ctx);
+        let result = unify(&Type::Prim(Primitive::Num), &ctx.lit(num("5")), &ctx);
 
         assert_eq!(result, Err(String::from("Unification failure")))
     }


### PR DESCRIPTION
`fresh_var()` and `fresh_id()` are the only builder methods that need to appear on `Context`.