### PR TITLE
Introduce Qualified<T> struct to help dedupe code a bit

### DIFF
--- a/crates/crochet_types/src/lam.rs
+++ b/crates/crochet_types/src/lam.rs
@@ -1,3 +1,4 @@
+use itertools::join;
 use std::fmt;
 use std::hash::Hash;
 
@@ -21,6 +22,13 @@ impl Hash for TLam {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.params.hash(state);
         self.ret.hash(state);
+    }
+}
+
+impl fmt::Display for TLam {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { params, ret } = self;
+        write!(f, "({}) => {}", join(params, ", "), ret)
     }
 }
 

--- a/crates/crochet_types/src/lib.rs
+++ b/crates/crochet_types/src/lib.rs
@@ -4,6 +4,7 @@ pub mod lit;
 pub mod obj;
 pub mod pat;
 pub mod prim;
+pub mod qualified;
 pub mod scheme;
 pub mod r#type;
 
@@ -13,5 +14,6 @@ pub use lit::*;
 pub use obj::*;
 pub use pat::*;
 pub use prim::*;
+pub use qualified::*;
 pub use r#type::*;
 pub use scheme::*;

--- a/crates/crochet_types/src/obj.rs
+++ b/crates/crochet_types/src/obj.rs
@@ -1,9 +1,12 @@
-use itertools::join;
 use std::fmt;
 
 use crate::keyword::TKeyword;
+use crate::lam::TLam;
+use crate::qualified::Qualified;
 use crate::r#type::Type;
-use crate::{Scheme, TFnParam};
+use crate::Scheme;
+
+pub type TCall = Qualified<TLam>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum TObjElem {
@@ -18,39 +21,8 @@ pub enum TObjElem {
 impl fmt::Display for TObjElem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TObjElem::Call(lam) => write!(f, "({}) => {}", join(&lam.params, ", "), lam.ret),
+            TObjElem::Call(lam) => write!(f, "{lam}"),
             TObjElem::Prop(prop) => write!(f, "{prop}"),
-        }
-    }
-}
-
-// This is really just a qualified TLam
-// What if we introduce a `Qualified` trait
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TCall {
-    pub params: Vec<TFnParam>,
-    pub ret: Box<Type>,
-    pub qualifiers: Vec<i32>,
-}
-
-impl fmt::Display for TCall {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Self {
-            params,
-            ret,
-            qualifiers,
-        } = self;
-
-        if qualifiers.is_empty() {
-            write!(f, "({}) => {}", join(params, ", "), ret)
-        } else {
-            write!(
-                f,
-                "<{}>({}) => {}",
-                join(qualifiers.iter().map(|id| { format!("t{id}") }), ", "),
-                join(params, ", "),
-                ret
-            )
         }
     }
 }

--- a/crates/crochet_types/src/qualified.rs
+++ b/crates/crochet_types/src/qualified.rs
@@ -1,0 +1,31 @@
+use itertools::join;
+use std::fmt;
+use std::hash;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Qualified<T>
+where
+    T: Clone + fmt::Debug + fmt::Display + PartialEq + Eq + hash::Hash,
+{
+    pub qualifiers: Vec<i32>,
+    pub t: T,
+}
+
+impl<T> fmt::Display for Qualified<T>
+where
+    T: Clone + fmt::Debug + fmt::Display + PartialEq + Eq + hash::Hash,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self { qualifiers, t } = self;
+        if qualifiers.is_empty() {
+            write!(f, "{t}")
+        } else {
+            write!(
+                f,
+                "<{}>{}",
+                join(qualifiers.iter().map(|id| { format!("t{id}") }), ", "),
+                t
+            )
+        }
+    }
+}

--- a/crates/crochet_types/src/scheme.rs
+++ b/crates/crochet_types/src/scheme.rs
@@ -1,14 +1,7 @@
-use itertools::join;
-use std::fmt;
-
+use crate::qualified::Qualified;
 use crate::Type;
 
-// A `Scheme` should be defined as `Qualified<Type>`
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Scheme {
-    pub qualifiers: Vec<i32>,
-    pub t: Type,
-}
+pub type Scheme = Qualified<Type>;
 
 impl From<Type> for Scheme {
     fn from(t: Type) -> Self {
@@ -24,25 +17,6 @@ impl From<&Type> for Scheme {
         Scheme {
             qualifiers: vec![],
             t: t.clone(),
-        }
-    }
-}
-
-impl fmt::Display for Scheme {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Scheme { qualifiers, t } = self;
-
-        if qualifiers.is_empty() {
-            write!(f, "{}", t)
-        } else {
-            let mut quals = qualifiers.clone();
-            quals.sort_unstable();
-            write!(
-                f,
-                "<{}>{}",
-                join(quals.iter().map(|id| { format!("t{id}") }), ", "),
-                t
-            )
         }
     }
 }

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -65,9 +65,7 @@ impl fmt::Display for Type {
             Type::App(TApp { args, ret }) => {
                 write!(f, "({}) => {}", join(args, ", "), ret)
             }
-            Type::Lam(TLam { params, ret, .. }) => {
-                write!(f, "({}) => {}", join(params, ", "), ret)
-            }
+            Type::Lam(lam) => write!(f, "{lam}"),
             Type::Prim(prim) => write!(f, "{}", prim),
             Type::Lit(lit) => write!(f, "{}", lit),
             Type::Keyword(keyword) => write!(f, "{}", keyword),


### PR DESCRIPTION
This allows us to redefine `Scheme` as
```
type Scheme = Qualified<Type>
```
and `TCall` as
```
type TCall = Qualified<TLam>
```