### PR TITLE
Start parsing tree-sitter CST to produce crochet AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crochet_tree_sitter_parser"
+version = "0.1.0"
+dependencies = [
+ "crochet_ast",
+ "insta",
+ "pretty_assertions",
+ "tree-sitter",
+ "tree_sitter_crochet",
+]
+
+[[package]]
 name = "crochet_types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,11 @@ version = "0.1.0"
 dependencies = [
  "crochet_ast",
  "insta",
+ "itertools",
  "pretty_assertions",
  "tree-sitter",
  "tree_sitter_crochet",
+ "unescape",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/crochet_dts",
     "crates/crochet_infer",
     "crates/crochet_parser",
-    "crates/tree_sitter_crochet",
+    "crates/crochet_tree_sitter_parser",
     "crates/crochet_types",
+    "crates/tree_sitter_crochet",
 ]

--- a/crates/crochet_ast/src/pattern.rs
+++ b/crates/crochet_ast/src/pattern.rs
@@ -3,8 +3,13 @@ use crate::ident::Ident;
 use crate::span::Span;
 use crate::Lit;
 
+// TODO: split this into separate patterns:
+// - one for assignment (obj, ident, array, rest)
+// - one for pattern matching/if let
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
+    // TODO: use Ident instead of BindingIdent, there's no need to
+    // have BindingIdent which simply wraps Ident
     Ident(BindingIdent),
     Rest(RestPat),
     Object(ObjectPat),

--- a/crates/crochet_tree_sitter_parser/Cargo.toml
+++ b/crates/crochet_tree_sitter_parser/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "crochet_tree_sitter_parser"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
+tree-sitter = "0.20.8"
+tree_sitter_crochet = { version = "0.1.0", path = "../tree_sitter_crochet" }
+
+[dev-dependencies]
+insta = "1.13.0"
+pretty_assertions = "1.2.1"

--- a/crates/crochet_tree_sitter_parser/Cargo.toml
+++ b/crates/crochet_tree_sitter_parser/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 
 [dependencies]
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
+itertools = "0.10.3"
 tree-sitter = "0.20.8"
 tree_sitter_crochet = { version = "0.1.0", path = "../tree_sitter_crochet" }
+unescape = "0.1.0"
 
 [dev-dependencies]
 insta = "1.13.0"

--- a/crates/crochet_tree_sitter_parser/src/lib.rs
+++ b/crates/crochet_tree_sitter_parser/src/lib.rs
@@ -1,0 +1,243 @@
+use crochet_ast::*;
+
+pub fn parse(src: &str) -> Result<Program, String> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(tree_sitter_crochet::language())
+        .expect("Error loading crochet language");
+
+    let tree = parser.parse(src, None).unwrap();
+
+    let root = tree.root_node();
+
+    let kind = root.kind();
+    if kind == "program" {
+        let mut cursor = root.walk();
+
+        let children = root.children(&mut cursor);
+
+        let mut body: Vec<Statement> = vec![];
+        for child in children {
+            let mut stmts = parse_statement(&child, src);
+            body.append(&mut stmts);
+        }
+
+        Ok(Program { body })
+    } else {
+        Err("not implemented yet".to_string())
+    }
+}
+
+fn parse_statement(node: &tree_sitter::Node, src: &str) -> Vec<Statement> {
+    match node.kind() {
+        "lexical_declaration" => parse_declaration(node, src),
+        _ => todo!("unhandled: {:#?}", node),
+    }
+}
+
+fn text_for_node(node: &tree_sitter::Node, src: &str) -> String {
+    src.get(node.byte_range()).unwrap().to_owned()
+}
+
+fn parse_declaration(node: &tree_sitter::Node, src: &str) -> Vec<Statement> {
+    let mut cursor = node.child(1).unwrap().walk();
+    let declarators = node.named_children(&mut cursor);
+
+    declarators
+        .into_iter()
+        .map(|decl| parse_declarator(&decl, src))
+        .collect()
+}
+
+fn parse_declarator(node: &tree_sitter::Node, src: &str) -> Statement {
+    let name = node.child_by_field_name("name").unwrap();
+    let name = parse_pattern(&name, src);
+
+    // We skip index:1 because that's the '='
+    let init = node.child(2).unwrap();
+    let init = parse_expression(&init, src);
+
+    Statement::VarDecl {
+        span: node.byte_range(),
+        pattern: name,
+        type_ann: None,
+        init: Some(init),
+        declare: false,
+    }
+}
+
+fn parse_pattern(node: &tree_sitter::Node, src: &str) -> Pattern {
+    match node.kind() {
+        "identifier" => {
+            let span = node.byte_range();
+            let name = src.get(span.clone()).unwrap().to_owned();
+            Pattern::Ident(BindingIdent {
+                span: span.clone(),
+                id: Ident { span, name },
+            })
+        }
+        "object_pattern" => todo!(),
+        "array_pattern" => todo!(),
+        "rest_pattern" => todo!(),
+        _ => panic!("unrecognized pattern {node:#?}"),
+    }
+}
+
+fn parse_func_param(node: &tree_sitter::Node, src: &str) -> EFnParamPat {
+    match node.kind() {
+        "identifier" => {
+            let span = node.byte_range();
+            let name = src.get(span.clone()).unwrap().to_owned();
+            EFnParamPat::Ident(EFnParamBindingIdent {
+                span: span.clone(),
+                id: Ident { span, name },
+            })
+        }
+        "object_pattern" => todo!(),
+        "array_pattern" => todo!(),
+        "rest_pattern" => todo!(),
+        _ => panic!("unrecognized pattern {node:#?}"),
+    }
+}
+
+fn parse_formal_parameters(node: &tree_sitter::Node, src: &str) -> Vec<EFnParam> {
+    assert_eq!(node.kind(), "formal_parameters");
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .into_iter()
+        .map(|param| {
+            let optional = match param.kind() {
+                "required_parameter" => false,
+                "optional_parameter" => true,
+                kind => panic!("Unexpected param kind: {kind}"),
+            };
+            let name = param.child(0).unwrap();
+
+            EFnParam {
+                pat: parse_func_param(&name, src),
+                type_ann: None,
+                optional,
+                mutable: false,
+            }
+        })
+        .collect()
+}
+
+fn parse_expression(node: &tree_sitter::Node, src: &str) -> Expr {
+    match node.kind() {
+        "arrow_function" => {
+            println!("arrow_function = {}", text_for_node(node, src));
+            let is_async = match node.child_count() {
+                3 => false,
+                4 => true,
+                _ => panic!("incorrect child_count for arrow function"),
+            };
+
+            // TODO: check if the body is a statement_block otherwise parse
+            // as a simple expression
+            let body = node.child_by_field_name("body").unwrap();
+            let body = match body.kind() {
+                "statement_block" => todo!(),
+                _ => parse_expression(&body, src),
+            };
+
+            let params = node.child_by_field_name("parameters").unwrap();
+            let params = parse_formal_parameters(&params, src);
+
+            Expr::Lambda(Lambda {
+                span: node.byte_range(),
+                params,
+                is_async,
+                body: Box::from(body),
+                return_type: None,
+                type_params: None,
+            })
+        }
+        "binary_expression" => {
+            let left = node.child_by_field_name("left").unwrap();
+            let left = Box::from(parse_expression(&left, src));
+            let operator = node.child_by_field_name("operator").unwrap();
+            let operator = text_for_node(&operator, src);
+            let right = node.child_by_field_name("right").unwrap();
+            let right = Box::from(parse_expression(&right, src));
+
+            let op = match operator.as_str() {
+                "+" => BinOp::Add,
+                "-" => BinOp::Sub,
+                _ => todo!("Unhandle operator: {operator}"),
+            };
+
+            Expr::Op(Op {
+                span: node.byte_range(),
+                left,
+                op,
+                right,
+            })
+        }
+        "call_expression" => {
+            let func = node.child_by_field_name("function").unwrap();
+            let func = parse_expression(&func, src);
+
+            let args = node.child_by_field_name("arguments").unwrap();
+
+            let mut cursor = args.walk();
+            let args = args.named_children(&mut cursor);
+
+            let args = args
+                .into_iter()
+                .map(|arg| {
+                    let expr = parse_expression(&arg, src);
+                    ExprOrSpread {
+                        spread: None,
+                        expr: Box::from(expr),
+                    }
+                })
+                .collect();
+
+            // TODO: handle template string
+            Expr::App(App {
+                span: node.byte_range(),
+                lam: Box::from(func),
+                args,
+            })
+        }
+        "identifier" => {
+            let span = node.byte_range();
+            let name = src.get(span.clone()).unwrap().to_owned();
+            Expr::Ident(Ident { span, name })
+        }
+        "number" => Expr::Lit(Lit::num(
+            src.get(node.byte_range()).unwrap().to_owned(),
+            node.byte_range(),
+        )),
+        "string" => {
+            // TODO: interpret escapes to generate "cooked" version of string
+            let str_frag = node.child_by_field_name("string_fragment").unwrap();
+            Expr::Lit(Lit::str(
+                src.get(str_frag.byte_range()).unwrap().to_owned(),
+                node.byte_range(),
+            ))
+        }
+        "true" => Expr::Lit(Lit::bool(true, node.byte_range())),
+        "false" => Expr::Lit(Lit::bool(false, node.byte_range())),
+        // TODO: handle null and undefined
+        _ => {
+            todo!("unhandled {node:#?} = '{}'", text_for_node(node, src))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let src = r#"
+        const add = (a, b) => a + b, sub = (a, b) => a - b;
+        const sum = add(5, 10);
+        "#;
+        insta::assert_debug_snapshot!(parse(src));
+    }
+}

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread-2.snap
@@ -1,0 +1,53 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let tuple = [a, ...b]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..21,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..9,
+                        id: Ident {
+                            span: 4..9,
+                            name: "tuple",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 12..21,
+                            elems: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 13..14,
+                                            name: "a",
+                                        },
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: Some(
+                                        16..20,
+                                    ),
+                                    expr: Ident(
+                                        Ident {
+                                            span: 19..20,
+                                            name: "b",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread-3.snap
@@ -1,0 +1,78 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let tuple = [1, ...[2, 3]]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..26,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..9,
+                        id: Ident {
+                            span: 4..9,
+                            name: "tuple",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 12..26,
+                            elems: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 13..14,
+                                                value: "1",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: Some(
+                                        16..25,
+                                    ),
+                                    expr: Tuple(
+                                        Tuple {
+                                            span: 19..25,
+                                            elems: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 20..21,
+                                                                value: "2",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 23..24,
+                                                                value: "3",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__array_spread.snap
@@ -1,0 +1,53 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let tuple = [...a, b]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..21,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..9,
+                        id: Ident {
+                            span: 4..9,
+                            name: "tuple",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 12..21,
+                            elems: [
+                                ExprOrSpread {
+                                    spread: Some(
+                                        13..17,
+                                    ),
+                                    expr: Ident(
+                                        Ident {
+                                            span: 16..17,
+                                            name: "a",
+                                        },
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 19..20,
+                                            name: "b",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-2.snap
@@ -1,0 +1,48 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = async () => { await 10 }\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..34,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..34,
+                            params: [],
+                            body: Await(
+                                Await {
+                                    span: 24..32,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 30..32,
+                                                value: "10",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ),
+                            is_async: true,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-3.snap
@@ -1,0 +1,63 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = async () => await a + await b\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..39,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..39,
+                            params: [],
+                            body: Op(
+                                Op {
+                                    span: 22..39,
+                                    op: Add,
+                                    left: Await(
+                                        Await {
+                                            span: 22..29,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 28..29,
+                                                    name: "a",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    right: Await(
+                                        Await {
+                                            span: 32..39,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 38..39,
+                                                    name: "b",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: true,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await-4.snap
@@ -1,0 +1,52 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = async () => await bar()\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..33,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..33,
+                            params: [],
+                            body: Await(
+                                Await {
+                                    span: 22..33,
+                                    expr: App(
+                                        App {
+                                            span: 28..33,
+                                            lam: Ident(
+                                                Ident {
+                                                    span: 28..31,
+                                                    name: "bar",
+                                                },
+                                            ),
+                                            args: [],
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: true,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__async_await.snap
@@ -1,0 +1,30 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"async () => 10\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..14,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..14,
+                        params: [],
+                        body: Lit(
+                            Num(
+                                Num {
+                                    span: 12..14,
+                                    value: "10",
+                                },
+                            ),
+                        ),
+                        is_async: true,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-2.snap
@@ -1,0 +1,34 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"   let x = 5\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 7..12,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 7..8,
+                        id: Ident {
+                            span: 7..8,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lit(
+                        Num(
+                            Num {
+                                span: 11..12,
+                                value: "5",
+                            },
+                        ),
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-3.snap
@@ -1,0 +1,32 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"declare let x: number\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 12..21,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 12..13,
+                        id: Ident {
+                            span: 12..13,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Prim(
+                        PrimType {
+                            span: 15..21,
+                            prim: Num,
+                        },
+                    ),
+                ),
+                init: None,
+                declare: true,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls-4.snap
@@ -1,0 +1,42 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"declare let foo: Foo<string>\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 12..28,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 12..15,
+                        id: Ident {
+                            span: 12..15,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    TypeRef(
+                        TypeRef {
+                            span: 17..28,
+                            name: "Foo",
+                            type_params: Some(
+                                [
+                                    Prim(
+                                        PrimType {
+                                            span: 21..27,
+                                            prim: Str,
+                                        },
+                                    ),
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+                init: None,
+                declare: true,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__decls.snap
@@ -1,0 +1,34 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let x = 5\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..9,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lit(
+                        Num(
+                            Num {
+                                span: 8..9,
+                                value: "5",
+                            },
+                        ),
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-2.snap
@@ -1,0 +1,65 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let {a, b, ...rest} = letters\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..29,
+                pattern: Object(
+                    ObjectPat {
+                        span: 4..19,
+                        props: [
+                            Assign(
+                                AssignPatProp {
+                                    span: 5..6,
+                                    key: Ident {
+                                        span: 5..6,
+                                        name: "a",
+                                    },
+                                    value: None,
+                                },
+                            ),
+                            Assign(
+                                AssignPatProp {
+                                    span: 8..9,
+                                    key: Ident {
+                                        span: 8..9,
+                                        name: "b",
+                                    },
+                                    value: None,
+                                },
+                            ),
+                            Rest(
+                                RestPat {
+                                    span: 11..18,
+                                    arg: Ident(
+                                        BindingIdent {
+                                            span: 14..18,
+                                            id: Ident {
+                                                span: 14..18,
+                                                name: "rest",
+                                            },
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        optional: false,
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Ident(
+                        Ident {
+                            span: 22..29,
+                            name: "letters",
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-3.snap
@@ -1,0 +1,103 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let {p0: {x, y}, p1: {x, y}} = line\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..35,
+                pattern: Object(
+                    ObjectPat {
+                        span: 4..28,
+                        props: [
+                            KeyValue(
+                                KeyValuePatProp {
+                                    key: Ident {
+                                        span: 5..7,
+                                        name: "p0",
+                                    },
+                                    value: Object(
+                                        ObjectPat {
+                                            span: 9..15,
+                                            props: [
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 10..11,
+                                                        key: Ident {
+                                                            span: 10..11,
+                                                            name: "x",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 13..14,
+                                                        key: Ident {
+                                                            span: 13..14,
+                                                            name: "y",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                },
+                            ),
+                            KeyValue(
+                                KeyValuePatProp {
+                                    key: Ident {
+                                        span: 17..19,
+                                        name: "p1",
+                                    },
+                                    value: Object(
+                                        ObjectPat {
+                                            span: 21..27,
+                                            props: [
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 22..23,
+                                                        key: Ident {
+                                                            span: 22..23,
+                                                            name: "x",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 25..26,
+                                                        key: Ident {
+                                                            span: 25..26,
+                                                            name: "y",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                        optional: false,
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Ident(
+                        Ident {
+                            span: 31..35,
+                            name: "line",
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-4.snap
@@ -1,0 +1,69 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let [a, b, ...rest] = letters\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..29,
+                pattern: Array(
+                    ArrayPat {
+                        span: 4..19,
+                        elems: [
+                            Some(
+                                Ident(
+                                    BindingIdent {
+                                        span: 5..6,
+                                        id: Ident {
+                                            span: 5..6,
+                                            name: "a",
+                                        },
+                                    },
+                                ),
+                            ),
+                            Some(
+                                Ident(
+                                    BindingIdent {
+                                        span: 8..9,
+                                        id: Ident {
+                                            span: 8..9,
+                                            name: "b",
+                                        },
+                                    },
+                                ),
+                            ),
+                            Some(
+                                Rest(
+                                    RestPat {
+                                        span: 11..18,
+                                        arg: Ident(
+                                            BindingIdent {
+                                                span: 14..18,
+                                                id: Ident {
+                                                    span: 14..18,
+                                                    name: "rest",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ],
+                        optional: false,
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Ident(
+                        Ident {
+                            span: 22..29,
+                            name: "letters",
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-5.snap
@@ -1,0 +1,84 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let [foo, ...[bar, ...rest]] = baz\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..34,
+                pattern: Array(
+                    ArrayPat {
+                        span: 4..28,
+                        elems: [
+                            Some(
+                                Ident(
+                                    BindingIdent {
+                                        span: 5..8,
+                                        id: Ident {
+                                            span: 5..8,
+                                            name: "foo",
+                                        },
+                                    },
+                                ),
+                            ),
+                            Some(
+                                Rest(
+                                    RestPat {
+                                        span: 10..27,
+                                        arg: Array(
+                                            ArrayPat {
+                                                span: 13..27,
+                                                elems: [
+                                                    Some(
+                                                        Ident(
+                                                            BindingIdent {
+                                                                span: 14..17,
+                                                                id: Ident {
+                                                                    span: 14..17,
+                                                                    name: "bar",
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Some(
+                                                        Rest(
+                                                            RestPat {
+                                                                span: 19..26,
+                                                                arg: Ident(
+                                                                    BindingIdent {
+                                                                        span: 22..26,
+                                                                        id: Ident {
+                                                                            span: 22..26,
+                                                                            name: "rest",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                optional: false,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ],
+                        optional: false,
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Ident(
+                        Ident {
+                            span: 31..34,
+                            name: "baz",
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-6.snap
@@ -1,0 +1,76 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = ([a, b]) => a\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..23,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..23,
+                            params: [
+                                EFnParam {
+                                    pat: Array(
+                                        EFnParamArrayPat {
+                                            span: 11..17,
+                                            elems: [
+                                                Some(
+                                                    Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 12..13,
+                                                            id: Ident {
+                                                                span: 12..13,
+                                                                name: "a",
+                                                            },
+                                                        },
+                                                    ),
+                                                ),
+                                                Some(
+                                                    Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 15..16,
+                                                            id: Ident {
+                                                                span: 15..16,
+                                                                name: "b",
+                                                            },
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Ident(
+                                Ident {
+                                    span: 22..23,
+                                    name: "a",
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-7.snap
@@ -1,0 +1,96 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = ([a, b]: [string, number]) => a\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..41,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..41,
+                            params: [
+                                EFnParam {
+                                    pat: Array(
+                                        EFnParamArrayPat {
+                                            span: 11..17,
+                                            elems: [
+                                                Some(
+                                                    Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 12..13,
+                                                            id: Ident {
+                                                                span: 12..13,
+                                                                name: "a",
+                                                            },
+                                                        },
+                                                    ),
+                                                ),
+                                                Some(
+                                                    Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 15..16,
+                                                            id: Ident {
+                                                                span: 15..16,
+                                                                name: "b",
+                                                            },
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: Some(
+                                        Tuple(
+                                            TupleType {
+                                                span: 19..35,
+                                                types: [
+                                                    Prim(
+                                                        PrimType {
+                                                            span: 20..26,
+                                                            prim: Str,
+                                                        },
+                                                    ),
+                                                    Prim(
+                                                        PrimType {
+                                                            span: 28..34,
+                                                            prim: Num,
+                                                        },
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Ident(
+                                Ident {
+                                    span: 40..41,
+                                    name: "a",
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-8.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-8.snap
@@ -1,0 +1,72 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = ({a, b}) => b\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..23,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..23,
+                            params: [
+                                EFnParam {
+                                    pat: Object(
+                                        EFnParamObjectPat {
+                                            span: 11..17,
+                                            props: [
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 12..13,
+                                                            name: "a",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 15..16,
+                                                            name: "b",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Ident(
+                                Ident {
+                                    span: 22..23,
+                                    name: "b",
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-9.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring-9.snap
@@ -1,0 +1,104 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = ({a, b}: {a: string, b: number}) => b\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..47,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..47,
+                            params: [
+                                EFnParam {
+                                    pat: Object(
+                                        EFnParamObjectPat {
+                                            span: 11..17,
+                                            props: [
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 12..13,
+                                                            name: "a",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 15..16,
+                                                            name: "b",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: Some(
+                                        Object(
+                                            ObjectType {
+                                                span: 19..41,
+                                                props: [
+                                                    TProp {
+                                                        span: 20..29,
+                                                        name: "a",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: Prim(
+                                                            PrimType {
+                                                                span: 23..29,
+                                                                prim: Str,
+                                                            },
+                                                        ),
+                                                    },
+                                                    TProp {
+                                                        span: 31..40,
+                                                        name: "b",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: Prim(
+                                                            PrimType {
+                                                                span: 34..40,
+                                                                prim: Num,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Ident(
+                                Ident {
+                                    span: 46..47,
+                                    name: "b",
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__destructuring.snap
@@ -1,0 +1,51 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let {x, y} = point\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..18,
+                pattern: Object(
+                    ObjectPat {
+                        span: 4..10,
+                        props: [
+                            Assign(
+                                AssignPatProp {
+                                    span: 5..6,
+                                    key: Ident {
+                                        span: 5..6,
+                                        name: "x",
+                                    },
+                                    value: None,
+                                },
+                            ),
+                            Assign(
+                                AssignPatProp {
+                                    span: 8..9,
+                                    key: Ident {
+                                        span: 8..9,
+                                        name: "y",
+                                    },
+                                    value: None,
+                                },
+                            ),
+                        ],
+                        optional: false,
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Ident(
+                        Ident {
+                            span: 13..18,
+                            name: "point",
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-2.snap
@@ -1,0 +1,44 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo(a, b)\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: App(
+                    App {
+                        span: 0..9,
+                        lam: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "foo",
+                            },
+                        ),
+                        args: [
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "a",
+                                    },
+                                ),
+                            },
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Ident(
+                                    Ident {
+                                        span: 7..8,
+                                        name: "b",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-3.snap
@@ -1,0 +1,48 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo(10, \\\"hello\\\")\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..16,
+                expr: App(
+                    App {
+                        span: 0..16,
+                        lam: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "foo",
+                            },
+                        ),
+                        args: [
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Lit(
+                                    Num(
+                                        Num {
+                                            span: 4..6,
+                                            value: "10",
+                                        },
+                                    ),
+                                ),
+                            },
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Lit(
+                                    Str(
+                                        Str {
+                                            span: 8..15,
+                                            value: "hello",
+                                        },
+                                    ),
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-4.snap
@@ -1,0 +1,67 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"f(x)(g(x))\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..10,
+                expr: App(
+                    App {
+                        span: 0..10,
+                        lam: App(
+                            App {
+                                span: 0..4,
+                                lam: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "f",
+                                    },
+                                ),
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 2..3,
+                                                name: "x",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                        args: [
+                            ExprOrSpread {
+                                spread: None,
+                                expr: App(
+                                    App {
+                                        span: 5..9,
+                                        lam: Ident(
+                                            Ident {
+                                                span: 5..6,
+                                                name: "g",
+                                            },
+                                        ),
+                                        args: [
+                                            ExprOrSpread {
+                                                spread: None,
+                                                expr: Ident(
+                                                    Ident {
+                                                        span: 7..8,
+                                                        name: "x",
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-5.snap
@@ -1,0 +1,46 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo(a, ...b)\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..12,
+                expr: App(
+                    App {
+                        span: 0..12,
+                        lam: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "foo",
+                            },
+                        ),
+                        args: [
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "a",
+                                    },
+                                ),
+                            },
+                            ExprOrSpread {
+                                spread: Some(
+                                    7..10,
+                                ),
+                                expr: Ident(
+                                    Ident {
+                                        span: 10..11,
+                                        name: "b",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application-6.snap
@@ -1,0 +1,276 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: parse(src)
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 13..48,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 13..14,
+                        id: Ident {
+                            span: 13..14,
+                            name: "S",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 17..48,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 18..19,
+                                            id: Ident {
+                                                span: 18..19,
+                                                name: "f",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Lambda(
+                                Lambda {
+                                    span: 24..48,
+                                    params: [
+                                        EFnParam {
+                                            pat: Ident(
+                                                EFnParamBindingIdent {
+                                                    span: 25..26,
+                                                    id: Ident {
+                                                        span: 25..26,
+                                                        name: "g",
+                                                    },
+                                                },
+                                            ),
+                                            type_ann: None,
+                                            optional: false,
+                                            mutable: false,
+                                        },
+                                    ],
+                                    body: Lambda(
+                                        Lambda {
+                                            span: 31..48,
+                                            params: [
+                                                EFnParam {
+                                                    pat: Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 32..33,
+                                                            id: Ident {
+                                                                span: 32..33,
+                                                                name: "x",
+                                                            },
+                                                        },
+                                                    ),
+                                                    type_ann: None,
+                                                    optional: false,
+                                                    mutable: false,
+                                                },
+                                            ],
+                                            body: App(
+                                                App {
+                                                    span: 38..48,
+                                                    lam: App(
+                                                        App {
+                                                            span: 38..42,
+                                                            lam: Ident(
+                                                                Ident {
+                                                                    span: 38..39,
+                                                                    name: "f",
+                                                                },
+                                                            ),
+                                                            args: [
+                                                                ExprOrSpread {
+                                                                    spread: None,
+                                                                    expr: Ident(
+                                                                        Ident {
+                                                                            span: 40..41,
+                                                                            name: "x",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                    args: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: App(
+                                                                App {
+                                                                    span: 43..47,
+                                                                    lam: Ident(
+                                                                        Ident {
+                                                                            span: 43..44,
+                                                                            name: "g",
+                                                                        },
+                                                                    ),
+                                                                    args: [
+                                                                        ExprOrSpread {
+                                                                            spread: None,
+                                                                            expr: Ident(
+                                                                                Ident {
+                                                                                    span: 45..46,
+                                                                                    name: "x",
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
+                                        },
+                                    ),
+                                    is_async: false,
+                                    return_type: None,
+                                    type_params: None,
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+            VarDecl {
+                span: 61..80,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 61..62,
+                        id: Ident {
+                            span: 61..62,
+                            name: "K",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 65..80,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 66..67,
+                                            id: Ident {
+                                                span: 66..67,
+                                                name: "x",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Lambda(
+                                Lambda {
+                                    span: 72..80,
+                                    params: [
+                                        EFnParam {
+                                            pat: Ident(
+                                                EFnParamBindingIdent {
+                                                    span: 73..74,
+                                                    id: Ident {
+                                                        span: 73..74,
+                                                        name: "y",
+                                                    },
+                                                },
+                                            ),
+                                            type_ann: None,
+                                            optional: false,
+                                            mutable: false,
+                                        },
+                                    ],
+                                    body: Ident(
+                                        Ident {
+                                            span: 79..80,
+                                            name: "x",
+                                        },
+                                    ),
+                                    is_async: false,
+                                    return_type: None,
+                                    type_params: None,
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+            VarDecl {
+                span: 93..104,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 93..94,
+                        id: Ident {
+                            span: 93..94,
+                            name: "I",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    App(
+                        App {
+                            span: 97..104,
+                            lam: App(
+                                App {
+                                    span: 97..101,
+                                    lam: Ident(
+                                        Ident {
+                                            span: 97..98,
+                                            name: "S",
+                                        },
+                                    ),
+                                    args: [
+                                        ExprOrSpread {
+                                            spread: None,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 99..100,
+                                                    name: "K",
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 102..103,
+                                            name: "K",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_application.snap
@@ -1,0 +1,25 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo()\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..5,
+                expr: App(
+                    App {
+                        span: 0..5,
+                        lam: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "foo",
+                            },
+                        ),
+                        args: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-2.snap
@@ -1,0 +1,30 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"() => 10\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..8,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..8,
+                        params: [],
+                        body: Lit(
+                            Num(
+                                Num {
+                                    span: 6..8,
+                                    value: "10",
+                                },
+                            ),
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-3.snap
@@ -1,0 +1,45 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"(a) => \\\"hello\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..14,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..14,
+                        params: [
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 1..2,
+                                        id: Ident {
+                                            span: 1..2,
+                                            name: "a",
+                                        },
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                        ],
+                        body: Lit(
+                            Str(
+                                Str {
+                                    span: 7..14,
+                                    value: "hello",
+                                },
+                            ),
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-4.snap
@@ -1,0 +1,64 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"(a, ...b) => true\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..17,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..17,
+                        params: [
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 1..2,
+                                        id: Ident {
+                                            span: 1..2,
+                                            name: "a",
+                                        },
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                            EFnParam {
+                                pat: Rest(
+                                    EFnParamRestPat {
+                                        span: 4..8,
+                                        arg: Ident(
+                                            EFnParamBindingIdent {
+                                                span: 7..8,
+                                                id: Ident {
+                                                    span: 7..8,
+                                                    name: "b",
+                                                },
+                                            },
+                                        ),
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                        ],
+                        body: Lit(
+                            Bool(
+                                Bool {
+                                    span: 13..17,
+                                    value: true,
+                                },
+                            ),
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-5.snap
@@ -1,0 +1,71 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"({x, y}) => x + y\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..17,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..17,
+                        params: [
+                            EFnParam {
+                                pat: Object(
+                                    EFnParamObjectPat {
+                                        span: 1..7,
+                                        props: [
+                                            Assign(
+                                                EFnParamAssignPatProp {
+                                                    key: Ident {
+                                                        span: 2..3,
+                                                        name: "x",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                            Assign(
+                                                EFnParamAssignPatProp {
+                                                    key: Ident {
+                                                        span: 5..6,
+                                                        name: "y",
+                                                    },
+                                                    value: None,
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                        ],
+                        body: Op(
+                            Op {
+                                span: 12..17,
+                                op: Add,
+                                left: Ident(
+                                    Ident {
+                                        span: 12..13,
+                                        name: "x",
+                                    },
+                                ),
+                                right: Ident(
+                                    Ident {
+                                        span: 16..17,
+                                        name: "y",
+                                    },
+                                ),
+                            },
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-6.snap
@@ -1,0 +1,87 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"({x: p, y: q}) => p + q\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..23,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..23,
+                        params: [
+                            EFnParam {
+                                pat: Object(
+                                    EFnParamObjectPat {
+                                        span: 1..13,
+                                        props: [
+                                            KeyValue(
+                                                EFnParamKeyValuePatProp {
+                                                    key: Ident {
+                                                        span: 2..3,
+                                                        name: "x",
+                                                    },
+                                                    value: Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 5..6,
+                                                            id: Ident {
+                                                                span: 5..6,
+                                                                name: "p",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            KeyValue(
+                                                EFnParamKeyValuePatProp {
+                                                    key: Ident {
+                                                        span: 8..9,
+                                                        name: "y",
+                                                    },
+                                                    value: Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 11..12,
+                                                            id: Ident {
+                                                                span: 11..12,
+                                                                name: "q",
+                                                            },
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                        ],
+                        body: Op(
+                            Op {
+                                span: 18..23,
+                                op: Add,
+                                left: Ident(
+                                    Ident {
+                                        span: 18..19,
+                                        name: "p",
+                                    },
+                                ),
+                                right: Ident(
+                                    Ident {
+                                        span: 22..23,
+                                        name: "q",
+                                    },
+                                ),
+                            },
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition-7.snap
@@ -1,0 +1,64 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"(a?: boolean, b?) => c\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..22,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..22,
+                        params: [
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 1..2,
+                                        id: Ident {
+                                            span: 1..2,
+                                            name: "a",
+                                        },
+                                    },
+                                ),
+                                type_ann: Some(
+                                    Prim(
+                                        PrimType {
+                                            span: 5..12,
+                                            prim: Bool,
+                                        },
+                                    ),
+                                ),
+                                optional: true,
+                                mutable: false,
+                            },
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 14..15,
+                                        id: Ident {
+                                            span: 14..15,
+                                            name: "b",
+                                        },
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: true,
+                                mutable: false,
+                            },
+                        ],
+                        body: Ident(
+                            Ident {
+                                span: 21..22,
+                                name: "c",
+                            },
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__function_definition.snap
@@ -1,0 +1,57 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"(a, b) => c\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..11,
+                expr: Lambda(
+                    Lambda {
+                        span: 0..11,
+                        params: [
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 1..2,
+                                        id: Ident {
+                                            span: 1..2,
+                                            name: "a",
+                                        },
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                            EFnParam {
+                                pat: Ident(
+                                    EFnParamBindingIdent {
+                                        span: 4..5,
+                                        id: Ident {
+                                            span: 4..5,
+                                            name: "b",
+                                        },
+                                    },
+                                ),
+                                type_ann: None,
+                                optional: false,
+                                mutable: false,
+                            },
+                        ],
+                        body: Ident(
+                            Ident {
+                                span: 10..11,
+                                name: "c",
+                            },
+                        ),
+                        is_async: false,
+                        return_type: None,
+                        type_params: None,
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__it_works.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__it_works.snap
@@ -1,0 +1,205 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: parse(src)
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 15..36,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 15..18,
+                        id: Ident {
+                            span: 15..18,
+                            name: "add",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 21..36,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 22..23,
+                                            id: Ident {
+                                                span: 22..23,
+                                                name: "a",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 25..26,
+                                            id: Ident {
+                                                span: 25..26,
+                                                name: "b",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Op(
+                                Op {
+                                    span: 31..36,
+                                    op: Add,
+                                    left: Ident(
+                                        Ident {
+                                            span: 31..32,
+                                            name: "a",
+                                        },
+                                    ),
+                                    right: Ident(
+                                        Ident {
+                                            span: 35..36,
+                                            name: "b",
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+            VarDecl {
+                span: 38..59,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 38..41,
+                        id: Ident {
+                            span: 38..41,
+                            name: "sub",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 44..59,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 45..46,
+                                            id: Ident {
+                                                span: 45..46,
+                                                name: "a",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 48..49,
+                                            id: Ident {
+                                                span: 48..49,
+                                                name: "b",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Op(
+                                Op {
+                                    span: 54..59,
+                                    op: Sub,
+                                    left: Ident(
+                                        Ident {
+                                            span: 54..55,
+                                            name: "a",
+                                        },
+                                    ),
+                                    right: Ident(
+                                        Ident {
+                                            span: 58..59,
+                                            name: "b",
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+            VarDecl {
+                span: 75..91,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 75..78,
+                        id: Ident {
+                            span: 75..78,
+                            name: "sum",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    App(
+                        App {
+                            span: 81..91,
+                            lam: Ident(
+                                Ident {
+                                    span: 81..84,
+                                    name: "add",
+                                },
+                            ),
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 85..86,
+                                                value: "5",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 88..90,
+                                                value: "10",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-10.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-10.snap
@@ -1,0 +1,86 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let elem = <div point={point} id=\\\"point\\\">Hello, {msg}</div>\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..59,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..8,
+                        id: Ident {
+                            span: 4..8,
+                            name: "elem",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    JSXElement(
+                        JSXElement {
+                            span: 11..59,
+                            name: "div",
+                            attrs: [
+                                JSXAttr {
+                                    span: 16..29,
+                                    ident: Ident {
+                                        span: 16..21,
+                                        name: "point",
+                                    },
+                                    value: JSXExprContainer(
+                                        JSXExprContainer {
+                                            span: 22..29,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 23..28,
+                                                    name: "point",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                JSXAttr {
+                                    span: 30..40,
+                                    ident: Ident {
+                                        span: 30..32,
+                                        name: "id",
+                                    },
+                                    value: Lit(
+                                        Str(
+                                            Str {
+                                                span: 33..40,
+                                                value: "point",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                            children: [
+                                JSXText(
+                                    JSXText {
+                                        span: 41..48,
+                                        value: "Hello, ",
+                                    },
+                                ),
+                                JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 48..53,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 49..52,
+                                                name: "msg",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-2.snap
@@ -1,0 +1,33 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo>{bar}</Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..16,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..16,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXExprContainer(
+                                JSXExprContainer {
+                                    span: 5..10,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 6..9,
+                                            name: "bar",
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-3.snap
@@ -1,0 +1,45 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo>Hello {world}!</Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..25,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..25,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXText(
+                                JSXText {
+                                    span: 5..11,
+                                    value: "Hello ",
+                                },
+                            ),
+                            JSXExprContainer(
+                                JSXExprContainer {
+                                    span: 11..18,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 12..17,
+                                            name: "world",
+                                        },
+                                    ),
+                                },
+                            ),
+                            JSXText(
+                                JSXText {
+                                    span: 18..19,
+                                    value: "!",
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-4.snap
@@ -1,0 +1,47 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo>{<Bar>{baz}</Bar>}</Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..29,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..29,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXExprContainer(
+                                JSXExprContainer {
+                                    span: 5..23,
+                                    expr: JSXElement(
+                                        JSXElement {
+                                            span: 6..22,
+                                            name: "Bar",
+                                            attrs: [],
+                                            children: [
+                                                JSXExprContainer(
+                                                    JSXExprContainer {
+                                                        span: 11..16,
+                                                        expr: Ident(
+                                                            Ident {
+                                                                span: 12..15,
+                                                                name: "baz",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-5.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo></Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..11,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..11,
+                        name: "Foo",
+                        attrs: [],
+                        children: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-6.snap
@@ -1,0 +1,40 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo bar={baz} />\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..17,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..17,
+                        name: "Foo",
+                        attrs: [
+                            JSXAttr {
+                                span: 5..14,
+                                ident: Ident {
+                                    span: 5..8,
+                                    name: "bar",
+                                },
+                                value: JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 9..14,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 10..13,
+                                                name: "baz",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        children: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-7.snap
@@ -1,0 +1,55 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo msg=\\\"hello\\\" bar={baz}></Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..33,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..33,
+                        name: "Foo",
+                        attrs: [
+                            JSXAttr {
+                                span: 5..16,
+                                ident: Ident {
+                                    span: 5..8,
+                                    name: "msg",
+                                },
+                                value: Lit(
+                                    Str(
+                                        Str {
+                                            span: 9..16,
+                                            value: "hello",
+                                        },
+                                    ),
+                                ),
+                            },
+                            JSXAttr {
+                                span: 17..26,
+                                ident: Ident {
+                                    span: 17..20,
+                                    name: "bar",
+                                },
+                                value: JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 21..26,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 22..25,
+                                                name: "baz",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        children: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-8.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-8.snap
@@ -1,0 +1,42 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo><Bar>{baz}</Bar></Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..27,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..27,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXElement(
+                                JSXElement {
+                                    span: 5..21,
+                                    name: "Bar",
+                                    attrs: [],
+                                    children: [
+                                        JSXExprContainer(
+                                            JSXExprContainer {
+                                                span: 10..15,
+                                                expr: Ident(
+                                                    Ident {
+                                                        span: 11..14,
+                                                        name: "baz",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-9.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx-9.snap
@@ -1,0 +1,55 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo>hello<Bar/>{world}<Baz/></Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..35,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..35,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXText(
+                                JSXText {
+                                    span: 5..10,
+                                    value: "hello",
+                                },
+                            ),
+                            JSXElement(
+                                JSXElement {
+                                    span: 10..16,
+                                    name: "Bar",
+                                    attrs: [],
+                                    children: [],
+                                },
+                            ),
+                            JSXExprContainer(
+                                JSXExprContainer {
+                                    span: 16..23,
+                                    expr: Ident(
+                                        Ident {
+                                            span: 17..22,
+                                            name: "world",
+                                        },
+                                    ),
+                                },
+                            ),
+                            JSXElement(
+                                JSXElement {
+                                    span: 23..29,
+                                    name: "Baz",
+                                    attrs: [],
+                                    children: [],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__jsx.snap
@@ -1,0 +1,28 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"<Foo>Hello</Foo>\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..16,
+                expr: JSXElement(
+                    JSXElement {
+                        span: 0..16,
+                        name: "Foo",
+                        attrs: [],
+                        children: [
+                            JSXText(
+                                JSXText {
+                                    span: 5..10,
+                                    value: "Hello",
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-2.snap
@@ -1,0 +1,36 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo.bar()\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: App(
+                    App {
+                        span: 0..9,
+                        lam: Member(
+                            Member {
+                                span: 0..7,
+                                obj: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
+                                ),
+                                prop: Ident(
+                                    Ident {
+                                        span: 4..7,
+                                        name: "bar",
+                                    },
+                                ),
+                            },
+                        ),
+                        args: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-3.snap
@@ -1,0 +1,99 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"p.x * p.x + p.y * p.y\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..21,
+                expr: Op(
+                    Op {
+                        span: 0..21,
+                        op: Add,
+                        left: Op(
+                            Op {
+                                span: 0..9,
+                                op: Mul,
+                                left: Member(
+                                    Member {
+                                        span: 0..3,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 0..1,
+                                                name: "p",
+                                            },
+                                        ),
+                                        prop: Ident(
+                                            Ident {
+                                                span: 2..3,
+                                                name: "x",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                right: Member(
+                                    Member {
+                                        span: 6..9,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 6..7,
+                                                name: "p",
+                                            },
+                                        ),
+                                        prop: Ident(
+                                            Ident {
+                                                span: 8..9,
+                                                name: "x",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                        right: Op(
+                            Op {
+                                span: 12..21,
+                                op: Mul,
+                                left: Member(
+                                    Member {
+                                        span: 12..15,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 12..13,
+                                                name: "p",
+                                            },
+                                        ),
+                                        prop: Ident(
+                                            Ident {
+                                                span: 14..15,
+                                                name: "y",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                right: Member(
+                                    Member {
+                                        span: 18..21,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 18..19,
+                                                name: "p",
+                                            },
+                                        ),
+                                        prop: Ident(
+                                            Ident {
+                                                span: 20..21,
+                                                name: "y",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-4.snap
@@ -1,0 +1,42 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo().bar()\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..11,
+                expr: App(
+                    App {
+                        span: 0..11,
+                        lam: Member(
+                            Member {
+                                span: 0..9,
+                                obj: App(
+                                    App {
+                                        span: 0..5,
+                                        lam: Ident(
+                                            Ident {
+                                                span: 0..3,
+                                                name: "foo",
+                                            },
+                                        ),
+                                        args: [],
+                                    },
+                                ),
+                                prop: Ident(
+                                    Ident {
+                                        span: 6..9,
+                                        name: "bar",
+                                    },
+                                ),
+                            },
+                        ),
+                        args: [],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-5.snap
@@ -1,0 +1,55 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"arr[0][1]\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: Member(
+                    Member {
+                        span: 0..9,
+                        obj: Member(
+                            Member {
+                                span: 0..6,
+                                obj: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "arr",
+                                    },
+                                ),
+                                prop: Computed(
+                                    ComputedPropName {
+                                        span: 4..5,
+                                        expr: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 4..5,
+                                                    value: "0",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                        prop: Computed(
+                            ComputedPropName {
+                                span: 7..8,
+                                expr: Lit(
+                                    Num(
+                                        Num {
+                                            span: 7..8,
+                                            value: "1",
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-6.snap
@@ -1,0 +1,51 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"arr[x](y)\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: App(
+                    App {
+                        span: 0..9,
+                        lam: Member(
+                            Member {
+                                span: 0..6,
+                                obj: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "arr",
+                                    },
+                                ),
+                                prop: Computed(
+                                    ComputedPropName {
+                                        span: 4..5,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 4..5,
+                                                name: "x",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                        args: [
+                            ExprOrSpread {
+                                spread: None,
+                                expr: Ident(
+                                    Ident {
+                                        span: 7..8,
+                                        name: "y",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-7.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"arr[arr.length - 1]\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..19,
+                expr: Member(
+                    Member {
+                        span: 0..19,
+                        obj: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "arr",
+                            },
+                        ),
+                        prop: Computed(
+                            ComputedPropName {
+                                span: 4..18,
+                                expr: Op(
+                                    Op {
+                                        span: 4..18,
+                                        op: Sub,
+                                        left: Member(
+                                            Member {
+                                                span: 4..14,
+                                                obj: Ident(
+                                                    Ident {
+                                                        span: 4..7,
+                                                        name: "arr",
+                                                    },
+                                                ),
+                                                prop: Ident(
+                                                    Ident {
+                                                        span: 8..14,
+                                                        name: "length",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        right: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 17..18,
+                                                    value: "1",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-8.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access-8.snap
@@ -1,0 +1,59 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"foo[bar[-1]]\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..12,
+                expr: Member(
+                    Member {
+                        span: 0..12,
+                        obj: Ident(
+                            Ident {
+                                span: 0..3,
+                                name: "foo",
+                            },
+                        ),
+                        prop: Computed(
+                            ComputedPropName {
+                                span: 4..11,
+                                expr: Member(
+                                    Member {
+                                        span: 4..11,
+                                        obj: Ident(
+                                            Ident {
+                                                span: 4..7,
+                                                name: "bar",
+                                            },
+                                        ),
+                                        prop: Computed(
+                                            ComputedPropName {
+                                                span: 8..10,
+                                                expr: UnaryExpr(
+                                                    UnaryExpr {
+                                                        span: 8..10,
+                                                        op: Minus,
+                                                        arg: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    span: 9..10,
+                                                                    value: "1",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__member_access.snap
@@ -1,0 +1,41 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a.b.c\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..5,
+                expr: Member(
+                    Member {
+                        span: 0..5,
+                        obj: Member(
+                            Member {
+                                span: 0..3,
+                                obj: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
+                                prop: Ident(
+                                    Ident {
+                                        span: 2..3,
+                                        name: "b",
+                                    },
+                                ),
+                            },
+                        ),
+                        prop: Ident(
+                            Ident {
+                                span: 4..5,
+                                name: "c",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers-2.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"1.23\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..4,
+                expr: Lit(
+                    Num(
+                        Num {
+                            span: 0..4,
+                            value: "1.23",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers-3.snap
@@ -1,0 +1,27 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"-10\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..3,
+                expr: UnaryExpr(
+                    UnaryExpr {
+                        span: 0..3,
+                        op: Minus,
+                        arg: Lit(
+                            Num(
+                                Num {
+                                    span: 1..3,
+                                    value: "10",
+                                },
+                            ),
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__numbers.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"10\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..2,
+                expr: Lit(
+                    Num(
+                        Num {
+                            span: 0..2,
+                            value: "10",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects-2.snap
@@ -1,0 +1,49 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let obj = {x, y}\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..16,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "obj",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Obj(
+                        Obj {
+                            span: 10..16,
+                            props: [
+                                Prop(
+                                    Shorthand(
+                                        Ident {
+                                            span: 10..16,
+                                            name: "x",
+                                        },
+                                    ),
+                                ),
+                                Prop(
+                                    Shorthand(
+                                        Ident {
+                                            span: 10..16,
+                                            name: "y",
+                                        },
+                                    ),
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects-3.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let obj = {a, b, ...others}\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..27,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "obj",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Obj(
+                        Obj {
+                            span: 10..27,
+                            props: [
+                                Prop(
+                                    Shorthand(
+                                        Ident {
+                                            span: 10..27,
+                                            name: "a",
+                                        },
+                                    ),
+                                ),
+                                Prop(
+                                    Shorthand(
+                                        Ident {
+                                            span: 10..27,
+                                            name: "b",
+                                        },
+                                    ),
+                                ),
+                                Spread(
+                                    SpreadElement {
+                                        span: 10..27,
+                                        expr: Ident(
+                                            Ident {
+                                                span: 20..26,
+                                                name: "others",
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__objects.snap
@@ -1,0 +1,52 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"{x: 5, y: 10}\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..13,
+                expr: Obj(
+                    Obj {
+                        span: 0..13,
+                        props: [
+                            Prop(
+                                KeyValue(
+                                    KeyValueProp {
+                                        span: 1..5,
+                                        name: "x",
+                                        value: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 4..5,
+                                                    value: "5",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                            Prop(
+                                KeyValue(
+                                    KeyValueProp {
+                                        span: 7..12,
+                                        name: "y",
+                                        value: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 10..12,
+                                                    value: "10",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-10.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-10.snap
@@ -1,0 +1,44 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let cond = a != b\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..17,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..8,
+                        id: Ident {
+                            span: 4..8,
+                            name: "cond",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Op(
+                        Op {
+                            span: 11..17,
+                            op: NotEq,
+                            left: Ident(
+                                Ident {
+                                    span: 11..12,
+                                    name: "a",
+                                },
+                            ),
+                            right: Ident(
+                                Ident {
+                                    span: 16..17,
+                                    name: "b",
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-11.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-11.snap
@@ -1,0 +1,25 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"-a\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..2,
+                expr: UnaryExpr(
+                    UnaryExpr {
+                        span: 0..2,
+                        op: Minus,
+                        arg: Ident(
+                            Ident {
+                                span: 1..2,
+                                name: "a",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-12.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-12.snap
@@ -1,0 +1,37 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"-(a + b)\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..8,
+                expr: UnaryExpr(
+                    UnaryExpr {
+                        span: 0..8,
+                        op: Minus,
+                        arg: Op(
+                            Op {
+                                span: 2..7,
+                                op: Add,
+                                left: Ident(
+                                    Ident {
+                                        span: 2..3,
+                                        name: "a",
+                                    },
+                                ),
+                                right: Ident(
+                                    Ident {
+                                        span: 6..7,
+                                        name: "b",
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-2.snap
@@ -1,0 +1,43 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"x * y / z\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: Op(
+                    Op {
+                        span: 0..9,
+                        op: Div,
+                        left: Op(
+                            Op {
+                                span: 0..5,
+                                op: Mul,
+                                left: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "x",
+                                    },
+                                ),
+                                right: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "y",
+                                    },
+                                ),
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 8..9,
+                                name: "z",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-3.snap
@@ -1,0 +1,43 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"(a + b) * c\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..11,
+                expr: Op(
+                    Op {
+                        span: 0..11,
+                        op: Mul,
+                        left: Op(
+                            Op {
+                                span: 1..6,
+                                op: Add,
+                                left: Ident(
+                                    Ident {
+                                        span: 1..2,
+                                        name: "a",
+                                    },
+                                ),
+                                right: Ident(
+                                    Ident {
+                                        span: 5..6,
+                                        name: "b",
+                                    },
+                                ),
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 10..11,
+                                name: "c",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-4.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a == b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..6,
+                expr: Op(
+                    Op {
+                        span: 0..6,
+                        op: EqEq,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 5..6,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-5.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a != b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..6,
+                expr: Op(
+                    Op {
+                        span: 0..6,
+                        op: NotEq,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 5..6,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-6.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a > b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..5,
+                expr: Op(
+                    Op {
+                        span: 0..5,
+                        op: Gt,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 4..5,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-7.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a >= b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..6,
+                expr: Op(
+                    Op {
+                        span: 0..6,
+                        op: GtEq,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 5..6,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-8.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-8.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a < b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..5,
+                expr: Op(
+                    Op {
+                        span: 0..5,
+                        op: Lt,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 4..5,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-9.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations-9.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a <= b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..6,
+                expr: Op(
+                    Op {
+                        span: 0..6,
+                        op: LtEq,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 5..6,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__operations.snap
@@ -1,0 +1,49 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"1 + 2 - 3\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..9,
+                expr: Op(
+                    Op {
+                        span: 0..9,
+                        op: Sub,
+                        left: Op(
+                            Op {
+                                span: 0..5,
+                                op: Add,
+                                left: Lit(
+                                    Num(
+                                        Num {
+                                            span: 0..1,
+                                            value: "1",
+                                        },
+                                    ),
+                                ),
+                                right: Lit(
+                                    Num(
+                                        Num {
+                                            span: 4..5,
+                                            value: "2",
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                        right: Lit(
+                            Num(
+                                Num {
+                                    span: 8..9,
+                                    value: "3",
+                                },
+                            ),
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-2.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\"hello\"\"#)"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..7,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 0..7,
+                            value: "hello",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-3.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"\\\"line 1\\\\nline 2\\\\nline 3\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..24,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 0..24,
+                            value: "line 1\nline 2\nline 3",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-4.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"\\\"a \\\\u2212 b\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..12,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 0..12,
+                            value: "a − b",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings-5.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"\\\"hello, \\\\\\\"world\\\\\\\"!\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..19,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 0..19,
+                            value: "hello, \"world\"!",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__strings.snap
@@ -1,0 +1,21 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\"\"\"#)"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..2,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 0..2,
+                            value: "",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tagged_template_literals.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tagged_template_literals.snap
@@ -1,0 +1,86 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"sql`SELECT * FROM ${table} WHERE id = ${id}`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..44,
+                expr: TaggedTemplateLiteral(
+                    TaggedTemplateLiteral {
+                        span: 0..44,
+                        tag: Ident {
+                            span: 0..3,
+                            name: "sql",
+                        },
+                        template: TemplateLiteral {
+                            span: 3..44,
+                            exprs: [
+                                Ident(
+                                    Ident {
+                                        span: 20..25,
+                                        name: "table",
+                                    },
+                                ),
+                                Ident(
+                                    Ident {
+                                        span: 40..42,
+                                        name: "id",
+                                    },
+                                ),
+                            ],
+                            quasis: [
+                                TemplateElem {
+                                    span: 4..18,
+                                    raw: Str(
+                                        Str {
+                                            span: 4..18,
+                                            value: "SELECT * FROM ",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 4..18,
+                                            value: "SELECT * FROM ",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 26..38,
+                                    raw: Str(
+                                        Str {
+                                            span: 26..38,
+                                            value: " WHERE id = ",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 26..38,
+                                            value: " WHERE id = ",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 43..43,
+                                    raw: Str(
+                                        Str {
+                                            span: 43..43,
+                                            value: "",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 43..43,
+                                            value: "",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-2.snap
@@ -1,0 +1,58 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`Hello, ${name}`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..16,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..16,
+                        exprs: [
+                            Ident(
+                                Ident {
+                                    span: 10..14,
+                                    name: "name",
+                                },
+                            ),
+                        ],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..8,
+                                raw: Str(
+                                    Str {
+                                        span: 1..8,
+                                        value: "Hello, ",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..8,
+                                        value: "Hello, ",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 15..15,
+                                raw: Str(
+                                    Str {
+                                        span: 15..15,
+                                        value: "",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 15..15,
+                                        value: "",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-3.snap
@@ -1,0 +1,79 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`(${x}, ${y})`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..14,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..14,
+                        exprs: [
+                            Ident(
+                                Ident {
+                                    span: 4..5,
+                                    name: "x",
+                                },
+                            ),
+                            Ident(
+                                Ident {
+                                    span: 10..11,
+                                    name: "y",
+                                },
+                            ),
+                        ],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..2,
+                                raw: Str(
+                                    Str {
+                                        span: 1..2,
+                                        value: "(",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..2,
+                                        value: "(",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 6..8,
+                                raw: Str(
+                                    Str {
+                                        span: 6..8,
+                                        value: ", ",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 6..8,
+                                        value: ", ",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 12..13,
+                                raw: Str(
+                                    Str {
+                                        span: 12..13,
+                                        value: ")",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 12..13,
+                                        value: ")",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-4.snap
@@ -1,0 +1,36 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"`Hello, \"world\"`\"#)"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..16,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..16,
+                        exprs: [],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..15,
+                                raw: Str(
+                                    Str {
+                                        span: 1..15,
+                                        value: "Hello, \"world\"",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..15,
+                                        value: "Hello, \"world\"",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-5.snap
@@ -1,0 +1,97 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`foo ${`bar ${baz}`}`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..21,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..21,
+                        exprs: [
+                            TemplateLiteral(
+                                TemplateLiteral {
+                                    span: 7..19,
+                                    exprs: [
+                                        Ident(
+                                            Ident {
+                                                span: 14..17,
+                                                name: "baz",
+                                            },
+                                        ),
+                                    ],
+                                    quasis: [
+                                        TemplateElem {
+                                            span: 8..12,
+                                            raw: Str(
+                                                Str {
+                                                    span: 8..12,
+                                                    value: "bar ",
+                                                },
+                                            ),
+                                            cooked: Str(
+                                                Str {
+                                                    span: 8..12,
+                                                    value: "bar ",
+                                                },
+                                            ),
+                                        },
+                                        TemplateElem {
+                                            span: 18..18,
+                                            raw: Str(
+                                                Str {
+                                                    span: 18..18,
+                                                    value: "",
+                                                },
+                                            ),
+                                            cooked: Str(
+                                                Str {
+                                                    span: 18..18,
+                                                    value: "",
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        ],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..5,
+                                raw: Str(
+                                    Str {
+                                        span: 1..5,
+                                        value: "foo ",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..5,
+                                        value: "foo ",
+                                    },
+                                ),
+                            },
+                            TemplateElem {
+                                span: 20..20,
+                                raw: Str(
+                                    Str {
+                                        span: 20..20,
+                                        value: "",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 20..20,
+                                        value: "",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-6.snap
@@ -1,0 +1,36 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`line 1\\\\nline 2\\\\nline 3`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..24,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..24,
+                        exprs: [],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..23,
+                                raw: Str(
+                                    Str {
+                                        span: 1..23,
+                                        value: "line 1\\nline 2\\nline 3",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..23,
+                                        value: "line 1\nline 2\nline 3",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals-7.snap
@@ -1,0 +1,36 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`a \\\\u2212 b`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..12,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..12,
+                        exprs: [],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..11,
+                                raw: Str(
+                                    Str {
+                                        span: 1..11,
+                                        value: "a \\u2212 b",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..11,
+                                        value: "a − b",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__template_literals.snap
@@ -1,0 +1,36 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"`Hello, world`\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..14,
+                expr: TemplateLiteral(
+                    TemplateLiteral {
+                        span: 0..14,
+                        exprs: [],
+                        quasis: [
+                            TemplateElem {
+                                span: 1..13,
+                                raw: Str(
+                                    Str {
+                                        span: 1..13,
+                                        value: "Hello, world",
+                                    },
+                                ),
+                                cooked: Str(
+                                    Str {
+                                        span: 1..13,
+                                        value: "Hello, world",
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__top_level_expressions-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__top_level_expressions-2.snap
@@ -1,0 +1,32 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"123\\n\\\"hello\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..3,
+                expr: Lit(
+                    Num(
+                        Num {
+                            span: 0..3,
+                            value: "123",
+                        },
+                    ),
+                ),
+            },
+            Expr {
+                span: 4..11,
+                expr: Lit(
+                    Str(
+                        Str {
+                            span: 4..11,
+                            value: "hello",
+                        },
+                    ),
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__top_level_expressions.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__top_level_expressions.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"a + b\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..5,
+                expr: Op(
+                    Op {
+                        span: 0..5,
+                        op: Add,
+                        left: Ident(
+                            Ident {
+                                span: 0..1,
+                                name: "a",
+                            },
+                        ),
+                        right: Ident(
+                            Ident {
+                                span: 4..5,
+                                name: "b",
+                            },
+                        ),
+                    },
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-2.snap
@@ -1,0 +1,66 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let x = [1, 2, 3]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..17,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 8..17,
+                            elems: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 9..10,
+                                                value: "1",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 12..13,
+                                                value: "2",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 15..16,
+                                                value: "3",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-3.snap
@@ -1,0 +1,72 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let x = [1, [a, b]]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..19,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 8..19,
+                            elems: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Lit(
+                                        Num(
+                                            Num {
+                                                span: 9..10,
+                                                value: "1",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Tuple(
+                                        Tuple {
+                                            span: 12..18,
+                                            elems: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Ident(
+                                                        Ident {
+                                                            span: 13..14,
+                                                            name: "a",
+                                                        },
+                                                    ),
+                                                },
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Ident(
+                                                        Ident {
+                                                            span: 16..17,
+                                                            name: "b",
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples-4.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let foo = () => [a, b]\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..22,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "foo",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..22,
+                            params: [],
+                            body: Tuple(
+                                Tuple {
+                                    span: 16..22,
+                                    elems: [
+                                        ExprOrSpread {
+                                            spread: None,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 17..18,
+                                                    name: "a",
+                                                },
+                                            ),
+                                        },
+                                        ExprOrSpread {
+                                            spread: None,
+                                            expr: Ident(
+                                                Ident {
+                                                    span: 20..21,
+                                                    name: "b",
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__tuples.snap
@@ -1,0 +1,32 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let x = []\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..10,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 8..10,
+                            elems: [],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-2.snap
@@ -1,0 +1,41 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let msg: string = \\\"hello\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..25,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "msg",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Prim(
+                        PrimType {
+                            span: 9..15,
+                            prim: Str,
+                        },
+                    ),
+                ),
+                init: Some(
+                    Lit(
+                        Str(
+                            Str {
+                                span: 18..25,
+                                value: "hello",
+                            },
+                        ),
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-3.snap
@@ -1,0 +1,103 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let add = (a: number, b: number): number => a + b\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..49,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "add",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 10..49,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 11..12,
+                                            id: Ident {
+                                                span: 11..12,
+                                                name: "a",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: Some(
+                                        Prim(
+                                            PrimType {
+                                                span: 14..20,
+                                                prim: Num,
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    mutable: false,
+                                },
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 22..23,
+                                            id: Ident {
+                                                span: 22..23,
+                                                name: "b",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: Some(
+                                        Prim(
+                                            PrimType {
+                                                span: 25..31,
+                                                prim: Num,
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Op(
+                                Op {
+                                    span: 44..49,
+                                    op: Add,
+                                    left: Ident(
+                                        Ident {
+                                            span: 44..45,
+                                            name: "a",
+                                        },
+                                    ),
+                                    right: Ident(
+                                        Ident {
+                                            span: 48..49,
+                                            name: "b",
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: false,
+                            return_type: Some(
+                                Prim(
+                                    PrimType {
+                                        span: 34..40,
+                                        prim: Num,
+                                    },
+                                ),
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-4.snap
@@ -1,0 +1,73 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let p: Point = {x: 5, y: 10}\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..28,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "p",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    TypeRef(
+                        TypeRef {
+                            span: 7..12,
+                            name: "Point",
+                            type_params: None,
+                        },
+                    ),
+                ),
+                init: Some(
+                    Obj(
+                        Obj {
+                            span: 15..28,
+                            props: [
+                                Prop(
+                                    KeyValue(
+                                        KeyValueProp {
+                                            span: 16..20,
+                                            name: "x",
+                                            value: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 19..20,
+                                                        value: "5",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ),
+                                Prop(
+                                    KeyValue(
+                                        KeyValueProp {
+                                            span: 22..27,
+                                            name: "y",
+                                            value: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 25..27,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations-5.snap
@@ -1,0 +1,43 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let FOO: \\\"foo\\\" = \\\"foo\\\"\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..22,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "FOO",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Lit(
+                        Str(
+                            Str {
+                                span: 9..14,
+                                value: "foo",
+                            },
+                        ),
+                    ),
+                ),
+                init: Some(
+                    Lit(
+                        Str(
+                            Str {
+                                span: 17..22,
+                                value: "foo",
+                            },
+                        ),
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_annotations.snap
@@ -1,0 +1,41 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let x: number = 5\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..17,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..5,
+                        id: Ident {
+                            span: 4..5,
+                            name: "x",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Prim(
+                        PrimType {
+                            span: 7..13,
+                            prim: Num,
+                        },
+                    ),
+                ),
+                init: Some(
+                    Lit(
+                        Num(
+                            Num {
+                                span: 16..17,
+                                value: "5",
+                            },
+                        ),
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-2.snap
@@ -1,0 +1,50 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"type Point = {x: number, y: number}\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..35,
+                declare: false,
+                id: Ident {
+                    span: 5..10,
+                    name: "Point",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 13..35,
+                        props: [
+                            TProp {
+                                span: 14..23,
+                                name: "x",
+                                optional: false,
+                                mutable: false,
+                                type_ann: Prim(
+                                    PrimType {
+                                        span: 17..23,
+                                        prim: Num,
+                                    },
+                                ),
+                            },
+                            TProp {
+                                span: 25..34,
+                                name: "y",
+                                optional: false,
+                                mutable: false,
+                                type_ann: Prim(
+                                    PrimType {
+                                        span: 28..34,
+                                        prim: Num,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-3.snap
@@ -1,0 +1,51 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"type Foo<T> = {bar: T}\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..22,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Foo",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 14..22,
+                        props: [
+                            TProp {
+                                span: 15..21,
+                                name: "bar",
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeRef(
+                                    TypeRef {
+                                        span: 20..21,
+                                        name: "T",
+                                        type_params: None,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 9..10,
+                            name: Ident {
+                                span: 9..10,
+                                name: "T",
+                            },
+                            constraint: None,
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-4.snap
@@ -1,0 +1,58 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"type Foo<T extends string> = {bar: T}\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..37,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Foo",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 29..37,
+                        props: [
+                            TProp {
+                                span: 30..36,
+                                name: "bar",
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeRef(
+                                    TypeRef {
+                                        span: 35..36,
+                                        name: "T",
+                                        type_params: None,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 9..25,
+                            name: Ident {
+                                span: 9..10,
+                                name: "T",
+                            },
+                            constraint: Some(
+                                Prim(
+                                    PrimType {
+                                        span: 19..25,
+                                        prim: Str,
+                                    },
+                                ),
+                            ),
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-5.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"type Foo<T = \"foo\"> = {bar: T}\"#)"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..30,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Foo",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 22..30,
+                        props: [
+                            TProp {
+                                span: 23..29,
+                                name: "bar",
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeRef(
+                                    TypeRef {
+                                        span: 28..29,
+                                        name: "T",
+                                        type_params: None,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 9..18,
+                            name: Ident {
+                                span: 9..10,
+                                name: "T",
+                            },
+                            constraint: None,
+                            default: Some(
+                                Lit(
+                                    Str(
+                                        Str {
+                                            span: 13..18,
+                                            value: "foo",
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls-6.snap
@@ -1,0 +1,67 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"type Foo<T extends string = \"foo\"> = {bar: T}\"#)"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..45,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Foo",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 37..45,
+                        props: [
+                            TProp {
+                                span: 38..44,
+                                name: "bar",
+                                optional: false,
+                                mutable: false,
+                                type_ann: TypeRef(
+                                    TypeRef {
+                                        span: 43..44,
+                                        name: "T",
+                                        type_params: None,
+                                    },
+                                ),
+                            },
+                        ],
+                    },
+                ),
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 9..33,
+                            name: Ident {
+                                span: 9..10,
+                                name: "T",
+                            },
+                            constraint: Some(
+                                Prim(
+                                    PrimType {
+                                        span: 19..25,
+                                        prim: Str,
+                                    },
+                                ),
+                            ),
+                            default: Some(
+                                Lit(
+                                    Str(
+                                        Str {
+                                            span: 28..33,
+                                            value: "foo",
+                                        },
+                                    ),
+                                ),
+                            ),
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__type_decls.snap
@@ -1,0 +1,25 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"type Num = number\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..17,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Num",
+                },
+                type_ann: Prim(
+                    PrimType {
+                        span: 11..17,
+                        prim: Num,
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-2.snap
@@ -1,0 +1,60 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"declare let get_bar: (foo: Foo) => T\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 12..36,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 12..19,
+                        id: Ident {
+                            span: 12..19,
+                            name: "get_bar",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Lam(
+                        LamType {
+                            span: 21..36,
+                            params: [
+                                TypeAnnFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 22..25,
+                                            id: Ident {
+                                                span: 22..25,
+                                                name: "foo",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 27..30,
+                                            name: "Foo",
+                                            type_params: None,
+                                        },
+                                    ),
+                                    optional: false,
+                                },
+                            ],
+                            ret: TypeRef(
+                                TypeRef {
+                                    span: 35..36,
+                                    name: "T",
+                                    type_params: None,
+                                },
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                ),
+                init: None,
+                declare: true,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-3.snap
@@ -1,0 +1,44 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let str_arr: string[] = []\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..26,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..11,
+                        id: Ident {
+                            span: 4..11,
+                            name: "str_arr",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Array(
+                        ArrayType {
+                            span: 13..21,
+                            elem_type: Prim(
+                                PrimType {
+                                    span: 13..19,
+                                    prim: Str,
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 24..26,
+                            elems: [],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-4.snap
@@ -1,0 +1,51 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let thunk_arr: (() => undefined)[] = []\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..39,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..13,
+                        id: Ident {
+                            span: 4..13,
+                            name: "thunk_arr",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Array(
+                        ArrayType {
+                            span: 15..34,
+                            elem_type: Lam(
+                                LamType {
+                                    span: 16..31,
+                                    params: [],
+                                    ret: Keyword(
+                                        KeywordType {
+                                            span: 22..31,
+                                            keyword: Undefined,
+                                        },
+                                    ),
+                                    type_params: None,
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 37..39,
+                            elems: [],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-5.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-5.snap
@@ -1,0 +1,62 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let arr: string[] | number[] = []\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..33,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..7,
+                        id: Ident {
+                            span: 4..7,
+                            name: "arr",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Union(
+                        UnionType {
+                            span: 9..28,
+                            types: [
+                                Array(
+                                    ArrayType {
+                                        span: 9..17,
+                                        elem_type: Prim(
+                                            PrimType {
+                                                span: 9..15,
+                                                prim: Str,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Array(
+                                    ArrayType {
+                                        span: 20..28,
+                                        elem_type: Prim(
+                                            PrimType {
+                                                span: 20..26,
+                                                prim: Num,
+                                            },
+                                        ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 31..33,
+                            elems: [],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-6.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-6.snap
@@ -1,0 +1,133 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"declare let add: ((a: number, b: number) => number) & (a: string, b: string) => string\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 12..86,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 12..15,
+                        id: Ident {
+                            span: 12..15,
+                            name: "add",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Intersection(
+                        IntersectionType {
+                            span: 17..86,
+                            types: [
+                                Lam(
+                                    LamType {
+                                        span: 18..50,
+                                        params: [
+                                            TypeAnnFnParam {
+                                                pat: Ident(
+                                                    EFnParamBindingIdent {
+                                                        span: 19..20,
+                                                        id: Ident {
+                                                            span: 19..20,
+                                                            name: "a",
+                                                        },
+                                                    },
+                                                ),
+                                                type_ann: Prim(
+                                                    PrimType {
+                                                        span: 22..28,
+                                                        prim: Num,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                            TypeAnnFnParam {
+                                                pat: Ident(
+                                                    EFnParamBindingIdent {
+                                                        span: 30..31,
+                                                        id: Ident {
+                                                            span: 30..31,
+                                                            name: "b",
+                                                        },
+                                                    },
+                                                ),
+                                                type_ann: Prim(
+                                                    PrimType {
+                                                        span: 33..39,
+                                                        prim: Num,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                        ],
+                                        ret: Prim(
+                                            PrimType {
+                                                span: 44..50,
+                                                prim: Num,
+                                            },
+                                        ),
+                                        type_params: None,
+                                    },
+                                ),
+                                Lam(
+                                    LamType {
+                                        span: 54..86,
+                                        params: [
+                                            TypeAnnFnParam {
+                                                pat: Ident(
+                                                    EFnParamBindingIdent {
+                                                        span: 55..56,
+                                                        id: Ident {
+                                                            span: 55..56,
+                                                            name: "a",
+                                                        },
+                                                    },
+                                                ),
+                                                type_ann: Prim(
+                                                    PrimType {
+                                                        span: 58..64,
+                                                        prim: Str,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                            TypeAnnFnParam {
+                                                pat: Ident(
+                                                    EFnParamBindingIdent {
+                                                        span: 66..67,
+                                                        id: Ident {
+                                                            span: 66..67,
+                                                            name: "b",
+                                                        },
+                                                    },
+                                                ),
+                                                type_ann: Prim(
+                                                    PrimType {
+                                                        span: 69..75,
+                                                        prim: Str,
+                                                    },
+                                                ),
+                                                optional: false,
+                                            },
+                                        ],
+                                        ret: Prim(
+                                            PrimType {
+                                                span: 80..86,
+                                                prim: Str,
+                                            },
+                                        ),
+                                        type_params: None,
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+                init: None,
+                declare: true,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-7.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-7.snap
@@ -1,0 +1,49 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let nested_arr: string[][] = []\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..31,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..14,
+                        id: Ident {
+                            span: 4..14,
+                            name: "nested_arr",
+                        },
+                    },
+                ),
+                type_ann: Some(
+                    Array(
+                        ArrayType {
+                            span: 16..26,
+                            elem_type: Array(
+                                ArrayType {
+                                    span: 16..24,
+                                    elem_type: Prim(
+                                        PrimType {
+                                            span: 16..22,
+                                            prim: Str,
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                ),
+                init: Some(
+                    Tuple(
+                        Tuple {
+                            span: 29..31,
+                            elems: [],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-8.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types-8.snap
@@ -1,0 +1,111 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: parse(src)
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 9..119,
+                declare: false,
+                id: Ident {
+                    span: 14..19,
+                    name: "Event",
+                },
+                type_ann: Union(
+                    UnionType {
+                        span: 33..119,
+                        types: [
+                            Union(
+                                UnionType {
+                                    span: 33..76,
+                                    types: [
+                                        Object(
+                                            ObjectType {
+                                                span: 35..76,
+                                                props: [
+                                                    TProp {
+                                                        span: 36..53,
+                                                        name: "type",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: Lit(
+                                                            Str(
+                                                                Str {
+                                                                    span: 42..53,
+                                                                    value: "mousedown",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    TProp {
+                                                        span: 55..64,
+                                                        name: "x",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: Prim(
+                                                            PrimType {
+                                                                span: 58..64,
+                                                                prim: Num,
+                                                            },
+                                                        ),
+                                                    },
+                                                    TProp {
+                                                        span: 66..75,
+                                                        name: "y",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: Prim(
+                                                            PrimType {
+                                                                span: 69..75,
+                                                                prim: Num,
+                                                            },
+                                                        ),
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                    ],
+                                },
+                            ),
+                            Object(
+                                ObjectType {
+                                    span: 89..119,
+                                    props: [
+                                        TProp {
+                                            span: 90..105,
+                                            name: "type",
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 96..105,
+                                                        value: "keydown",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                        TProp {
+                                            span: 107..118,
+                                            name: "key",
+                                            optional: false,
+                                            mutable: false,
+                                            type_ann: Prim(
+                                                PrimType {
+                                                    span: 112..118,
+                                                    prim: Str,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__types.snap
@@ -1,0 +1,97 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(\"let get_bar = <T>(foo: Foo<T>) => foo.bar\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 4..41,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 4..11,
+                        id: Ident {
+                            span: 4..11,
+                            name: "get_bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Lambda(
+                        Lambda {
+                            span: 14..41,
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
+                                            span: 18..21,
+                                            id: Ident {
+                                                span: 18..21,
+                                                name: "foo",
+                                            },
+                                        },
+                                    ),
+                                    type_ann: Some(
+                                        TypeRef(
+                                            TypeRef {
+                                                span: 23..29,
+                                                name: "Foo",
+                                                type_params: Some(
+                                                    [
+                                                        TypeRef(
+                                                            TypeRef {
+                                                                span: 27..28,
+                                                                name: "T",
+                                                                type_params: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Member(
+                                Member {
+                                    span: 34..41,
+                                    obj: Ident(
+                                        Ident {
+                                            span: 34..37,
+                                            name: "foo",
+                                        },
+                                    ),
+                                    prop: Ident(
+                                        Ident {
+                                            span: 38..41,
+                                            name: "bar",
+                                        },
+                                    ),
+                                },
+                            ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: Some(
+                                [
+                                    TypeParam {
+                                        span: 15..16,
+                                        name: Ident {
+                                            span: 15..16,
+                                            name: "T",
+                                        },
+                                        constraint: None,
+                                        default: None,
+                                    },
+                                ],
+                            ),
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/tree_sitter_crochet/grammar/js.js
+++ b/crates/tree_sitter_crochet/grammar/js.js
@@ -651,6 +651,9 @@ module.exports = grammar({
     jsx_attribute: ($) =>
       seq($._jsx_attribute_name, optional(seq("=", $._jsx_attribute_value))),
 
+    // TODO: It seems like we should be able to simplify this since
+    // jsx_expression should always match anythign that _jsx_element or
+    // jsx_fragment would.
     _jsx_attribute_value: ($) =>
       choice($.string, $.jsx_expression, $._jsx_element, $.jsx_fragment),
 

--- a/crates/tree_sitter_crochet/grammar/js.js
+++ b/crates/tree_sitter_crochet/grammar/js.js
@@ -953,6 +953,7 @@ module.exports = grammar({
         )
       ),
 
+    // TODO: remove sequence expressions
     sequence_expression: ($) =>
       seq(
         field("left", $.expression),

--- a/crates/tree_sitter_crochet/grammar/tsx.js
+++ b/crates/tree_sitter_crochet/grammar/tsx.js
@@ -861,7 +861,7 @@ module.exports = grammar(require("./js"), {
         "symbol",
         "void",
         "unknown",
-        "string",
+        "string", // TODO: remove duplicates from choice()
         "never",
         "object"
       ),

--- a/crates/tree_sitter_crochet/grammar/tsx.js
+++ b/crates/tree_sitter_crochet/grammar/tsx.js
@@ -898,6 +898,8 @@ module.exports = grammar(require("./js"), {
         optional($.accessibility_modifier),
         optional("static"),
         optional($.override_modifier),
+        // TODO: change this to "mutable" or just "mut" since everything
+        // will immutable by default
         optional("readonly"),
         field("name", $._property_name),
         optional("?"),


### PR DESCRIPTION
This only covers some basics where the syntax is the same between Crochet and TSX.  In future PRs, I'll modify the tree-sitter grammar to be closer to Crochet's current grammar.

TODO:
- [x] handle parsing type annotations
- [x] handle more patterns (array, object, rest)
- [x] object, array/tuple, literals
- [x] async/await
- [x] template string literals
- [x] member access
- [x] decls and type decls
- [x] JSX