### PR TITLE
Remove partial application

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -550,7 +550,6 @@ pub fn build_type(ty: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             elem_type: Box::from(build_type(t, None)),
         }),
         Type::Rest(_) => todo!(),
-        Type::Wildcard => todo!(),
     }
 }
 

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -346,7 +346,6 @@ fn replace_aliases(t: &Type, map: &HashMap<String, Type>) -> Type {
                 .collect(),
             ret: Box::from(replace_aliases(ret, map)),
         }),
-        Type::Wildcard => t.to_owned(),
         Type::Prim(_) => t.to_owned(),
         Type::Lit(_) => t.to_owned(),
         Type::Keyword(_) => t.to_owned(),

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -82,11 +82,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
         }
         Expr::Ident(Ident { name, .. }) => {
             let s = Subst::default();
-            let t = if name == "_" {
-                Type::Wildcard
-            } else {
-                ctx.lookup_value_and_instantiate(name)?
-            };
+            let t = ctx.lookup_value_and_instantiate(name)?;
             Ok((s, t))
         }
         Expr::IfElse(IfElse {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1162,84 +1162,6 @@ mod tests {
     }
 
     #[test]
-    fn call_partially_applied_fn_immediately() {
-        let src = r#"
-        declare let add: (a: number, b: number) => number
-        let sum = add(5, _)(10)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("sum", &ctx), "number");
-    }
-
-    #[test]
-    fn partially_apply_first_param() {
-        let src = r#"
-        declare let foo: (a: number, b: string) => bool
-        let foo_num = foo(5, _)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("foo_num", &ctx), "(b: string) => bool");
-    }
-
-    #[test]
-    fn partially_apply_second_param() {
-        let src = r#"
-        declare let foo: (a: number, b: string) => bool
-        let foo_str = foo(_, "hello")
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("foo_str", &ctx), "(a: number) => bool");
-    }
-
-    #[test]
-    fn partially_apply_multiple_params() {
-        let src = r#"
-        declare let foo: (a: number, b: string, c: bool) => undefined
-        let foo_bool = foo(5, "hello", _)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("foo_bool", &ctx), "(c: bool) => undefined");
-    }
-
-    #[test]
-    fn multiple_placeholders() {
-        let src = r#"
-        declare let foo: (a: number, b: string, c: bool) => undefined
-        let foo_num_bool = foo(_, "hello", _)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(
-            get_type("foo_num_bool", &ctx),
-            "(a: number, c: bool) => undefined"
-        );
-    }
-
-    #[test]
-    fn all_multiple_placeholders() {
-        let src = r#"
-        declare let foo: (a: number, b: string, c: bool) => undefined
-        let foo_num_str_bool = foo(_, _, _)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(
-            get_type("foo_num_str_bool", &ctx),
-            "(a: number, b: string, c: bool) => undefined"
-        );
-    }
-
-    #[test]
     fn pass_callback_with_too_few_params() {
         let src = r#"
         declare let fold_num: (cb: (a: number, b: number) => boolean, seed: number) => number
@@ -1334,33 +1256,6 @@ mod tests {
         let ctx = infer_prog(src);
 
         assert_eq!(get_type("result", &ctx), "number");
-    }
-
-    #[test]
-    fn spread_param_tuple_with_not_enough_elements_and_placeholder_is_partial_application() {
-        let src = r#"
-        declare let add: (a: number, b: number) => number
-        let args = [5]
-        let result1 = add(...args, _)
-        let result2 = add(_, ...args)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("result1", &ctx), "(b: number) => number");
-        assert_eq!(get_type("result2", &ctx), "(a: number) => number");
-    }
-
-    #[test]
-    fn partial_application_with_placeholder_rest() {
-        let src = r#"
-        declare let add: (a: number, b: number, c: number) => number
-        let add5 = add(5, ..._)
-        "#;
-
-        let ctx = infer_prog(src);
-
-        assert_eq!(get_type("add5", &ctx), "(b: number, c: number) => number");
     }
 
     #[test]

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -26,7 +26,6 @@ impl Substitutable for Type {
                 params: lam.params.iter().map(|param| param.apply(sub)).collect(),
                 ret: Box::from(lam.ret.apply(sub)),
             }),
-            Type::Wildcard => self.to_owned(),
             Type::Prim(_) => self.to_owned(),
             Type::Lit(_) => self.to_owned(),
             Type::Keyword(_) => self.to_owned(),
@@ -56,7 +55,6 @@ impl Substitutable for Type {
                 result.extend(ret.ftv());
                 result
             }
-            Type::Wildcard => HashSet::new(),
             Type::Prim(_) => HashSet::new(),
             Type::Lit(_) => HashSet::new(),
             Type::Keyword(_) => HashSet::new(),

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -43,7 +43,6 @@ pub fn normalize(sc: &Scheme, ctx: &Context) -> Scheme {
                 let ret = Box::from(norm_type(&lam.ret, mapping, ctx));
                 Type::Lam(TLam { params, ret })
             }
-            Type::Wildcard => ty.to_owned(),
             Type::Prim(_) => ty.to_owned(),
             Type::Lit(_) => ty.to_owned(),
             Type::Keyword(_) => ty.to_owned(),

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -261,7 +261,6 @@ pub enum Type {
     Var(i32), // i32 is the if of the type variable
     App(TApp),
     Lam(TLam),
-    Wildcard,
     // Query, // use for typed holes
     Prim(TPrim),
     Lit(TLit),
@@ -292,7 +291,6 @@ impl fmt::Display for Type {
             Type::Lam(TLam { params, ret, .. }) => {
                 write!(f, "({}) => {}", join(params, ", "), ret)
             }
-            Type::Wildcard => write!(f, "_"),
             Type::Prim(prim) => write!(f, "{}", prim),
             Type::Lit(lit) => write!(f, "{}", lit),
             Type::Keyword(keyword) => write!(f, "{}", keyword),

--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -10,7 +10,7 @@ type Crochet = typeof import("../crates/crochet/pkg");
 const DEFAULT_CODE = `
 // Welcome to the Crochet Playground!
 let add = (a, b) => a + b
-let add5 = add(5, _)
+let add5 = (b) => add(5, b)
 let sum = add5(10)
 `;
 
@@ -31,9 +31,11 @@ export const App = () => {
   }, []);
 
   React.useEffect(() => {
-    fetch(libPath).then(res => res.text()).then(text => {
-      setLib(text);
-    });
+    fetch(libPath)
+      .then((res) => res.text())
+      .then((text) => {
+        setLib(text);
+      });
   }, []);
 
   let output = React.useMemo(() => {


### PR DESCRIPTION
It adds a bunch of complexity without much value.  It's still possible to create partially applied functions without special syntax by creating a new function that calls an existing function, e.g.
```
let add = (a, b) => a + b
let add5 = (b) => 5 + b
```
