### PR TITLE
Update statement_block to allow a trailing expression

### DIFF
--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -1237,7 +1237,7 @@ class Foo {
 
 async (a) => { return foo; };
 
-async function* foo() { yield 1; }
+async function* foo() { yield 1 }
 
 --------------------------------------------------------------------------------
 
@@ -1271,9 +1271,8 @@ async function* foo() { yield 1; }
     (identifier)
     (formal_parameters)
     (statement_block
-      (expression_statement
-        (yield_expression
-          (number))))))
+      (yield_expression
+        (number)))))
 
 ================================================================================
 Math operators
@@ -1907,7 +1906,7 @@ Forward slashes after parenthesized expressions
 ================================================================================
 
 (foo - bar) / baz;
-if (foo - bar) { /baz/; };
+if (foo - bar) { /baz/ };
 (this.a() / this.b() - 1) / 2;
 
 --------------------------------------------------------------------------------
@@ -1927,9 +1926,8 @@ if (foo - bar) { /baz/; };
           (identifier)
           (identifier)))
       (statement_block
-        (expression_statement
-          (regex
-            (regex_pattern))))))
+        (regex
+          (regex_pattern)))))
   (expression_statement
     (binary_expression
       (parenthesized_expression
@@ -2130,15 +2128,15 @@ i = <Foo:Bar bar={}>{...children}</Foo:Bar>;
 Do expressions
 ================================================================================
 
-let sum = do {x = 5; y = 10; x + y;};
+let sum = do {x = 5; y = 10; x + y};
 
-let nested = do { do { x = 5; y = 10; x + y;}; };
+let nested = do { do { x = 5; y = 10; x + y} };
 
-let objectReturn = do { {x, y}; };
+let objectReturn = do { {x, y} };
 
-let sum = do { x; } + do { y; };
+let sum = do { x } + do { y };
 
-do { x; } while (do { x > y; });
+do { x } while (do { x > y });
 
 --------------------------------------------------------------------------------
 
@@ -2147,15 +2145,15 @@ do { x; } while (do { x > y; });
     (variable_declarator
       (identifier)
       (do_expression
-        (expression_statement
-          (assignment_expression
-            (identifier)
-            (number)))
-        (expression_statement
-          (assignment_expression
-            (identifier)
-            (number)))
-        (expression_statement
+        (statement_block
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (number)))
+          (expression_statement
+            (assignment_expression
+              (identifier)
+              (number)))
           (binary_expression
             (identifier)
             (identifier))))))
@@ -2163,17 +2161,17 @@ do { x; } while (do { x > y; });
     (variable_declarator
       (identifier)
       (do_expression
-        (expression_statement
+        (statement_block
           (do_expression
-            (expression_statement
-              (assignment_expression
-                (identifier)
-                (number)))
-            (expression_statement
-              (assignment_expression
-                (identifier)
-                (number)))
-            (expression_statement
+            (statement_block
+              (expression_statement
+                (assignment_expression
+                  (identifier)
+                  (number)))
+              (expression_statement
+                (assignment_expression
+                  (identifier)
+                  (number)))
               (binary_expression
                 (identifier)
                 (identifier))))))))
@@ -2181,7 +2179,7 @@ do { x; } while (do { x > y; });
     (variable_declarator
       (identifier)
       (do_expression
-        (expression_statement
+        (statement_block
           (object
             (shorthand_property_identifier)
             (shorthand_property_identifier))))))
@@ -2190,18 +2188,17 @@ do { x; } while (do { x > y; });
       (identifier)
       (binary_expression
         (do_expression
-          (expression_statement
+          (statement_block
             (identifier)))
         (do_expression
-          (expression_statement
+          (statement_block
             (identifier))))))
   (do_statement
     (statement_block
-      (expression_statement
-        (identifier)))
+      (identifier))
     (parenthesized_expression
       (do_expression
-        (expression_statement
+        (statement_block
           (binary_expression
             (identifier)
             (identifier)))))))
@@ -2210,10 +2207,10 @@ do { x; } while (do { x > y; });
 Try catch finally expressions
 ================================================================================
 
-let result = try { a; } catch (b) { c; };
-let result = try { d; } finally { e; };
-let result = try { f; } catch { g; } finally { h; };
-let result = try { throw [a, b]; } catch ([c, d]) { };
+let result = try { a } catch (b) { c };
+let result = try { d } finally { e };
+let result = try { f } catch { g } finally { h };
+let result = try { throw [a, b] } catch ([c, d]) { };
 
 --------------------------------------------------------------------------------
 
@@ -2223,49 +2220,41 @@ let result = try { throw [a, b]; } catch ([c, d]) { };
       (identifier)
       (try_statement
         (statement_block
-          (expression_statement
-            (identifier)))
+          (identifier))
         (catch_clause
           (identifier)
           (statement_block
-            (expression_statement
-              (identifier)))))))
+            (identifier))))))
   (lexical_declaration
     (variable_declarator
       (identifier)
       (try_statement
         (statement_block
-          (expression_statement
-            (identifier)))
+          (identifier))
         (finally_clause
           (statement_block
-            (expression_statement
-              (identifier)))))))
+            (identifier))))))
   (lexical_declaration
     (variable_declarator
       (identifier)
       (try_statement
         (statement_block
-          (expression_statement
-            (identifier)))
+          (identifier))
         (catch_clause
           (statement_block
-            (expression_statement
-              (identifier))))
+            (identifier)))
         (finally_clause
           (statement_block
-            (expression_statement
-              (identifier)))))))
+            (identifier))))))
   (lexical_declaration
     (variable_declarator
       (identifier)
       (try_statement
         (statement_block
-          (expression_statement
-            (unary_expression
-              (array
-                (identifier)
-                (identifier)))))
+          (unary_expression
+            (array
+              (identifier)
+              (identifier))))
         (catch_clause
           (array_pattern
             (identifier)

--- a/crates/tree_sitter_crochet/corpus/statements.txt
+++ b/crates/tree_sitter_crochet/corpus/statements.txt
@@ -960,10 +960,10 @@ throw new Error("uh oh");
 Try catch finally statements
 ================================================================================
 
-try { a; } catch (b) { c; };
-try { d; } finally { e; };
-try { f; } catch { g; } finally { h; };
-try { throw [a, b]; } catch ([c, d]) { };
+try { a } catch (b) { c };
+try { d } finally { e };
+try { f } catch { g } finally { h };
+try { throw [a, b] } catch ([c, d]) { };
 
 --------------------------------------------------------------------------------
 
@@ -971,43 +971,35 @@ try { throw [a, b]; } catch ([c, d]) { };
   (expression_statement
     (try_statement
       (statement_block
-        (expression_statement
-          (identifier)))
+        (identifier))
       (catch_clause
         (identifier)
         (statement_block
-          (expression_statement
-            (identifier))))))
+          (identifier)))))
   (expression_statement
     (try_statement
       (statement_block
-        (expression_statement
-          (identifier)))
+        (identifier))
       (finally_clause
         (statement_block
-          (expression_statement
-            (identifier))))))
+          (identifier)))))
   (expression_statement
     (try_statement
       (statement_block
-        (expression_statement
-          (identifier)))
+        (identifier))
       (catch_clause
         (statement_block
-          (expression_statement
-            (identifier))))
+          (identifier)))
       (finally_clause
         (statement_block
-          (expression_statement
-            (identifier))))))
+          (identifier)))))
   (expression_statement
     (try_statement
       (statement_block
-        (expression_statement
-          (unary_expression
-            (array
-              (identifier)
-              (identifier)))))
+        (unary_expression
+          (array
+            (identifier)
+            (identifier))))
       (catch_clause
         (array_pattern
           (identifier)
@@ -1087,8 +1079,9 @@ while (true) {
     label: (statement_identifier)
     body: (expression_statement
       (do_expression
-        (break_statement
-          label: (statement_identifier)))))
+        (statement_block
+          (break_statement
+            label: (statement_identifier))))))
   (labeled_statement
     label: (statement_identifier)
     body: (while_statement

--- a/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
@@ -207,15 +207,13 @@ declare module Foo {
           (unary_expression
             argument: (string
               (string_fragment))))
-        (expression_statement
-          (try_statement
-            body: (statement_block)
-            handler: (catch_clause
-              parameter: (identifier)
-              body: (statement_block))
-            finalizer: (finally_clause
-              body: (statement_block)))
-          (MISSING ";"))))))
+        (try_statement
+          body: (statement_block)
+          handler: (catch_clause
+            parameter: (identifier)
+            body: (statement_block))
+          finalizer: (finally_clause
+            body: (statement_block)))))))
 
 ================================================================================
 Exception handling

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -58,13 +58,15 @@ module.exports = grammar(tsx, {
     },
 
     // Removes the automatic semicolon insertion from these nodes
-    statement_block: ($, prev) => prec.right(dropLastMember(prev.content)),
     class_declaration: ($, prev) =>
       prec("declaration", dropLastMember(prev.content)),
     function_declaration: ($, prev) =>
       prec.right("declaration", dropLastMember(prev.content)),
     generator_function_declaration: ($, prev) =>
       prec.right("declaration", dropLastMember(prev.content)),
+
+    statement_block: ($, prev) =>
+      seq("{", repeat($.statement), optional($.expression), "}"),
 
     // Requires these statements ot use { }
     for_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
@@ -76,7 +78,7 @@ module.exports = grammar(tsx, {
     switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
 
     // Add do-expressions
-    do_expression: ($) => seq("do", "{", repeat($.statement), "}"),
+    do_expression: ($) => seq("do", $.statement_block),
 
     // Make if-else an expression
     if_statement: ($, prev) =>

--- a/crates/tree_sitter_crochet/src/grammar.json
+++ b/crates/tree_sitter_crochet/src/grammar.json
@@ -963,28 +963,36 @@
       ]
     },
     "statement_block": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SYMBOL",
-              "name": "statement"
-            }
-          },
-          {
-            "type": "STRING",
-            "value": "}"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
           }
-        ]
-      }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
     },
     "else_clause": {
       "type": "SEQ",
@@ -10203,19 +10211,8 @@
           "value": "do"
         },
         {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "statement"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "statement_block"
         }
       ]
     }

--- a/crates/tree_sitter_crochet/src/node-types.json
+++ b/crates/tree_sitter_crochet/src/node-types.json
@@ -1778,11 +1778,11 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "statement",
+          "type": "statement_block",
           "named": true
         }
       ]
@@ -4928,6 +4928,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
         {
           "type": "statement",
           "named": true


### PR DESCRIPTION
This will allow us to write things like:
```
const foo = (): number => {
  let x = 5;
  let y = 10;
  x + y
}
```
The last line in this example is `expression` instead of an `expression_statement`.

The last line can be either an `expression` or an `expression_statement`.  In the case of the former, that value will be used as the value for the block (and in the case of functions/methods it will be the return value).  If is the latter, then the value of the block will be `undefined` effectively ignoring the value of the `expression_statement`.