### PR TITLE
Update WasmPackPlugin to watch all crates

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,13 @@ module.exports = {
     }),
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "./crates/crochet"),
+      watchDirectories: [
+        path.resolve(__dirname, "./crates/crochet_ast/src"),
+        path.resolve(__dirname, "./crates/crochet_codegen/src"),
+        path.resolve(__dirname, "./crates/crochet_dst/src"),
+        path.resolve(__dirname, "./crates/crochet_infer/src"),
+        path.resolve(__dirname, "./crates/crochet_parser/src"),
+      ],
     }),
   ],
   module: {


### PR DESCRIPTION
This still requires making a change to a .ts(x) file in demo/ before the changes will appear in the browser, but at least the .wasm bundle is being rebuilt in response to changes in the crates' source code now.