### PR TITLE
Add support for parsing 'match' expressions to AST

### DIFF
--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__if_let-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__if_let-2.snap
@@ -1,0 +1,161 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n            let bar = if (let {x: x is string} = foo) {\n                \"object\"\n            } else if (let [a is Array, _, ...rest] = foo) {\n                \"array\"\n            } else {\n                \"other\"\n            };              \n            \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 17..225,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 17..20,
+                        id: Ident {
+                            span: 17..20,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    IfElse(
+                        IfElse {
+                            span: 23..225,
+                            cond: LetExpr(
+                                LetExpr {
+                                    span: 27..53,
+                                    pat: Object(
+                                        ObjectPat {
+                                            span: 31..47,
+                                            props: [
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 32..33,
+                                                            name: "x",
+                                                        },
+                                                        value: Is(
+                                                            IsPat {
+                                                                span: 35..46,
+                                                                id: Ident {
+                                                                    span: 35..36,
+                                                                    name: "x",
+                                                                },
+                                                                is_id: Ident {
+                                                                    span: 40..46,
+                                                                    name: "string",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                    expr: Ident(
+                                        Ident {
+                                            span: 50..53,
+                                            name: "foo",
+                                        },
+                                    ),
+                                },
+                            ),
+                            consequent: Lit(
+                                Str(
+                                    Str {
+                                        span: 73..81,
+                                        value: "object",
+                                    },
+                                ),
+                            ),
+                            alternate: Some(
+                                IfElse(
+                                    IfElse {
+                                        span: 101..225,
+                                        cond: LetExpr(
+                                            LetExpr {
+                                                span: 105..139,
+                                                pat: Array(
+                                                    ArrayPat {
+                                                        span: 109..133,
+                                                        elems: [
+                                                            Some(
+                                                                Is(
+                                                                    IsPat {
+                                                                        span: 110..120,
+                                                                        id: Ident {
+                                                                            span: 110..111,
+                                                                            name: "a",
+                                                                        },
+                                                                        is_id: Ident {
+                                                                            span: 115..120,
+                                                                            name: "Array",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            Some(
+                                                                Wildcard(
+                                                                    WildcardPat {
+                                                                        span: 122..123,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            Some(
+                                                                Rest(
+                                                                    RestPat {
+                                                                        span: 125..132,
+                                                                        arg: Ident(
+                                                                            BindingIdent {
+                                                                                span: 128..132,
+                                                                                id: Ident {
+                                                                                    span: 128..132,
+                                                                                    name: "rest",
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        ],
+                                                        optional: false,
+                                                    },
+                                                ),
+                                                expr: Ident(
+                                                    Ident {
+                                                        span: 136..139,
+                                                        name: "foo",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        consequent: Lit(
+                                            Str(
+                                                Str {
+                                                    span: 159..166,
+                                                    value: "array",
+                                                },
+                                            ),
+                                        ),
+                                        alternate: Some(
+                                            Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 204..211,
+                                                        value: "other",
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__if_let.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__if_let.snap
@@ -1,0 +1,177 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n            let bar = if (let {x, y: b, ...rest} = foo) {\n                \"object\"\n            } else if (let [a, _, ...rest] = foo) {\n                \"array\"\n            } else {\n                \"other\"\n            };              \n        \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 17..218,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 17..20,
+                        id: Ident {
+                            span: 17..20,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    IfElse(
+                        IfElse {
+                            span: 23..218,
+                            cond: LetExpr(
+                                LetExpr {
+                                    span: 27..55,
+                                    pat: Object(
+                                        ObjectPat {
+                                            span: 31..49,
+                                            props: [
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 32..33,
+                                                        key: Ident {
+                                                            span: 32..33,
+                                                            name: "x",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 35..36,
+                                                            name: "y",
+                                                        },
+                                                        value: Ident(
+                                                            BindingIdent {
+                                                                span: 38..39,
+                                                                id: Ident {
+                                                                    span: 38..39,
+                                                                    name: "b",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                Rest(
+                                                    RestPat {
+                                                        span: 41..48,
+                                                        arg: Ident(
+                                                            BindingIdent {
+                                                                span: 44..48,
+                                                                id: Ident {
+                                                                    span: 44..48,
+                                                                    name: "rest",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                    expr: Ident(
+                                        Ident {
+                                            span: 52..55,
+                                            name: "foo",
+                                        },
+                                    ),
+                                },
+                            ),
+                            consequent: Lit(
+                                Str(
+                                    Str {
+                                        span: 75..83,
+                                        value: "object",
+                                    },
+                                ),
+                            ),
+                            alternate: Some(
+                                IfElse(
+                                    IfElse {
+                                        span: 103..218,
+                                        cond: LetExpr(
+                                            LetExpr {
+                                                span: 107..132,
+                                                pat: Array(
+                                                    ArrayPat {
+                                                        span: 111..126,
+                                                        elems: [
+                                                            Some(
+                                                                Ident(
+                                                                    BindingIdent {
+                                                                        span: 112..113,
+                                                                        id: Ident {
+                                                                            span: 112..113,
+                                                                            name: "a",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            Some(
+                                                                Wildcard(
+                                                                    WildcardPat {
+                                                                        span: 115..116,
+                                                                    },
+                                                                ),
+                                                            ),
+                                                            Some(
+                                                                Rest(
+                                                                    RestPat {
+                                                                        span: 118..125,
+                                                                        arg: Ident(
+                                                                            BindingIdent {
+                                                                                span: 121..125,
+                                                                                id: Ident {
+                                                                                    span: 121..125,
+                                                                                    name: "rest",
+                                                                                },
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        ],
+                                                        optional: false,
+                                                    },
+                                                ),
+                                                expr: Ident(
+                                                    Ident {
+                                                        span: 129..132,
+                                                        name: "foo",
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        consequent: Lit(
+                                            Str(
+                                                Str {
+                                                    span: 152..159,
+                                                    value: "array",
+                                                },
+                                            ),
+                                        ),
+                                        alternate: Some(
+                                            Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 197..204,
+                                                        value: "other",
+                                                    },
+                                                ),
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-2.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/crochet_tree_sitter_parser/src/lib.rs
-expression: "parse(r#\"\n            let bar = match (foo) {\n                1 -> \"one\",\n                2 -> \"two\",\n                n if (n < 5) -> \"few\",\n                _ -> \"many\"\n              };\n            \"#)"
+expression: "parse(r#\"\n            let bar = match (foo) {\n                {a: {b: {c}}} -> \"object\",\n                _ -> \"fallthrough\"\n            };              \n            \"#)"
 ---
 Ok(
     Program {
         body: [
             VarDecl {
-                span: 17..175,
+                span: 17..128,
                 pattern: Ident(
                     BindingIdent {
                         span: 17..20,
@@ -20,7 +20,7 @@ Ok(
                 init: Some(
                     Match(
                         Match {
-                            span: 23..175,
+                            span: 23..128,
                             expr: Ident(
                                 Ident {
                                     span: 30..33,
@@ -29,106 +29,80 @@ Ok(
                             ),
                             arms: [
                                 Arm {
-                                    span: 53..63,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 53..54,
-                                            lit: Num(
-                                                Num {
-                                                    span: 53..54,
-                                                    value: "1",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    guard: None,
-                                    expr: Lit(
-                                        Str(
-                                            Str {
-                                                span: 58..63,
-                                                value: "one",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 81..91,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 81..82,
-                                            lit: Num(
-                                                Num {
-                                                    span: 81..82,
-                                                    value: "2",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    guard: None,
-                                    expr: Lit(
-                                        Str(
-                                            Str {
-                                                span: 86..91,
-                                                value: "two",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 109..130,
-                                    pattern: Ident(
-                                        BindingIdent {
-                                            span: 109..110,
-                                            id: Ident {
-                                                span: 109..110,
-                                                name: "n",
-                                            },
-                                        },
-                                    ),
-                                    guard: Some(
-                                        Op(
-                                            Op {
-                                                span: 115..120,
-                                                op: Lt,
-                                                left: Ident(
-                                                    Ident {
-                                                        span: 115..116,
-                                                        name: "n",
+                                    span: 53..78,
+                                    pattern: Object(
+                                        ObjectPat {
+                                            span: 53..66,
+                                            props: [
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 54..55,
+                                                            name: "a",
+                                                        },
+                                                        value: Object(
+                                                            ObjectPat {
+                                                                span: 57..65,
+                                                                props: [
+                                                                    KeyValue(
+                                                                        KeyValuePatProp {
+                                                                            key: Ident {
+                                                                                span: 58..59,
+                                                                                name: "b",
+                                                                            },
+                                                                            value: Object(
+                                                                                ObjectPat {
+                                                                                    span: 61..64,
+                                                                                    props: [
+                                                                                        Assign(
+                                                                                            AssignPatProp {
+                                                                                                span: 62..63,
+                                                                                                key: Ident {
+                                                                                                    span: 62..63,
+                                                                                                    name: "c",
+                                                                                                },
+                                                                                                value: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    ],
+                                                                                    optional: false,
+                                                                                },
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                optional: false,
+                                                            },
+                                                        ),
                                                     },
                                                 ),
-                                                right: Lit(
-                                                    Num(
-                                                        Num {
-                                                            span: 119..120,
-                                                            value: "5",
-                                                        },
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    ),
-                                    expr: Lit(
-                                        Str(
-                                            Str {
-                                                span: 125..130,
-                                                value: "few",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 148..159,
-                                    pattern: Wildcard(
-                                        WildcardPat {
-                                            span: 148..149,
+                                            ],
+                                            optional: false,
                                         },
                                     ),
                                     guard: None,
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 153..159,
-                                                value: "many",
+                                                span: 70..78,
+                                                value: "object",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 96..114,
+                                    pattern: Wildcard(
+                                        WildcardPat {
+                                            span: 96..97,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 101..114,
+                                                value: "fallthrough",
                                             },
                                         ),
                                     ),

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-2.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-2.snap
@@ -1,0 +1,144 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n            let bar = match (foo) {\n                1 -> \"one\",\n                2 -> \"two\",\n                n if (n < 5) -> \"few\",\n                _ -> \"many\"\n              };\n            \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 17..175,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 17..20,
+                        id: Ident {
+                            span: 17..20,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Match(
+                        Match {
+                            span: 23..175,
+                            expr: Ident(
+                                Ident {
+                                    span: 30..33,
+                                    name: "foo",
+                                },
+                            ),
+                            arms: [
+                                Arm {
+                                    span: 53..63,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 53..54,
+                                            lit: Num(
+                                                Num {
+                                                    span: 53..54,
+                                                    value: "1",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 58..63,
+                                                value: "one",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 81..91,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 81..82,
+                                            lit: Num(
+                                                Num {
+                                                    span: 81..82,
+                                                    value: "2",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 86..91,
+                                                value: "two",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 109..130,
+                                    pattern: Ident(
+                                        BindingIdent {
+                                            span: 109..110,
+                                            id: Ident {
+                                                span: 109..110,
+                                                name: "n",
+                                            },
+                                        },
+                                    ),
+                                    guard: Some(
+                                        Op(
+                                            Op {
+                                                span: 115..120,
+                                                op: Lt,
+                                                left: Ident(
+                                                    Ident {
+                                                        span: 115..116,
+                                                        name: "n",
+                                                    },
+                                                ),
+                                                right: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 119..120,
+                                                            value: "5",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 125..130,
+                                                value: "few",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 148..159,
+                                    pattern: Wildcard(
+                                        WildcardPat {
+                                            span: 148..149,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 153..159,
+                                                value: "many",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-3.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-3.snap
@@ -1,0 +1,122 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n            let bar = match (foo) {\n                n is number -> \"number\",\n                {a: a is Array} -> \"Array\",\n                _ -> \"fallthrough\"\n            };\n            \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 17..170,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 17..20,
+                        id: Ident {
+                            span: 17..20,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Match(
+                        Match {
+                            span: 23..170,
+                            expr: Ident(
+                                Ident {
+                                    span: 30..33,
+                                    name: "foo",
+                                },
+                            ),
+                            arms: [
+                                Arm {
+                                    span: 53..76,
+                                    pattern: Is(
+                                        IsPat {
+                                            span: 53..64,
+                                            id: Ident {
+                                                span: 53..54,
+                                                name: "n",
+                                            },
+                                            is_id: Ident {
+                                                span: 58..64,
+                                                name: "number",
+                                            },
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 68..76,
+                                                value: "number",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 94..120,
+                                    pattern: Object(
+                                        ObjectPat {
+                                            span: 94..109,
+                                            props: [
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 95..96,
+                                                            name: "a",
+                                                        },
+                                                        value: Is(
+                                                            IsPat {
+                                                                span: 98..108,
+                                                                id: Ident {
+                                                                    span: 98..99,
+                                                                    name: "a",
+                                                                },
+                                                                is_id: Ident {
+                                                                    span: 103..108,
+                                                                    name: "Array",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 113..120,
+                                                value: "Array",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 138..156,
+                                    pattern: Wildcard(
+                                        WildcardPat {
+                                            span: 138..139,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 143..156,
+                                                value: "fallthrough",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-4.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching-4.snap
@@ -1,0 +1,144 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n            let bar = match (foo) {\n                1 -> \"one\",\n                2 -> \"two\",\n                n if (n < 5) -> \"few\",\n                _ -> \"many\"\n            };\n            \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 17..173,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 17..20,
+                        id: Ident {
+                            span: 17..20,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Match(
+                        Match {
+                            span: 23..173,
+                            expr: Ident(
+                                Ident {
+                                    span: 30..33,
+                                    name: "foo",
+                                },
+                            ),
+                            arms: [
+                                Arm {
+                                    span: 53..63,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 53..54,
+                                            lit: Num(
+                                                Num {
+                                                    span: 53..54,
+                                                    value: "1",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 58..63,
+                                                value: "one",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 81..91,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 81..82,
+                                            lit: Num(
+                                                Num {
+                                                    span: 81..82,
+                                                    value: "2",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 86..91,
+                                                value: "two",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 109..130,
+                                    pattern: Ident(
+                                        BindingIdent {
+                                            span: 109..110,
+                                            id: Ident {
+                                                span: 109..110,
+                                                name: "n",
+                                            },
+                                        },
+                                    ),
+                                    guard: Some(
+                                        Op(
+                                            Op {
+                                                span: 115..120,
+                                                op: Lt,
+                                                left: Ident(
+                                                    Ident {
+                                                        span: 115..116,
+                                                        name: "n",
+                                                    },
+                                                ),
+                                                right: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 119..120,
+                                                            value: "5",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 125..130,
+                                                value: "few",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 148..159,
+                                    pattern: Wildcard(
+                                        WildcardPat {
+                                            span: 148..149,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 153..159,
+                                                value: "many",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching.snap
@@ -1,17 +1,17 @@
 ---
 source: crates/crochet_tree_sitter_parser/src/lib.rs
-expression: "parse(r#\"\n        let bar = match (foo) {\n            {x, y: b, z: 5, ...rest} -> \"object\",\n            [a, _, ...rest] -> \"array\",\n            \"string\" -> \"string\",\n            true -> \"true\",\n            false -> \"false\",\n            n -> \"variable\",\n            _ -> \"wildcard\"\n          };\n        \"#)"
+expression: "parse(r#\"\n            let bar = match (foo) {\n                {x, y: b, z: 5, ...rest} -> \"object\",\n                [a, _, ...rest] -> \"array\",\n                \"string\" -> \"string\",\n                true -> \"true\",\n                false -> \"false\",\n                n -> \"variable\",\n                _ -> \"wildcard\"\n            };\n        \"#)"
 ---
 Ok(
     Program {
         body: [
             VarDecl {
-                span: 13..283,
+                span: 17..317,
                 pattern: Ident(
                     BindingIdent {
-                        span: 13..16,
+                        span: 17..20,
                         id: Ident {
-                            span: 13..16,
+                            span: 17..20,
                             name: "bar",
                         },
                     },
@@ -20,25 +20,25 @@ Ok(
                 init: Some(
                     Match(
                         Match {
-                            span: 19..283,
+                            span: 23..317,
                             expr: Ident(
                                 Ident {
-                                    span: 26..29,
+                                    span: 30..33,
                                     name: "foo",
                                 },
                             ),
                             arms: [
                                 Arm {
-                                    span: 45..81,
+                                    span: 53..89,
                                     pattern: Object(
                                         ObjectPat {
-                                            span: 45..69,
+                                            span: 53..77,
                                             props: [
                                                 Assign(
                                                     AssignPatProp {
-                                                        span: 46..47,
+                                                        span: 54..55,
                                                         key: Ident {
-                                                            span: 46..47,
+                                                            span: 54..55,
                                                             name: "x",
                                                         },
                                                         value: None,
@@ -47,14 +47,14 @@ Ok(
                                                 KeyValue(
                                                     KeyValuePatProp {
                                                         key: Ident {
-                                                            span: 49..50,
+                                                            span: 57..58,
                                                             name: "y",
                                                         },
                                                         value: Ident(
                                                             BindingIdent {
-                                                                span: 52..53,
+                                                                span: 60..61,
                                                                 id: Ident {
-                                                                    span: 52..53,
+                                                                    span: 60..61,
                                                                     name: "b",
                                                                 },
                                                             },
@@ -64,15 +64,15 @@ Ok(
                                                 KeyValue(
                                                     KeyValuePatProp {
                                                         key: Ident {
-                                                            span: 55..56,
+                                                            span: 63..64,
                                                             name: "z",
                                                         },
                                                         value: Lit(
                                                             LitPat {
-                                                                span: 58..59,
+                                                                span: 66..67,
                                                                 lit: Num(
                                                                     Num {
-                                                                        span: 58..59,
+                                                                        span: 66..67,
                                                                         value: "5",
                                                                     },
                                                                 ),
@@ -82,12 +82,12 @@ Ok(
                                                 ),
                                                 Rest(
                                                     RestPat {
-                                                        span: 61..68,
+                                                        span: 69..76,
                                                         arg: Ident(
                                                             BindingIdent {
-                                                                span: 64..68,
+                                                                span: 72..76,
                                                                 id: Ident {
-                                                                    span: 64..68,
+                                                                    span: 72..76,
                                                                     name: "rest",
                                                                 },
                                                             },
@@ -102,24 +102,24 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 73..81,
+                                                span: 81..89,
                                                 value: "object",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 95..121,
+                                    span: 107..133,
                                     pattern: Array(
                                         ArrayPat {
-                                            span: 95..110,
+                                            span: 107..122,
                                             elems: [
                                                 Some(
                                                     Ident(
                                                         BindingIdent {
-                                                            span: 96..97,
+                                                            span: 108..109,
                                                             id: Ident {
-                                                                span: 96..97,
+                                                                span: 108..109,
                                                                 name: "a",
                                                             },
                                                         },
@@ -128,19 +128,19 @@ Ok(
                                                 Some(
                                                     Wildcard(
                                                         WildcardPat {
-                                                            span: 99..100,
+                                                            span: 111..112,
                                                         },
                                                     ),
                                                 ),
                                                 Some(
                                                     Rest(
                                                         RestPat {
-                                                            span: 102..109,
+                                                            span: 114..121,
                                                             arg: Ident(
                                                                 BindingIdent {
-                                                                    span: 105..109,
+                                                                    span: 117..121,
                                                                     id: Ident {
-                                                                        span: 105..109,
+                                                                        span: 117..121,
                                                                         name: "rest",
                                                                     },
                                                                 },
@@ -156,20 +156,20 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 114..121,
+                                                span: 126..133,
                                                 value: "array",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 135..155,
+                                    span: 151..171,
                                     pattern: Lit(
                                         LitPat {
-                                            span: 135..143,
+                                            span: 151..159,
                                             lit: Str(
                                                 Str {
-                                                    span: 135..143,
+                                                    span: 151..159,
                                                     value: "string",
                                                 },
                                             ),
@@ -179,20 +179,20 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 147..155,
+                                                span: 163..171,
                                                 value: "string",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 169..183,
+                                    span: 189..203,
                                     pattern: Lit(
                                         LitPat {
-                                            span: 169..173,
+                                            span: 189..193,
                                             lit: Bool(
                                                 Bool {
-                                                    span: 169..173,
+                                                    span: 189..193,
                                                     value: true,
                                                 },
                                             ),
@@ -202,20 +202,20 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 177..183,
+                                                span: 197..203,
                                                 value: "true",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 197..213,
+                                    span: 221..237,
                                     pattern: Lit(
                                         LitPat {
-                                            span: 197..202,
+                                            span: 221..226,
                                             lit: Bool(
                                                 Bool {
-                                                    span: 197..202,
+                                                    span: 221..226,
                                                     value: false,
                                                 },
                                             ),
@@ -225,19 +225,19 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 206..213,
+                                                span: 230..237,
                                                 value: "false",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 227..242,
+                                    span: 255..270,
                                     pattern: Ident(
                                         BindingIdent {
-                                            span: 227..228,
+                                            span: 255..256,
                                             id: Ident {
-                                                span: 227..228,
+                                                span: 255..256,
                                                 name: "n",
                                             },
                                         },
@@ -246,24 +246,24 @@ Ok(
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 232..242,
+                                                span: 260..270,
                                                 value: "variable",
                                             },
                                         ),
                                     ),
                                 },
                                 Arm {
-                                    span: 256..271,
+                                    span: 288..303,
                                     pattern: Wildcard(
                                         WildcardPat {
-                                            span: 256..257,
+                                            span: 288..289,
                                         },
                                     ),
                                     guard: None,
                                     expr: Lit(
                                         Str(
                                             Str {
-                                                span: 261..271,
+                                                span: 293..303,
                                                 value: "wildcard",
                                             },
                                         ),

--- a/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching.snap
+++ b/crates/crochet_tree_sitter_parser/src/snapshots/crochet_tree_sitter_parser__tests__pattern_matching.snap
@@ -1,0 +1,280 @@
+---
+source: crates/crochet_tree_sitter_parser/src/lib.rs
+expression: "parse(r#\"\n        let bar = match (foo) {\n            {x, y: b, z: 5, ...rest} -> \"object\",\n            [a, _, ...rest] -> \"array\",\n            \"string\" -> \"string\",\n            true -> \"true\",\n            false -> \"false\",\n            n -> \"variable\",\n            _ -> \"wildcard\"\n          };\n        \"#)"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 13..283,
+                pattern: Ident(
+                    BindingIdent {
+                        span: 13..16,
+                        id: Ident {
+                            span: 13..16,
+                            name: "bar",
+                        },
+                    },
+                ),
+                type_ann: None,
+                init: Some(
+                    Match(
+                        Match {
+                            span: 19..283,
+                            expr: Ident(
+                                Ident {
+                                    span: 26..29,
+                                    name: "foo",
+                                },
+                            ),
+                            arms: [
+                                Arm {
+                                    span: 45..81,
+                                    pattern: Object(
+                                        ObjectPat {
+                                            span: 45..69,
+                                            props: [
+                                                Assign(
+                                                    AssignPatProp {
+                                                        span: 46..47,
+                                                        key: Ident {
+                                                            span: 46..47,
+                                                            name: "x",
+                                                        },
+                                                        value: None,
+                                                    },
+                                                ),
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 49..50,
+                                                            name: "y",
+                                                        },
+                                                        value: Ident(
+                                                            BindingIdent {
+                                                                span: 52..53,
+                                                                id: Ident {
+                                                                    span: 52..53,
+                                                                    name: "b",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                KeyValue(
+                                                    KeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 55..56,
+                                                            name: "z",
+                                                        },
+                                                        value: Lit(
+                                                            LitPat {
+                                                                span: 58..59,
+                                                                lit: Num(
+                                                                    Num {
+                                                                        span: 58..59,
+                                                                        value: "5",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                                Rest(
+                                                    RestPat {
+                                                        span: 61..68,
+                                                        arg: Ident(
+                                                            BindingIdent {
+                                                                span: 64..68,
+                                                                id: Ident {
+                                                                    span: 64..68,
+                                                                    name: "rest",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 73..81,
+                                                value: "object",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 95..121,
+                                    pattern: Array(
+                                        ArrayPat {
+                                            span: 95..110,
+                                            elems: [
+                                                Some(
+                                                    Ident(
+                                                        BindingIdent {
+                                                            span: 96..97,
+                                                            id: Ident {
+                                                                span: 96..97,
+                                                                name: "a",
+                                                            },
+                                                        },
+                                                    ),
+                                                ),
+                                                Some(
+                                                    Wildcard(
+                                                        WildcardPat {
+                                                            span: 99..100,
+                                                        },
+                                                    ),
+                                                ),
+                                                Some(
+                                                    Rest(
+                                                        RestPat {
+                                                            span: 102..109,
+                                                            arg: Ident(
+                                                                BindingIdent {
+                                                                    span: 105..109,
+                                                                    id: Ident {
+                                                                        span: 105..109,
+                                                                        name: "rest",
+                                                                    },
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                            optional: false,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 114..121,
+                                                value: "array",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 135..155,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 135..143,
+                                            lit: Str(
+                                                Str {
+                                                    span: 135..143,
+                                                    value: "string",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 147..155,
+                                                value: "string",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 169..183,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 169..173,
+                                            lit: Bool(
+                                                Bool {
+                                                    span: 169..173,
+                                                    value: true,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 177..183,
+                                                value: "true",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 197..213,
+                                    pattern: Lit(
+                                        LitPat {
+                                            span: 197..202,
+                                            lit: Bool(
+                                                Bool {
+                                                    span: 197..202,
+                                                    value: false,
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 206..213,
+                                                value: "false",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 227..242,
+                                    pattern: Ident(
+                                        BindingIdent {
+                                            span: 227..228,
+                                            id: Ident {
+                                                span: 227..228,
+                                                name: "n",
+                                            },
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 232..242,
+                                                value: "variable",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                Arm {
+                                    span: 256..271,
+                                    pattern: Wildcard(
+                                        WildcardPat {
+                                            span: 256..257,
+                                        },
+                                    ),
+                                    guard: None,
+                                    expr: Lit(
+                                        Str(
+                                            Str {
+                                                span: 261..271,
+                                                value: "wildcard",
+                                            },
+                                        ),
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
+++ b/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
@@ -20,59 +20,60 @@ let bar = match (foo) {
       (identifier)
       (match_expression
         (identifier)
-        (match_arm
-          (refutable_pattern
-            (refutable_object_pattern
-              (shorthand_property_identifier_pattern)
-              (refutable_pair_pattern
-                (property_identifier)
-                (refutable_pattern
-                  (identifier)))
-              (refutable_pair_pattern
-                (property_identifier)
-                (refutable_pattern
-                  (number)))
-              (rest_pattern
-                (identifier))))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (refutable_array_pattern
-              (refutable_pattern
-                (identifier))
-              (refutable_pattern
-                (identifier))
-              (refutable_rest_pattern
-                (identifier))))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
+        (match_arms
+          (match_arm
+            (refutable_pattern
+              (refutable_object_pattern
+                (shorthand_property_identifier_pattern)
+                (refutable_pair_pattern
+                  (property_identifier)
+                  (refutable_pattern
+                    (identifier)))
+                (refutable_pair_pattern
+                  (property_identifier)
+                  (refutable_pattern
+                    (number)))
+                (refutable_rest_pattern
+                  (identifier))))
             (string
               (string_fragment)))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (true))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (false))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (identifier))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (identifier))
-          (string
-            (string_fragment)))))))
+          (match_arm
+            (refutable_pattern
+              (refutable_array_pattern
+                (refutable_pattern
+                  (identifier))
+                (refutable_pattern
+                  (identifier))
+                (refutable_rest_pattern
+                  (identifier))))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (string
+                (string_fragment)))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (true))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (false))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (identifier))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (identifier))
+            (string
+              (string_fragment))))))))
 
 ================================================================================
 Pattern matching (nested patterns)
@@ -91,25 +92,26 @@ let bar = match (foo) {
       (identifier)
       (match_expression
         (identifier)
-        (match_arm
-          (refutable_pattern
-            (refutable_object_pattern
-              (refutable_pair_pattern
-                (property_identifier)
-                (refutable_pattern
-                  (refutable_object_pattern
-                    (refutable_pair_pattern
-                      (property_identifier)
-                      (refutable_pattern
-                        (refutable_object_pattern
-                          (shorthand_property_identifier_pattern)))))))))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (identifier))
-          (string
-            (string_fragment)))))))
+        (match_arms
+          (match_arm
+            (refutable_pattern
+              (refutable_object_pattern
+                (refutable_pair_pattern
+                  (property_identifier)
+                  (refutable_pattern
+                    (refutable_object_pattern
+                      (refutable_pair_pattern
+                        (property_identifier)
+                        (refutable_pattern
+                          (refutable_object_pattern
+                            (shorthand_property_identifier_pattern)))))))))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (identifier))
+            (string
+              (string_fragment))))))))
 
 ================================================================================
 Pattern matching ("is" patterns)
@@ -130,32 +132,33 @@ let bar = match (foo) {
       (identifier)
       (match_expression
         (identifier)
-        (match_arm
-          (refutable_pattern
-            (refutable_is_pattern
-              (identifier)
-              (identifier)))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (refutable_is_pattern
-              (identifier)
-              (identifier)))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (refutable_is_pattern
-              (identifier)
-              (identifier)))
-          (string
-            (string_fragment)))
-        (match_arm
-          (refutable_pattern
-            (identifier))
-          (string
-            (string_fragment)))))))
+        (match_arms
+          (match_arm
+            (refutable_pattern
+              (refutable_is_pattern
+                (identifier)
+                (identifier)))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (refutable_is_pattern
+                (identifier)
+                (identifier)))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (refutable_is_pattern
+                (identifier)
+                (identifier)))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (identifier))
+            (string
+              (string_fragment))))))))
 
 ================================================================================
 if-let (basic patterns)
@@ -184,7 +187,7 @@ let bar = if (let {x, y: b, ...rest} = foo) {
                 (property_identifier)
                 (refutable_pattern
                   (identifier)))
-              (rest_pattern
+              (refutable_rest_pattern
                 (identifier))))
           (identifier))
         (statement_block

--- a/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
+++ b/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
@@ -119,8 +119,7 @@ Pattern matching ("is" patterns)
 
 let bar = match (foo) {
   n is number -> "number",
-  b is boolean -> "boolean",
-  a is Array -> "array",
+  {a: a is Array} -> "Array",
   _ -> "fallthrough"
 };
 
@@ -142,16 +141,57 @@ let bar = match (foo) {
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (refutable_is_pattern
-                (identifier)
-                (identifier)))
+              (refutable_object_pattern
+                (refutable_pair_pattern
+                  (property_identifier)
+                  (refutable_pattern
+                    (refutable_is_pattern
+                      (identifier)
+                      (identifier))))))
             (string
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (refutable_is_pattern
-                (identifier)
-                (identifier)))
+              (identifier))
+            (string
+              (string_fragment))))))))
+
+================================================================================
+Pattern matching (with guards)
+================================================================================
+
+let bar = match (foo) {
+  1 -> "one",
+  2 -> "two",
+  n if (n < 5) -> "few",
+  _ -> "many"
+};
+
+--------------------------------------------------------------------------------
+
+(program
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (match_expression
+        (identifier)
+        (match_arms
+          (match_arm
+            (refutable_pattern
+              (number))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (number))
+            (string
+              (string_fragment)))
+          (match_arm
+            (refutable_pattern
+              (identifier))
+            (binary_expression
+              (identifier)
+              (number))
             (string
               (string_fragment)))
           (match_arm

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -135,6 +135,14 @@ module.exports = grammar(tsx, {
     match_arm: ($) =>
       seq(
         field("pattern", $.refutable_pattern),
+        optional(
+          seq(
+            "if",
+            "(",
+            field("condition", choice($.let_expression, $.expression)),
+            ")"
+          )
+        ),
         // NOTE: we use "->" instead of "=>" to help indicate that there isn't
         // a new stack frame when stepping through match expressions like there
         // is with an arrow expression.

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -124,11 +124,13 @@ module.exports = grammar(tsx, {
     match_expression: ($) =>
       seq(
         "match",
-        field("expression", seq("(", $.expression, ")")),
-        "{",
-        commaSep($.match_arm),
-        "}"
+        "(",
+        field("expression", $.expression),
+        ")",
+        field("arms", $.match_arms)
       ),
+
+    match_arms: ($) => seq("{", commaSep($.match_arm), "}"),
 
     match_arm: ($) =>
       seq(
@@ -178,7 +180,7 @@ module.exports = grammar(tsx, {
             optional(
               choice(
                 $.refutable_pair_pattern,
-                $.rest_pattern,
+                $.refutable_rest_pattern,
                 alias(
                   choice($.identifier, $._reserved_identifier),
                   $.shorthand_property_identifier_pattern

--- a/crates/tree_sitter_crochet/src/grammar.json
+++ b/crates/tree_sitter_crochet/src/grammar.json
@@ -10389,6 +10389,48 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "if"
+                },
+                {
+                  "type": "STRING",
+                  "value": "("
+                },
+                {
+                  "type": "FIELD",
+                  "name": "condition",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "let_expression"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": ")"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "->"
         },

--- a/crates/tree_sitter_crochet/src/grammar.json
+++ b/crates/tree_sitter_crochet/src/grammar.json
@@ -10306,26 +10306,34 @@
           "value": "match"
         },
         {
+          "type": "STRING",
+          "value": "("
+        },
+        {
           "type": "FIELD",
           "name": "expression",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "("
-              },
-              {
-                "type": "SYMBOL",
-                "name": "expression"
-              },
-              {
-                "type": "STRING",
-                "value": ")"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "expression"
           }
         },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "FIELD",
+          "name": "arms",
+          "content": {
+            "type": "SYMBOL",
+            "name": "match_arms"
+          }
+        }
+      ]
+    },
+    "match_arms": {
+      "type": "SEQ",
+      "members": [
         {
           "type": "STRING",
           "value": "{"
@@ -10549,7 +10557,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "rest_pattern"
+                            "name": "refutable_rest_pattern"
                           },
                           {
                             "type": "ALIAS",
@@ -10597,7 +10605,7 @@
                                 },
                                 {
                                   "type": "SYMBOL",
-                                  "name": "rest_pattern"
+                                  "name": "refutable_rest_pattern"
                                 },
                                 {
                                   "type": "ALIAS",

--- a/crates/tree_sitter_crochet/src/node-types.json
+++ b/crates/tree_sitter_crochet/src/node-types.json
@@ -3738,28 +3738,9 @@
     }
   },
   {
-    "type": "match_expression",
+    "type": "match_arms",
     "named": true,
-    "fields": {
-      "expression": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "(",
-            "named": false
-          },
-          {
-            "type": ")",
-            "named": false
-          },
-          {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
       "multiple": true,
       "required": false,
@@ -3769,6 +3750,32 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "match_expression",
+    "named": true,
+    "fields": {
+      "arms": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "match_arms",
+            "named": true
+          }
+        ]
+      },
+      "expression": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -4831,7 +4838,7 @@
           "named": true
         },
         {
-          "type": "rest_pattern",
+          "type": "refutable_rest_pattern",
           "named": true
         },
         {
@@ -6421,11 +6428,11 @@
   },
   {
     "type": "number",
-    "named": false
+    "named": true
   },
   {
     "type": "number",
-    "named": true
+    "named": false
   },
   {
     "type": "object",

--- a/crates/tree_sitter_crochet/src/node-types.json
+++ b/crates/tree_sitter_crochet/src/node-types.json
@@ -3711,6 +3711,20 @@
     "type": "match_arm",
     "named": true,
     "fields": {
+      "condition": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "let_expression",
+            "named": true
+          }
+        ]
+      },
       "pattern": {
         "multiple": false,
         "required": true,


### PR DESCRIPTION
TODO:
- [x] more test cases for parsing `match`
- [x] parse `if-let` to the AST
- [x] handle guards
