### PR TITLE
Remove crochet_ast dep from crochet_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
 name = "crochet_ast"
 version = "0.1.0"
 dependencies = [
+ "crochet_types",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -269,7 +270,6 @@ name = "crochet_types"
 version = "0.1.0"
 dependencies = [
  "chumsky",
- "crochet_ast",
  "insta",
  "itertools",
  "pretty_assertions",

--- a/crates/crochet_ast/Cargo.toml
+++ b/crates/crochet_ast/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crochet_types = { version = "0.1.0", path = "../crochet_types" }
 # TODO: hide these behind a feature and then only use that feature in the codegen crate
 swc_atoms = "0.3.1"
 swc_common = "0.26.0"

--- a/crates/crochet_ast/src/expr.rs
+++ b/crates/crochet_ast/src/expr.rs
@@ -1,9 +1,9 @@
 use crate::ident::Ident;
 use crate::jsx::JSXElement;
-use crate::literal::Lit;
+use crate::lit::Lit;
 use crate::pattern::Pattern;
 use crate::span::Span;
-use crate::types::{TypeAnn, TypeParam};
+use crate::type_ann::{TypeAnn, TypeParam};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Program {

--- a/crates/crochet_ast/src/jsx.rs
+++ b/crates/crochet_ast/src/jsx.rs
@@ -1,6 +1,6 @@
 use crate::expr::Expr;
 use crate::ident::Ident;
-use crate::literal::Lit;
+use crate::lit::Lit;
 use crate::span::Span;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_ast/src/lib.rs
+++ b/crates/crochet_ast/src/lib.rs
@@ -1,17 +1,17 @@
 pub mod expr;
 pub mod ident;
 pub mod jsx;
-pub mod literal;
+pub mod lit;
 pub mod pattern;
-pub mod span;
-pub mod types;
 pub mod prim;
+pub mod span;
+pub mod type_ann;
 
 pub use expr::*;
 pub use ident::*;
 pub use jsx::*;
-pub use literal::*;
+pub use lit::*;
 pub use pattern::*;
-pub use span::*;
-pub use types::*;
 pub use prim::*;
+pub use span::*;
+pub use type_ann::*;

--- a/crates/crochet_ast/src/lit.rs
+++ b/crates/crochet_ast/src/lit.rs
@@ -1,8 +1,9 @@
-use swc_atoms::{JsWord, Atom};
+use std::fmt;
+use swc_atoms::{Atom, JsWord};
 use swc_common::source_map::DUMMY_SP;
 use swc_ecma_ast;
 
-use std::fmt;
+use crochet_types::{TLit, Type};
 
 use crate::span::Span;
 
@@ -125,6 +126,18 @@ impl From<&Lit> for swc_ecma_ast::Expr {
     }
 }
 
+impl From<Lit> for Type {
+    fn from(lit: Lit) -> Self {
+        Type::Lit(match lit {
+            Lit::Num(n) => TLit::Num(n.value),
+            Lit::Bool(b) => TLit::Bool(b.value),
+            Lit::Str(s) => TLit::Str(s.value),
+            Lit::Null(_) => TLit::Null,
+            Lit::Undefined(_) => TLit::Undefined,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,14 +167,14 @@ mod tests {
 
     #[test]
     fn null() {
-        let null = Lit::Null(Null { span: 0..4});
+        let null = Lit::Null(Null { span: 0..4 });
         assert_eq!(format!("{}", null), "null");
         assert_eq!(null.span(), 0..4);
     }
 
     #[test]
     fn undefined() {
-        let undefined = Lit::Undefined(Undefined { span: 0..9});
+        let undefined = Lit::Undefined(Undefined { span: 0..9 });
         assert_eq!(format!("{}", undefined), "undefined");
         assert_eq!(undefined.span(), 0..9);
     }

--- a/crates/crochet_ast/src/prim.rs
+++ b/crates/crochet_ast/src/prim.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::hash::Hash;
 
+use crochet_types::{TPrim, Type};
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Primitive {
     Num,
@@ -19,5 +21,17 @@ impl fmt::Display for Primitive {
             Primitive::Null => write!(f, "null"),
             Primitive::Undefined => write!(f, "undefined"),
         }
+    }
+}
+
+impl From<Primitive> for Type {
+    fn from(prim: Primitive) -> Self {
+        Type::Prim(match prim {
+            Primitive::Num => TPrim::Num,
+            Primitive::Bool => TPrim::Bool,
+            Primitive::Str => TPrim::Str,
+            Primitive::Null => TPrim::Null,
+            Primitive::Undefined => TPrim::Undefined,
+        })
     }
 }

--- a/crates/crochet_ast/src/type_ann.rs
+++ b/crates/crochet_ast/src/type_ann.rs
@@ -1,6 +1,6 @@
 use crate::expr::EFnParamPat;
 use crate::ident::Ident;
-use crate::literal::Lit;
+use crate::lit::Lit;
 use crate::pattern::{BindingIdent, RestPat};
 use crate::prim::Primitive;
 use crate::span::Span;
@@ -32,12 +32,6 @@ pub struct PrimType {
     pub span: Span,
     pub prim: Primitive,
 }
-
-// #[derive(Clone, Debug, PartialEq, Eq)]
-// pub struct LitType {
-//     pub span: Span,
-//     pub lit: Lit,
-// }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeRef {

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -417,11 +417,11 @@ pub fn build_type(
         }
         Type::Prim(prim) => {
             let kind = match prim {
-                types::Primitive::Num => TsKeywordTypeKind::TsNumberKeyword,
-                types::Primitive::Bool => TsKeywordTypeKind::TsBooleanKeyword,
-                types::Primitive::Str => TsKeywordTypeKind::TsStringKeyword,
-                types::Primitive::Undefined => TsKeywordTypeKind::TsUndefinedKeyword,
-                types::Primitive::Null => TsKeywordTypeKind::TsNullKeyword,
+                types::TPrim::Num => TsKeywordTypeKind::TsNumberKeyword,
+                types::TPrim::Bool => TsKeywordTypeKind::TsBooleanKeyword,
+                types::TPrim::Str => TsKeywordTypeKind::TsStringKeyword,
+                types::TPrim::Undefined => TsKeywordTypeKind::TsUndefinedKeyword,
+                types::TPrim::Null => TsKeywordTypeKind::TsNullKeyword,
             };
 
             TsType::TsKeywordType(TsKeywordType {
@@ -431,16 +431,16 @@ pub fn build_type(
         }
         Type::Lit(lit) => {
             let lit = match lit {
-                types::Lit::Num(n) => TsLit::Number(Number {
+                types::TLit::Num(n) => TsLit::Number(Number {
                     span: DUMMY_SP,
                     value: n.parse().unwrap(),
                     raw: Some(Atom::new(n.to_owned())),
                 }),
-                types::Lit::Bool(b) => TsLit::Bool(Bool {
+                types::TLit::Bool(b) => TsLit::Bool(Bool {
                     span: DUMMY_SP,
                     value: b.to_owned(),
                 }),
-                types::Lit::Str(s) => TsLit::Str(Str {
+                types::TLit::Str(s) => TsLit::Str(Str {
                     span: DUMMY_SP,
                     value: JsWord::from(s.clone()),
                     raw: None,
@@ -457,7 +457,7 @@ pub fn build_type(
                 lit,
             })
         }
-        Type::App(types::AppType { args, ret, .. }) => {
+        Type::App(types::TApp { args, ret, .. }) => {
             // This can happen when a function type is inferred by usage
             match expr {
                 // TODO: handle is_async
@@ -495,7 +495,7 @@ pub fn build_type(
         }
         // This is used to copy the names of args from the expression
         // over to the lambda's type.
-        Type::Lam(types::LamType { params, ret, .. }) => {
+        Type::Lam(types::TLam { params, ret, .. }) => {
             match expr {
                 // TODO: handle is_async
                 Some(ast::Expr::Lambda(other_lam)) => {
@@ -578,7 +578,7 @@ pub fn build_type(
                 members,
             })
         }
-        Type::Alias(types::AliasType {
+        Type::Alias(types::TAlias {
             name, type_params, ..
         }) => TsType::TsTypeRef(TsTypeRef {
             span: DUMMY_SP,

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -8,9 +8,9 @@ use swc_ecma_parser::{error::Error, parse_file_as_module, Syntax, TsConfig};
 use swc_ecma_visit::*;
 
 // TODO: have crochet_infer re-export Lit
-use crochet_ast::{Lit, Primitive};
+use crochet_ast::Lit;
 use crochet_infer::Context;
-use crochet_types::{self as types, RestPat, Scheme, TFnParam, TPat, TProp, Type};
+use crochet_types::{self as types, RestPat, Scheme, TFnParam, TPat, TPrim, TProp, Type};
 
 type Interface = Vec<TProp>;
 
@@ -34,15 +34,15 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
         TsType::TsKeywordType(keyword) => match &keyword.kind {
             TsKeywordTypeKind::TsAnyKeyword => ctx.fresh_var(),
             TsKeywordTypeKind::TsUnknownKeyword => todo!(),
-            TsKeywordTypeKind::TsNumberKeyword => Type::Prim(Primitive::Num),
+            TsKeywordTypeKind::TsNumberKeyword => Type::Prim(TPrim::Num),
             TsKeywordTypeKind::TsObjectKeyword => todo!(),
-            TsKeywordTypeKind::TsBooleanKeyword => Type::Prim(Primitive::Bool),
+            TsKeywordTypeKind::TsBooleanKeyword => Type::Prim(TPrim::Bool),
             TsKeywordTypeKind::TsBigIntKeyword => todo!(),
-            TsKeywordTypeKind::TsStringKeyword => Type::Prim(Primitive::Str),
+            TsKeywordTypeKind::TsStringKeyword => Type::Prim(TPrim::Str),
             TsKeywordTypeKind::TsSymbolKeyword => todo!(),
             TsKeywordTypeKind::TsVoidKeyword => todo!(),
-            TsKeywordTypeKind::TsUndefinedKeyword => Type::Prim(Primitive::Undefined),
-            TsKeywordTypeKind::TsNullKeyword => Type::Prim(Primitive::Null),
+            TsKeywordTypeKind::TsUndefinedKeyword => Type::Prim(TPrim::Undefined),
+            TsKeywordTypeKind::TsNullKeyword => Type::Prim(TPrim::Null),
             TsKeywordTypeKind::TsNeverKeyword => todo!(),
             TsKeywordTypeKind::TsIntrinsicKeyword => todo!(),
         },
@@ -95,7 +95,7 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     })
                     .collect();
                 let ret = infer_ts_type_ann(&fn_type.type_ann.type_ann, ctx);
-                Type::Lam(types::LamType {
+                Type::Lam(types::TLam {
                     params,
                     ret: Box::from(ret),
                 })
@@ -118,7 +118,7 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Type {
                     .map(|t| infer_ts_type_ann(t, ctx))
                     .collect()
             });
-            Type::Alias(types::AliasType { name, type_params })
+            Type::Alias(types::TAlias { name, type_params })
         }
         TsType::TsTypeQuery(_) => todo!(),
         TsType::TsTypeLit(_) => todo!(),
@@ -287,7 +287,7 @@ impl InterfaceCollector {
             None => panic!("method has no return type"),
         };
         // TODO: maintain param names
-        Type::Lam(types::LamType {
+        Type::Lam(types::TLam {
             params,
             ret: Box::from(ret),
         })

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -52,7 +52,7 @@ impl Context {
         Ok(self.instantiate(scheme))
     }
 
-    pub fn lookup_alias(&self, alias: &AliasType) -> Result<Type, String> {
+    pub fn lookup_alias(&self, alias: &TAlias) -> Result<Type, String> {
         match self.types.get(&alias.name) {
             Some(scheme) => {
                 // Replaces qualifiers in the scheme with the corresponding type params

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crochet_ast::*;
-use crochet_types::{self as types, Scheme, TFnParam, TPat, Type};
+use crochet_types::{self as types, Scheme, TFnParam, TPat, TPrim, Type};
 
 use super::context::Context;
 use super::infer_type_ann::*;
@@ -44,7 +44,7 @@ pub fn infer_fn_param(
                 match a.iter().find(|(_, value)| type_ann_ty == value.ty) {
                     Some((name, scheme)) => {
                         let mut scheme = scheme.to_owned();
-                        scheme.ty = Type::Union(vec![scheme.ty, Type::Prim(Primitive::Undefined)]);
+                        scheme.ty = Type::Union(vec![scheme.ty, Type::Prim(TPrim::Undefined)]);
                         a.insert(name.to_owned(), scheme);
                     }
                     None => (),
@@ -67,7 +67,7 @@ pub fn infer_fn_param(
                 match new_vars.iter().find(|(_, value)| pat_type == value.ty) {
                     Some((name, scheme)) => {
                         let mut scheme = scheme.to_owned();
-                        scheme.ty = Type::Union(vec![scheme.ty, Type::Prim(Primitive::Undefined)]);
+                        scheme.ty = Type::Union(vec![scheme.ty, Type::Prim(TPrim::Undefined)]);
                         new_vars.insert(name.to_owned(), scheme);
                     }
                     None => (),

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -65,13 +65,13 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
         Pattern::Lit(LitPat { lit, .. }) => Ok(Type::from(lit.to_owned())),
         Pattern::Is(IsPat { id, is_id, .. }) => {
             let ty = match is_id.name.as_str() {
-                "string" => Type::Prim(types::Primitive::Str),
-                "number" => Type::Prim(types::Primitive::Num),
-                "boolean" => Type::Prim(types::Primitive::Bool),
+                "string" => Type::Prim(types::TPrim::Str),
+                "number" => Type::Prim(types::TPrim::Num),
+                "boolean" => Type::Prim(types::TPrim::Bool),
                 // The alias type will be used for `instanceof` of checks, but
                 // only if the definition of the alias is an object type with a
                 // `constructor` method.
-                name => Type::Alias(types::AliasType {
+                name => Type::Alias(types::TAlias {
                     name: name.to_owned(),
                     type_params: None,
                 }),

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -78,10 +78,10 @@ fn infer_type_ann_rec(
                 })
                 .collect();
             let ret = Box::from(infer_type_ann_rec(ret.as_ref(), ctx, type_param_map));
-            Type::Lam(types::LamType { params, ret })
+            Type::Lam(types::TLam { params, ret })
         }
         TypeAnn::Lit(lit) => Type::from(lit.to_owned()),
-        TypeAnn::Prim(PrimType { prim, .. }) => Type::Prim(prim.to_owned()),
+        TypeAnn::Prim(PrimType { prim, .. }) => Type::from(prim.to_owned()),
         TypeAnn::Object(ObjectType { props, .. }) => {
             let props: Vec<_> = props
                 .iter()
@@ -105,7 +105,7 @@ fn infer_type_ann_rec(
                         .map(|param| infer_type_ann_rec(param, ctx, type_param_map))
                         .collect()
                 });
-                Type::Alias(types::AliasType {
+                Type::Alias(types::TAlias {
                     name: name.to_owned(),
                     type_params,
                 })

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -19,12 +19,12 @@ impl Substitutable for Type {
                 Some(replacement) => replacement.to_owned(),
                 None => self.to_owned(),
             },
-            Type::App(app) => Type::App(AppType {
+            Type::App(app) => Type::App(TApp {
                 args: app.args.iter().map(|param| param.apply(sub)).collect(),
                 ret: Box::from(app.ret.apply(sub)),
             }),
             // TODO: handle widening of lambdas
-            Type::Lam(lam) => Type::Lam(LamType {
+            Type::Lam(lam) => Type::Lam(TLam {
                 params: lam.params.iter().map(|param| param.apply(sub)).collect(),
                 ret: Box::from(lam.ret.apply(sub)),
             }),
@@ -34,7 +34,7 @@ impl Substitutable for Type {
             Type::Union(types) => Type::Union(types.apply(sub)),
             Type::Intersection(types) => Type::Intersection(types.apply(sub)),
             Type::Object(props) => Type::Object(props.apply(sub)),
-            Type::Alias(alias) => Type::Alias(AliasType {
+            Type::Alias(alias) => Type::Alias(TAlias {
                 type_params: alias.type_params.apply(sub),
                 ..alias.to_owned()
             }),
@@ -47,12 +47,12 @@ impl Substitutable for Type {
     fn ftv(&self) -> HashSet<i32> {
         match &self {
             Type::Var(id) => HashSet::from([id.to_owned()]),
-            Type::App(AppType { args, ret }) => {
+            Type::App(TApp { args, ret }) => {
                 let mut result: HashSet<_> = args.ftv();
                 result.extend(ret.ftv());
                 result
             }
-            Type::Lam(LamType { params, ret, .. }) => {
+            Type::Lam(TLam { params, ret, .. }) => {
                 let mut result: HashSet<_> = params.ftv();
                 result.extend(ret.ftv());
                 result
@@ -63,7 +63,7 @@ impl Substitutable for Type {
             Type::Union(types) => types.ftv(),
             Type::Intersection(types) => types.ftv(),
             Type::Object(props) => props.ftv(),
-            Type::Alias(AliasType { type_params, .. }) => type_params.ftv(),
+            Type::Alias(TAlias { type_params, .. }) => type_params.ftv(),
             Type::Tuple(types) => types.ftv(),
             Type::Array(t) => t.ftv(),
             Type::Rest(arg) => arg.ftv(),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -1,8 +1,7 @@
 use std::cmp;
 use std::collections::HashSet;
 
-use crochet_ast::Primitive;
-use crochet_types::{self as types, TFnParam, Type};
+use crochet_types::{self as types, TFnParam, TPrim, Type};
 
 use super::context::Context;
 use super::substitutable::{Subst, Substitutable};
@@ -18,9 +17,9 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         (Type::Lit(lit), Type::Prim(prim)) => {
             let b = matches!(
                 (lit, prim),
-                (types::Lit::Num(_), Primitive::Num)
-                    | (types::Lit::Str(_), Primitive::Str)
-                    | (types::Lit::Bool(_), Primitive::Bool)
+                (types::TLit::Num(_), TPrim::Num)
+                    | (types::TLit::Str(_), TPrim::Str)
+                    | (types::TLit::Bool(_), TPrim::Bool)
             );
             if b {
                 Ok(Subst::default())
@@ -185,7 +184,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         };
                     }
 
-                    let partial_ret = Type::Lam(types::LamType {
+                    let partial_ret = Type::Lam(types::TLam {
                         params: partial_params,
                         ret: lam.ret.clone(),
                     });
@@ -534,13 +533,13 @@ mod tests {
     fn literals_are_subtypes_of_corresponding_primitives() {
         let ctx = Context::default();
 
-        let result = unify(&Type::from(num("5")), &Type::Prim(Primitive::Num), &ctx);
+        let result = unify(&Type::from(num("5")), &Type::Prim(TPrim::Num), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&Type::from(str("hello")), &Type::Prim(Primitive::Str), &ctx);
+        let result = unify(&Type::from(str("hello")), &Type::Prim(TPrim::Str), &ctx);
         assert_eq!(result, Ok(Subst::default()));
 
-        let result = unify(&Type::from(bool(&true)), &Type::Prim(Primitive::Bool), &ctx);
+        let result = unify(&Type::from(bool(&true)), &Type::Prim(TPrim::Bool), &ctx);
         assert_eq!(result, Ok(Subst::default()));
     }
 
@@ -566,7 +565,7 @@ mod tests {
                 name: String::from("baz"),
                 optional: false,
                 mutable: false,
-                ty: Type::Prim(Primitive::Str),
+                ty: Type::Prim(TPrim::Str),
             },
         ]);
 
@@ -575,13 +574,13 @@ mod tests {
                 name: String::from("foo"),
                 optional: false,
                 mutable: false,
-                ty: Type::Prim(Primitive::Num),
+                ty: Type::Prim(TPrim::Num),
             },
             types::TProp {
                 name: String::from("bar"),
                 optional: true,
                 mutable: false,
-                ty: Type::Prim(Primitive::Bool),
+                ty: Type::Prim(TPrim::Bool),
             },
             // It's okay for qux to not appear in the subtype since
             // it's an optional property.
@@ -589,7 +588,7 @@ mod tests {
                 name: String::from("qux"),
                 optional: true,
                 mutable: false,
-                ty: Type::Prim(Primitive::Str),
+                ty: Type::Prim(TPrim::Str),
             },
         ]);
 
@@ -603,7 +602,7 @@ mod tests {
     fn failure_case() {
         let ctx = Context::default();
 
-        let result = unify(&Type::Prim(Primitive::Num), &Type::from(num("5")), &ctx);
+        let result = unify(&Type::Prim(TPrim::Num), &Type::from(num("5")), &ctx);
 
         assert_eq!(result, Err(String::from("Unification failure")))
     }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -29,7 +29,7 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     .map(|arg| norm_type(arg, mapping, ctx))
                     .collect();
                 let ret = Box::from(norm_type(&app.ret, mapping, ctx));
-                Type::App(AppType { args, ret })
+                Type::App(TApp { args, ret })
             }
             Type::Lam(lam) => {
                 let params: Vec<_> = lam
@@ -41,7 +41,7 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     })
                     .collect();
                 let ret = Box::from(norm_type(&lam.ret, mapping, ctx));
-                Type::Lam(LamType { params, ret })
+                Type::Lam(TLam { params, ret })
             }
             Type::Wildcard => ty.to_owned(),
             Type::Prim(_) => ty.to_owned(),
@@ -72,14 +72,14 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                     .collect();
                 Type::Object(props)
             }
-            Type::Alias(AliasType { name, type_params }) => {
+            Type::Alias(TAlias { name, type_params }) => {
                 let type_params = type_params.clone().map(|params| {
                     params
                         .iter()
                         .map(|ty| norm_type(ty, mapping, ctx))
                         .collect()
                 });
-                Type::Alias(AliasType {
+                Type::Alias(TAlias {
                     name: name.to_owned(),
                     type_params,
                 })
@@ -201,11 +201,11 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         .filter(|ty| match &ty {
             // Primitive types subsume corresponding literal types
             Type::Lit(lit) => match lit {
-                Lit::Num(_) => !prim_types.contains(&Type::Prim(Primitive::Num)),
-                Lit::Bool(_) => !prim_types.contains(&Type::Prim(Primitive::Bool)),
-                Lit::Str(_) => !prim_types.contains(&Type::Prim(Primitive::Str)),
-                Lit::Null => !prim_types.contains(&Type::Prim(Primitive::Null)),
-                Lit::Undefined => !prim_types.contains(&Type::Prim(Primitive::Undefined)),
+                TLit::Num(_) => !prim_types.contains(&Type::Prim(TPrim::Num)),
+                TLit::Bool(_) => !prim_types.contains(&Type::Prim(TPrim::Bool)),
+                TLit::Str(_) => !prim_types.contains(&Type::Prim(TPrim::Str)),
+                TLit::Null => !prim_types.contains(&Type::Prim(TPrim::Null)),
+                TLit::Undefined => !prim_types.contains(&Type::Prim(TPrim::Undefined)),
             },
             _ => false,
         })

--- a/crates/crochet_types/Cargo.toml
+++ b/crates/crochet_types/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 chumsky = "0.8.0"
-crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 itertools = "0.10.3"
 
 [dev-dependencies]

--- a/crates/crochet_types/src/lib.rs
+++ b/crates/crochet_types/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod lit;
+pub mod prim;
 pub mod scheme;
 pub mod r#type;
 
-pub use crochet_ast::Primitive;
 pub use lit::*;
+pub use prim::*;
 pub use r#type::*;
 pub use scheme::*;

--- a/crates/crochet_types/src/lit.rs
+++ b/crates/crochet_types/src/lit.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::Hash;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Lit {
+pub enum TLit {
     // We store all of the values as strings since f64 doesn't
     // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.
     Num(String),
@@ -12,14 +12,14 @@ pub enum Lit {
     Undefined,
 }
 
-impl fmt::Display for Lit {
+impl fmt::Display for TLit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Lit::Num(n) => write!(f, "{}", n),
-            Lit::Bool(b) => write!(f, "{}", b),
-            Lit::Str(s) => write!(f, "\"{}\"", s),
-            Lit::Null => write!(f, "null"),
-            Lit::Undefined => write!(f, "undefined"),
+            TLit::Num(n) => write!(f, "{}", n),
+            TLit::Bool(b) => write!(f, "{}", b),
+            TLit::Str(s) => write!(f, "\"{}\"", s),
+            TLit::Null => write!(f, "null"),
+            TLit::Undefined => write!(f, "undefined"),
         }
     }
 }

--- a/crates/crochet_types/src/prim.rs
+++ b/crates/crochet_types/src/prim.rs
@@ -1,0 +1,23 @@
+use std::fmt;
+use std::hash::Hash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TPrim {
+    Num,
+    Bool,
+    Str,
+    Undefined,
+    Null,
+}
+
+impl fmt::Display for TPrim {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TPrim::Num => write!(f, "number",),
+            TPrim::Bool => write!(f, "boolean"),
+            TPrim::Str => write!(f, "string"),
+            TPrim::Null => write!(f, "null"),
+            TPrim::Undefined => write!(f, "undefined"),
+        }
+    }
+}


### PR DESCRIPTION
This is necessary in order for us to add `inferred_type` fields to AST nodes in `crochet_ast`, otherwise there'd be a cyclic dependency between crates which isn't allowed.

This PR also renames a few structs to make it easier to differentiate between structs from `crochet_ast` and `crochet_types`.