### PR TITLE
Add support for do-expressions

### DIFF
--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -38,6 +38,11 @@ pub fn codegen_js(program: &ast::Program) -> String {
         runtime: Some(Runtime::Automatic),
         ..Default::default()
     };
+    let x = {
+        let y = 10;
+        let z = 15;
+        y + z
+    };
 
     let globals = Globals::default();
     // The call to Mark::new() must be wrapped in a GLOBALS.set() closure

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -38,11 +38,6 @@ pub fn codegen_js(program: &ast::Program) -> String {
         runtime: Some(Runtime::Automatic),
         ..Default::default()
     };
-    let x = {
-        let y = 10;
-        let z = 15;
-        y + z
-    };
 
     let globals = Globals::default();
     // The call to Mark::new() must be wrapped in a GLOBALS.set() closure

--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -315,8 +315,8 @@ Objects
 --------------------------------------------------------------------------------
 
 (program
-  (statement_block)
-  (empty_statement)
+  (expression_statement
+    (object))
   (expression_statement
     (object
       (pair

--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -2125,3 +2125,83 @@ i = <Foo:Bar bar={}>{...children}</Foo:Bar>
           (jsx_namespace_name
             (identifier)
             (identifier)))))))
+
+================================================================================
+Do expressions
+================================================================================
+
+let sum = do {x = 5; y = 10; x + y}
+
+let nested = do { do { x = 5; y = 10; x + y} }
+
+let objectReturn = do { {x, y} }
+
+let sum = do { x } + do { y }
+
+do { x } while (do { x > y })
+
+--------------------------------------------------------------------------------
+
+(program
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (do_expression
+        (expression_statement
+          (assignment_expression
+            (identifier)
+            (number)))
+        (expression_statement
+          (assignment_expression
+            (identifier)
+            (number)))
+        (expression_statement
+          (binary_expression
+            (identifier)
+            (identifier))))))
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (do_expression
+        (expression_statement
+          (do_expression
+            (expression_statement
+              (assignment_expression
+                (identifier)
+                (number)))
+            (expression_statement
+              (assignment_expression
+                (identifier)
+                (number)))
+            (expression_statement
+              (binary_expression
+                (identifier)
+                (identifier))))))))
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (do_expression
+        (expression_statement
+          (object
+            (shorthand_property_identifier)
+            (shorthand_property_identifier))))))
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (binary_expression
+        (do_expression
+          (expression_statement
+            (identifier)))
+        (do_expression
+          (expression_statement
+            (identifier))))))
+  (do_statement
+    (statement_block
+      (expression_statement
+        (identifier)))
+    (parenthesized_expression
+      (do_expression
+        (expression_statement
+          (binary_expression
+            (identifier)
+            (identifier)))))))

--- a/crates/tree_sitter_crochet/corpus/semicolon_insertion.txt
+++ b/crates/tree_sitter_crochet/corpus/semicolon_insertion.txt
@@ -277,10 +277,10 @@ if/for/while/do statements without semicolons
 ================================================================================
 
 if (a) { if (b) { return c } }
-if (d) { for (;;) break }
-if (e) { for (f in g) break }
-if (h) { for (i of j) continue }
-if (k) { while (l) break }
+if (d) { for (;;) { break } }
+if (e) { for (f in g) { break } }
+if (h) { for (i of j) { continue } }
+if (k) { while (l) { break } }
 if (m) { do { n; } while (o) }
 if (p) { var q }
 
@@ -307,7 +307,8 @@ if (p) { var q }
         (for_statement
           (empty_statement)
           (empty_statement)
-          (break_statement)))))
+          (statement_block
+            (break_statement))))))
   (expression_statement
     (if_expression
       (parenthesized_expression
@@ -316,7 +317,8 @@ if (p) { var q }
         (for_in_statement
           (identifier)
           (identifier)
-          (break_statement)))))
+          (statement_block
+            (break_statement))))))
   (expression_statement
     (if_expression
       (parenthesized_expression
@@ -325,7 +327,8 @@ if (p) { var q }
         (for_in_statement
           (identifier)
           (identifier)
-          (continue_statement)))))
+          (statement_block
+            (continue_statement))))))
   (expression_statement
     (if_expression
       (parenthesized_expression
@@ -334,7 +337,8 @@ if (p) { var q }
         (while_statement
           (parenthesized_expression
             (identifier))
-          (break_statement)))))
+          (statement_block
+            (break_statement))))))
   (expression_statement
     (if_expression
       (parenthesized_expression

--- a/crates/tree_sitter_crochet/corpus/statements.txt
+++ b/crates/tree_sitter_crochet/corpus/statements.txt
@@ -411,11 +411,13 @@ let result = if (a) {
 For statements
 ================================================================================
 
-for (var a; c; d)
+for (var a; c; d) {
   e;
+}
 
-for (i = 0; i < 10; i++)
+for (i = 0; i < 10; i++) {
   log(y);
+}
 
 for (;;) {
   z;
@@ -437,8 +439,9 @@ for (var i = 0
     condition: (expression_statement
       (identifier))
     increment: (identifier)
-    body: (expression_statement
-      (identifier)))
+    body: (statement_block
+      (expression_statement
+        (identifier))))
   (for_statement
     initializer: (expression_statement
       (assignment_expression
@@ -450,11 +453,12 @@ for (var i = 0
         right: (number)))
     increment: (update_expression
       argument: (identifier))
-    body: (expression_statement
-      (call_expression
-        function: (identifier)
-        arguments: (arguments
-          (identifier)))))
+    body: (statement_block
+      (expression_statement
+        (call_expression
+          function: (identifier)
+          arguments: (arguments
+            (identifier))))))
   (for_statement
     initializer: (empty_statement)
     condition: (empty_statement)
@@ -479,14 +483,17 @@ for (var i = 0
 For-in statements
 ================================================================================
 
-for (item in items)
+for (item in items) {
   item();
+}
 
-for (var item in items || {})
+for (var item in items || {}) {
   item();
+}
 
-for (const {thing} in things)
+for (const {thing} in things) {
   thing();
+}
 
 for (x[i] in a) {}
 
@@ -504,27 +511,30 @@ for (var foo = bar in baz) {}
   (for_in_statement
     (identifier)
     (identifier)
-    (expression_statement
-      (call_expression
-        (identifier)
-        (arguments))))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments)))))
   (for_in_statement
     (identifier)
     (binary_expression
       (identifier)
       (object))
-    (expression_statement
-      (call_expression
-        (identifier)
-        (arguments))))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments)))))
   (for_in_statement
     (object_pattern
       (shorthand_property_identifier_pattern))
     (identifier)
-    (expression_statement
-      (call_expression
-        (identifier)
-        (arguments))))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments)))))
   (for_in_statement
     (subscript_expression
       (identifier)
@@ -590,11 +600,13 @@ for (key in something && i = 0; i < n; i++) {
 For-of statements
 ================================================================================
 
-for (a of b)
+for (a of b) {
   process(a);
+}
 
-for (let {a, b} of items || [])
+for (let {a, b} of items || []) {
   process(a, b);
+}
 
 --------------------------------------------------------------------------------
 
@@ -602,11 +614,12 @@ for (let {a, b} of items || [])
   (for_in_statement
     (identifier)
     (identifier)
-    (expression_statement
-      (call_expression
-        (identifier)
-        (arguments
-          (identifier)))))
+    (statement_block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier))))))
   (for_in_statement
     (object_pattern
       (shorthand_property_identifier_pattern)
@@ -614,12 +627,13 @@ for (let {a, b} of items || [])
     (binary_expression
       (identifier)
       (array))
-    (expression_statement
-      (call_expression
-        (identifier)
-        (arguments
+    (statement_block
+      (expression_statement
+        (call_expression
           (identifier)
-          (identifier))))))
+          (arguments
+            (identifier)
+            (identifier)))))))
 
 ================================================================================
 For-await-of statements
@@ -645,8 +659,9 @@ for await (const chunk of stream) {
 While statements
 ================================================================================
 
-while (a)
+while (a) {
   b();
+}
 
 while (a) {
 
@@ -658,10 +673,11 @@ while (a) {
   (while_statement
     condition: (parenthesized_expression
       (identifier))
-    body: (expression_statement
-      (call_expression
-        function: (identifier)
-        arguments: (arguments))))
+    body: (statement_block
+      (expression_statement
+        (call_expression
+          function: (identifier)
+          arguments: (arguments)))))
   (while_statement
     condition: (parenthesized_expression
       (identifier))
@@ -675,8 +691,6 @@ do {
   a;
 } while (b)
 
-do a; while (b)
-
 do {} while (b)
 
 --------------------------------------------------------------------------------
@@ -686,11 +700,6 @@ do {} while (b)
     body: (statement_block
       (expression_statement
         (identifier)))
-    condition: (parenthesized_expression
-      (identifier)))
-  (do_statement
-    body: (expression_statement
-      (identifier))
     condition: (parenthesized_expression
       (identifier)))
   (do_statement
@@ -884,14 +893,17 @@ Switch statements
 
 switch (x) {
   case 1:
-  case 2:
+  case 2: {
     something();
     break;
-  case "three":
+  }
+  case "three": {
     somethingElse();
     break;
-  default:
+  }
+  default: {
     return 4;
+  }
 }
 
 --------------------------------------------------------------------------------
@@ -902,25 +914,29 @@ switch (x) {
       (identifier))
     (switch_body
       (switch_case
-        (number))
-      (switch_case
         (number)
-        (expression_statement
-          (call_expression
-            (identifier)
-            (arguments)))
-        (break_statement))
+        (ERROR
+          (identifier)
+          (number))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments)))
+          (break_statement)))
       (switch_case
         (string
           (string_fragment))
-        (expression_statement
-          (call_expression
-            (identifier)
-            (arguments)))
-        (break_statement))
+        (statement_block
+          (expression_statement
+            (call_expression
+              (identifier)
+              (arguments)))
+          (break_statement)))
       (switch_default
-        (return_statement
-          (number))))))
+        (statement_block
+          (return_statement
+            (number)))))))
 
 ================================================================================
 Throw statements
@@ -1031,7 +1047,7 @@ for (;;) {
 }
 
 label
-: {
+: do {
   break label;
 }
 
@@ -1062,9 +1078,10 @@ while (true) {
                   label: (statement_identifier)))))))))
   (labeled_statement
     label: (statement_identifier)
-    body: (statement_block
-      (break_statement
-        label: (statement_identifier))))
+    body: (expression_statement
+      (do_expression
+        (break_statement
+          label: (statement_identifier)))))
   (labeled_statement
     label: (statement_identifier)
     body: (while_statement

--- a/crates/tree_sitter_crochet/corpus/statements.txt
+++ b/crates/tree_sitter_crochet/corpus/statements.txt
@@ -892,7 +892,7 @@ Switch statements
 ================================================================================
 
 switch (x) {
-  case 1:
+  case 1: {}
   case 2: {
     something();
     break;
@@ -915,9 +915,9 @@ switch (x) {
     (switch_body
       (switch_case
         (number)
-        (ERROR
-          (identifier)
-          (number))
+        (statement_block))
+      (switch_case
+        (number)
         (statement_block
           (expression_statement
             (call_expression

--- a/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
@@ -46,10 +46,12 @@ declare module Foo {
   1;
   return;
   switch (x) {
-      case 1:
+      case 1: {
           break;
-      default:
+      }
+      default: {
           break;
+      }
   }
   throw "hello";
   try { }
@@ -196,9 +198,11 @@ declare module Foo {
           body: (switch_body
             (switch_case
               value: (number)
-              body: (break_statement))
+              body: (statement_block
+                (break_statement)))
             (switch_default
-              body: (break_statement))))
+              body: (statement_block
+                (break_statement)))))
         (throw_statement
           (string
             (string_fragment)))

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -1,52 +1,108 @@
 const tsx = require("tree-sitter-typescript/tsx/grammar.js");
 
+const replaceField = (prev, name, replacement) => {
+  const members = prev.members.map((member) => {
+    if (member.type === "FIELD" && member.name === name) {
+      return field(name, replacement);
+    } else {
+      return member;
+    }
+  });
+
+  return seq(...members);
+};
+
 module.exports = grammar(tsx, {
   name: "crochet",
 
+  // conflicts: ($, previous) =>
+  //   previous.concat([
+  //     [$.object, $.object_type, $.statement_block],
+  //     [$.object, $.object_pattern, $.object_type, $.statement_block],
+  //     [$.object_type, $.statement_block],
+  //     [$.object_type, $.empty_statement],
+
+  //     [$.primary_expression, $.method_definition, $.method_signature],
+  //     [
+  //       $.primary_expression,
+  //       $.method_definition,
+  //       $.method_signature,
+  //       $.property_signature,
+  //     ],
+  //     [
+  //       $.primary_expression,
+  //       $.method_definition,
+  //       $.method_signature,
+  //       $.property_signature,
+  //       $.index_signature,
+  //     ],
+  //     [$.primary_expression, $.index_signature],
+  //   ]),
+
   rules: {
     // Removes sequence expression and optional flow-style type assertion
-    parenthesized_expression: ($, previous) => {
+    parenthesized_expression: ($, prev) => {
       return seq("(", $.expression, ")");
     },
 
     // Removes sequence expression
-    _expressions: ($, previous) => {
+    _expressions: ($, prev) => {
       return $.expression;
     },
 
-    expression: ($, previous) => {
+    expression: ($, prev) => {
       // Removes ternary expression
-      const choices = previous.members.filter(
+      const choices = prev.members.filter(
         (member) => member.name !== "ternary_expression"
       );
+
       // Makes if-else an expression
       choices.push($.if_expression);
+      choices.push($.do_expression);
+
       return choice(...choices);
     },
 
     // Removes with statement
-    statement: ($, previous) => {
-      const choices = previous.members.filter(
+    statement: ($, prev) => {
+      const choices = prev.members.filter(
         (member) =>
-          member.name !== "with_statement" && member.name !== "if_statement"
+          ![
+            "with_statement",
+            "if_statement",
+            "label_statement",
+            "statement_block",
+          ].includes(member.name)
       );
       return choice(...choices);
     },
 
-    else_clause: ($, previous) => {
-      // Always require the alternative to be in a block
-      return seq("else", choice($.if_expression, $.statement_block));
-    },
-    if_expression: ($, previous) => {
-      return prec.right(
+    // Removes the optional semicolon
+    statement_block: ($, prev) =>
+      prec.right(seq("{", repeat($.statement), "}")),
+
+    do_expression: ($) => seq("do", "{", repeat($.statement), "}"),
+
+    for_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
+    for_in_statement: ($, prev) =>
+      replaceField(prev, "body", $.statement_block),
+    while_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
+    do_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
+    switch_case: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
+    switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
+
+    if_expression: ($, prev) =>
+      prec.right(
         seq(
           "if",
           field("condition", $.parenthesized_expression),
-          // Always require the alternative to be in a block
+          // Always require the consequence to be a block
           field("consequence", $.statement_block),
           optional(field("alternative", $.else_clause))
         )
-      );
-    },
+      ),
+    else_clause: ($, prev) =>
+      // Always require the alternative to be a block
+      seq("else", choice($.if_expression, $.statement_block)),
   },
 });

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -32,8 +32,9 @@ module.exports = grammar(tsx, {
         (member) => member.name !== "ternary_expression"
       );
 
-      choices.push($.if_expression);
+      choices.push(alias($.if_statement, $.if_expression));
       choices.push($.do_expression);
+      // choices.push($.try_statement);
 
       return choice(...choices);
     },
@@ -45,7 +46,7 @@ module.exports = grammar(tsx, {
           ![
             "with_statement",
             "if_statement",
-            "label_statement",
+            // "try_statement",
             "statement_block",
           ].includes(member.name)
       );
@@ -66,18 +67,13 @@ module.exports = grammar(tsx, {
     switch_case: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
     switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
 
-    if_expression: ($, prev) =>
-      prec.right(
-        seq(
-          "if",
-          field("condition", $.parenthesized_expression),
-          // Always require the consequence to be a block
-          field("consequence", $.statement_block),
-          optional(field("alternative", $.else_clause))
-        )
-      ),
+    if_statement: ($, prev) =>
+      prec.right(replaceField(prev.content, "consequence", $.statement_block)),
     else_clause: ($, prev) =>
       // Always require the alternative to be a block
-      seq("else", choice($.if_expression, $.statement_block)),
+      seq(
+        "else",
+        choice(alias($.if_statement, $.if_expression), $.statement_block)
+      ),
   },
 });

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -15,30 +15,6 @@ const replaceField = (prev, name, replacement) => {
 module.exports = grammar(tsx, {
   name: "crochet",
 
-  // conflicts: ($, previous) =>
-  //   previous.concat([
-  //     [$.object, $.object_type, $.statement_block],
-  //     [$.object, $.object_pattern, $.object_type, $.statement_block],
-  //     [$.object_type, $.statement_block],
-  //     [$.object_type, $.empty_statement],
-
-  //     [$.primary_expression, $.method_definition, $.method_signature],
-  //     [
-  //       $.primary_expression,
-  //       $.method_definition,
-  //       $.method_signature,
-  //       $.property_signature,
-  //     ],
-  //     [
-  //       $.primary_expression,
-  //       $.method_definition,
-  //       $.method_signature,
-  //       $.property_signature,
-  //       $.index_signature,
-  //     ],
-  //     [$.primary_expression, $.index_signature],
-  //   ]),
-
   rules: {
     // Removes sequence expression and optional flow-style type assertion
     parenthesized_expression: ($, prev) => {
@@ -56,7 +32,6 @@ module.exports = grammar(tsx, {
         (member) => member.name !== "ternary_expression"
       );
 
-      // Makes if-else an expression
       choices.push($.if_expression);
       choices.push($.do_expression);
 

--- a/crates/tree_sitter_crochet/src/grammar.json
+++ b/crates/tree_sitter_crochet/src/grammar.json
@@ -736,10 +736,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "statement_block"
-        },
-        {
-          "type": "SYMBOL",
           "name": "switch_statement"
         },
         {
@@ -994,18 +990,6 @@
           {
             "type": "STRING",
             "value": "}"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_automatic_semicolon"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
           }
         ]
       }
@@ -1180,7 +1164,7 @@
           "name": "body",
           "content": {
             "type": "SYMBOL",
-            "name": "statement"
+            "name": "statement_block"
           }
         }
       ]
@@ -1213,7 +1197,7 @@
           "name": "body",
           "content": {
             "type": "SYMBOL",
-            "name": "statement"
+            "name": "statement_block"
           }
         }
       ]
@@ -1379,7 +1363,7 @@
           "name": "body",
           "content": {
             "type": "SYMBOL",
-            "name": "statement"
+            "name": "statement_block"
           }
         }
       ]
@@ -1396,7 +1380,7 @@
           "name": "body",
           "content": {
             "type": "SYMBOL",
-            "name": "statement"
+            "name": "statement_block"
           }
         },
         {
@@ -1713,11 +1697,8 @@
           "type": "FIELD",
           "name": "body",
           "content": {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "statement"
-            }
+            "type": "SYMBOL",
+            "name": "statement_block"
           }
         }
       ]
@@ -1737,11 +1718,8 @@
           "type": "FIELD",
           "name": "body",
           "content": {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "statement"
-            }
+            "type": "SYMBOL",
+            "name": "statement_block"
           }
         }
       ]
@@ -1917,6 +1895,10 @@
         {
           "type": "SYMBOL",
           "name": "if_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "do_expression"
         }
       ]
     },
@@ -10247,6 +10229,30 @@
       },
       "named": true,
       "value": "type_identifier"
+    },
+    "do_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "do"
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
     },
     "if_expression": {
       "type": "PREC_RIGHT",

--- a/crates/tree_sitter_crochet/src/grammar.json
+++ b/crates/tree_sitter_crochet/src/grammar.json
@@ -1005,8 +1005,13 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "if_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "if_statement"
+              },
+              "named": true,
+              "value": "if_expression"
             },
             {
               "type": "SYMBOL",
@@ -1039,7 +1044,7 @@
             "name": "consequence",
             "content": {
               "type": "SYMBOL",
-              "name": "statement"
+              "name": "statement_block"
             }
           },
           {
@@ -1893,8 +1898,13 @@
           "name": "yield_expression"
         },
         {
-          "type": "SYMBOL",
-          "name": "if_expression"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "if_statement"
+          },
+          "named": true,
+          "value": "if_expression"
         },
         {
           "type": "SYMBOL",
@@ -10253,51 +10263,6 @@
           "value": "}"
         }
       ]
-    },
-    "if_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "if"
-          },
-          {
-            "type": "FIELD",
-            "name": "condition",
-            "content": {
-              "type": "SYMBOL",
-              "name": "parenthesized_expression"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "consequence",
-            "content": {
-              "type": "SYMBOL",
-              "name": "statement_block"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "alternative",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "else_clause"
-                }
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
     }
   },
   "extras": [

--- a/crates/tree_sitter_crochet/src/node-types.json
+++ b/crates/tree_sitter_crochet/src/node-types.json
@@ -168,6 +168,10 @@
         "named": true
       },
       {
+        "type": "do_expression",
+        "named": true
+      },
+      {
         "type": "glimmer_template",
         "named": true
       },
@@ -407,10 +411,6 @@
       },
       {
         "type": "return_statement",
-        "named": true
-      },
-      {
-        "type": "statement_block",
         "named": true
       },
       {
@@ -1778,6 +1778,21 @@
     }
   },
   {
+    "type": "do_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "statement",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "do_statement",
     "named": true,
     "fields": {
@@ -1786,7 +1801,7 @@
         "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -2156,7 +2171,7 @@
         "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -2262,7 +2277,7 @@
         "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -5015,11 +5030,11 @@
     "named": true,
     "fields": {
       "body": {
-        "multiple": true,
-        "required": false,
+        "multiple": false,
+        "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -5041,11 +5056,11 @@
     "named": true,
     "fields": {
       "body": {
-        "multiple": true,
-        "required": false,
+        "multiple": false,
+        "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -5680,7 +5695,7 @@
         "required": true,
         "types": [
           {
-            "type": "statement",
+            "type": "statement_block",
             "named": true
           }
         ]
@@ -6142,11 +6157,11 @@
   },
   {
     "type": "number",
-    "named": false
+    "named": true
   },
   {
     "type": "number",
-    "named": true
+    "named": false
   },
   {
     "type": "object",


### PR DESCRIPTION
This PR also updates a number of statements that were using `field("body", $.statement)` to use `field("body", $.statement_block)` instead, e.g. `while`, `for`, etc.

TODO:
- [x] add do-expression test cases to corpus