### PR TITLE
Add multiple scopes to Context

### DIFF
--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -333,7 +333,7 @@ pub fn parse_dts(d_ts_source: &str) -> Result<Context, Error> {
 
     for name in collector.interfaces.keys() {
         let t = collector.get_interface(name);
-        collector.ctx.types.insert(name.to_owned(), Scheme::from(t));
+        collector.ctx.insert_type(name.to_owned(), Scheme::from(t));
     }
 
     Ok(collector.ctx)

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -32,6 +32,6 @@ fn infer_adding_variables() {
     let len = msg.length.toString() // radix is optional
     "#;
     let (_, ctx) = infer_prog(src);
-    let result = format!("{}", ctx.values.get("len").unwrap());
+    let result = format!("{}", ctx.lookup_value_scheme("len").unwrap());
     assert_eq!(result, "string");
 }

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -19,7 +19,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
         mutable: false,
         ty: Type::from(Lit::str(String::from("Promise"), 0..0)),
     }]));
-    ctx.types.insert(String::from("Promise"), promise_scheme);
+    ctx.insert_type(String::from("Promise"), promise_scheme);
     // TODO: replace with Class type once it exists
     // We use {_name: "JSXElement"} to differentiate it from other
     // object types.
@@ -29,8 +29,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
         mutable: false,
         ty: Type::from(Lit::str(String::from("JSXElement"), 0..0)),
     }]));
-    ctx.types
-        .insert(String::from("JSXElement"), jsx_element_scheme);
+    ctx.insert_type(String::from("JSXElement"), jsx_element_scheme);
 
     // TODO: figure out how report multiple errors
     for stmt in &prog.body {
@@ -49,7 +48,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
                                 match type_ann {
                                     Some(type_ann) => {
                                         let scheme = infer_scheme(type_ann, ctx);
-                                        ctx.values.insert(id.name.to_owned(), scheme);
+                                        ctx.insert_value(id.name.to_owned(), scheme);
                                     }
                                     None => {
                                         // A type annotation should always be provided when using `declare`
@@ -79,7 +78,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
                         // current context.
                         for (name, scheme) in pa {
                             let scheme = normalize(&scheme.apply(&s), ctx);
-                            ctx.values.insert(name, scheme);
+                            ctx.insert_value(name, scheme);
                         }
                     }
                 };
@@ -91,7 +90,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
                 ..
             } => {
                 let scheme = infer_scheme_with_type_params(type_ann, type_params, ctx);
-                ctx.types.insert(id.name.to_owned(), scheme);
+                ctx.insert_type(id.name.to_owned(), scheme);
             }
             Statement::Expr { expr, .. } => {
                 // We ignore the type that was inferred, we only care that

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -215,13 +215,12 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             type_params,
             ..
         }) => {
-            let mut new_ctx = ctx.clone();
-            new_ctx.is_async = is_async.to_owned();
+            ctx.push_scope(is_async.to_owned());
 
             let type_params_map: HashMap<String, Type> = match type_params {
                 Some(params) => params
                     .iter()
-                    .map(|param| (param.name.name.to_owned(), new_ctx.fresh_var()))
+                    .map(|param| (param.name.name.to_owned(), ctx.fresh_var()))
                     .collect(),
                 None => HashMap::default(),
             };
@@ -229,12 +228,12 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             let params: Result<Vec<(Subst, TFnParam)>, String> = params
                 .iter()
                 .map(|e_param| {
-                    let (ps, pa, t_param) = infer_fn_param(e_param, &new_ctx, &type_params_map)?;
+                    let (ps, pa, t_param) = infer_fn_param(e_param, ctx, &type_params_map)?;
 
                     // Inserts any new variables introduced by infer_fn_param() into
                     // the current context.
                     for (name, scheme) in pa {
-                        new_ctx.insert_value(name, scheme);
+                        ctx.insert_value(name, scheme);
                     }
 
                     Ok((ps, t_param))
@@ -243,10 +242,9 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
             let (ss, t_params): (Vec<_>, Vec<_>) = params?.iter().cloned().unzip();
 
-            let (rs, rt) = infer_expr(&mut new_ctx, body)?;
+            let (rs, rt) = infer_expr(ctx, body)?;
 
-            // Copies over the count from new_ctx so that it's unique across Contexts.
-            ctx.state.count.set(new_ctx.state.count.get());
+            ctx.pop_scope();
 
             let rt = if *is_async && !is_promise(&rt) {
                 Type::Alias(types::TAlias {
@@ -381,7 +379,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             }
         }
         Expr::Await(Await { expr, .. }) => {
-            if !ctx.is_async {
+            if !ctx.is_async() {
                 return Err(String::from("Can't use `await` inside non-async lambda"));
             }
 
@@ -500,22 +498,22 @@ fn infer_let(
     type_ann: &Option<TypeAnn>,
     init: &Expr,
     body: &Expr,
-    ctx: &Context,
+    ctx: &mut Context,
     pu: &PatternUsage,
 ) -> Result<(Subst, Type), String> {
-    let mut new_ctx = ctx.clone();
-    let (pa, s1) = infer_pattern_and_init(pat, type_ann, init, &mut new_ctx, pu)?;
+    ctx.push_scope(ctx.is_async());
+    let (pa, s1) = infer_pattern_and_init(pat, type_ann, init, ctx, pu)?;
 
     // Inserts the new variables from infer_pattern_and_init() into the
     // current context.
+    // TODO: have infer_pattern_and_init do this
     for (name, scheme) in pa {
-        new_ctx.insert_value(name.to_owned(), scheme.to_owned());
+        ctx.insert_value(name.to_owned(), scheme.to_owned());
     }
 
-    let (s2, t2) = infer_expr(&mut new_ctx, body)?;
+    let (s2, t2) = infer_expr(ctx, body)?;
 
-    // Copies over the count from new_ctx so that it's unique across Contexts.
-    ctx.state.count.set(new_ctx.state.count.get());
+    ctx.pop_scope();
 
     let s = compose_subs(&s2, &s1);
     let t = t2;

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -76,7 +76,10 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
                     type_params: None,
                 }),
             };
-            let scheme = generalize(&ctx.types, &ty);
+            // TODO: we need a method on Context to get all types that currently in
+            // scope so that we can pass them to generalize()
+            let all_types = ctx.get_all_types();
+            let scheme = generalize(&all_types, &ty);
             if assump.insert(id.name.to_owned(), scheme).is_some() {
                 return Err(String::from("Duplicate identifier in pattern"));
             }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -33,9 +33,9 @@ mod tests {
     }
 
     fn get_type(name: &str, ctx: &Context) -> String {
-        match ctx.values.get(name) {
-            Some(t) => format!("{t}"),
-            None => panic!("Couldn't find type with name '{name}'"),
+        match ctx.lookup_value_scheme(name) {
+            Ok(t) => format!("{t}"),
+            Err(_) => panic!("Couldn't find type with name '{name}'"),
         }
     }
 
@@ -350,8 +350,8 @@ mod tests {
 
         assert_eq!(get_type("a", &ctx), "5");
         assert_eq!(get_type("b", &ctx), "10");
-        assert_eq!(ctx.values.get("x"), None);
-        assert_eq!(ctx.values.get("y"), None);
+        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value_scheme("y").is_err());
     }
 
     #[test]
@@ -365,8 +365,8 @@ mod tests {
     fn nested_destructure_obj() {
         let ctx = infer_prog("let {a: {b: {c}}} = {a: {b: {c: \"hello\"}}}");
 
-        assert_eq!(ctx.values.get("a"), None);
-        assert_eq!(ctx.values.get("b"), None);
+        assert!(ctx.lookup_value_scheme("a").is_err());
+        assert!(ctx.lookup_value_scheme("b").is_err());
         assert_eq!(get_type("c", &ctx), "\"hello\"");
     }
 
@@ -486,7 +486,7 @@ mod tests {
         "#;
         let ctx = infer_prog(src);
 
-        let x = format!("{}", ctx.values.get("x").unwrap());
+        let x = format!("{}", ctx.lookup_value_scheme("x").unwrap());
         assert_eq!(x, "number | undefined");
     }
 
@@ -552,8 +552,8 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
-        assert!(ctx.values.get("y").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value_scheme("y").is_err());
     }
 
     #[test]
@@ -600,8 +600,8 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "0 | 1 | 5");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
-        assert!(ctx.values.get("y").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value_scheme("y").is_err());
     }
 
     #[test]
@@ -640,7 +640,7 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
     }
 
     #[test]
@@ -661,8 +661,8 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number | string | true");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
-        assert!(ctx.values.get("y").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value_scheme("y").is_err());
     }
 
     #[test]
@@ -694,7 +694,7 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
     }
 
     #[test]
@@ -749,7 +749,7 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
     }
 
     #[test]
@@ -770,7 +770,7 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number | string | true");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
     }
 
     #[test]
@@ -819,8 +819,8 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.values.get("x").is_none());
-        assert!(ctx.values.get("y").is_none());
+        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value_scheme("y").is_err());
     }
 
     // TODO: handle refutable patterns in if-else
@@ -848,7 +848,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert_eq!(ctx.values.get("_"), None);
+        assert!(ctx.lookup_value_scheme("_").is_err());
     }
 
     #[test]
@@ -2117,7 +2117,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Component 'Bar' is not in scope"]
+    #[should_panic = "Can't find type: Bar"]
     fn jsx_custom_element_not_found() {
         let src = r#"
         let Foo = () => <div>Hello, world!</div>


### PR DESCRIPTION
Having a vector of `Scope`s within the `Context` struct will allow us to track which symbols were added to which scopes.  This information will help us to determine which symbols were added by a module as opposed to being in scope because they were imported from another module or because they're globals.