### PR TITLE
Rename .type_params to .type_args on TAlias

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -527,7 +527,9 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             })
         }
         Type::Alias(types::TAlias {
-            name, type_params, ..
+            name,
+            type_args: type_params,
+            ..
         }) => TsType::TsTypeRef(TsTypeRef {
             span: DUMMY_SP,
             type_name: TsEntityName::from(Ident {

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -98,12 +98,12 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
                         .collect();
                     Ok(Type::Alias(types::TAlias {
                         name,
-                        type_params: result.ok(),
+                        type_args: result.ok(),
                     }))
                 }
                 None => Ok(Type::Alias(types::TAlias {
                     name,
-                    type_params: None,
+                    type_args: None,
                 })),
             }
         }
@@ -477,6 +477,8 @@ fn merge_types(t1: &Type, t2: &Type) -> Type {
                 .collect();
 
             // TODO: merge qualifiers
+            // We need this to support Promise<T> which was extended in es2018 to
+            // include a .finally() method.
             Type::Object(TObject {
                 elems,
                 // TODO: merge type params as well

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -148,7 +148,7 @@ impl Context {
                     // Replaces qualifiers in the scheme with the corresponding type params
                     // from the alias type.
                     let ids = type_params.iter().map(|id| id.to_owned());
-                    let subs: Subst = match &alias.type_params {
+                    let subs: Subst = match &alias.type_args {
                         Some(type_params) => {
                             if type_params.len() != type_params.len() {
                                 println!("type = {t}");

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -185,7 +185,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
 
                         let ret_type = Type::Alias(types::TAlias {
                             name: String::from("JSXElement"),
-                            type_params: None,
+                            type_args: None,
                         });
 
                         let call_type = Type::App(types::TApp {
@@ -211,7 +211,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             // TODO: check props on JSXInstrinsics
             let t = Type::Alias(types::TAlias {
                 name: String::from("JSXElement"),
-                type_params: None,
+                type_args: None,
             });
 
             Ok((s, t))
@@ -258,7 +258,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             let rt = if *is_async && !is_promise(&rt) {
                 Type::Alias(types::TAlias {
                     name: String::from("Promise"),
-                    type_params: Some(vec![rt]),
+                    type_args: Some(vec![rt]),
                 })
             } else {
                 rt
@@ -403,7 +403,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &Expr) -> Result<(Subst, Type), Strin
             let wrapped_type = ctx.fresh_var();
             let promise_type = Type::Alias(types::TAlias {
                 name: String::from("Promise"),
-                type_params: Some(vec![wrapped_type.clone()]),
+                type_args: Some(vec![wrapped_type.clone()]),
             });
 
             let s2 = unify(&t1, &promise_type, ctx)?;

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -72,7 +72,7 @@ fn infer_pattern_rec(pat: &Pattern, ctx: &Context, assump: &mut Assump) -> Resul
                 // `constructor` method.
                 name => Type::Alias(types::TAlias {
                     name: name.to_owned(),
-                    type_params: None,
+                    type_args: None,
                 }),
             };
             // TODO: we need a method on Context to get all types that currently in

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -130,7 +130,7 @@ fn infer_type_ann_rec(
                 });
                 Type::Alias(types::TAlias {
                     name: name.to_owned(),
-                    type_params,
+                    type_args: type_params,
                 })
             }
         },

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -44,7 +44,7 @@ impl Substitutable for Type {
                 })
             }
             Type::Alias(alias) => Type::Alias(TAlias {
-                type_params: alias.type_params.apply(sub),
+                type_args: alias.type_args.apply(sub),
                 ..alias.to_owned()
             }),
             Type::Tuple(types) => Type::Tuple(types.apply(sub)),
@@ -73,7 +73,10 @@ impl Substitutable for Type {
                     obj.type_params.iter().map(|id| id.to_owned()).collect();
                 obj.elems.ftv().difference(&qualifiers).cloned().collect()
             }
-            Type::Alias(TAlias { type_params, .. }) => type_params.ftv(),
+            Type::Alias(TAlias {
+                type_args: type_params,
+                ..
+            }) => type_params.ftv(),
             Type::Tuple(types) => types.ftv(),
             Type::Array(t) => t.ftv(),
             Type::Rest(arg) => arg.ftv(),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -471,7 +471,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         }
         (Type::Alias(alias1), Type::Alias(alias2)) => {
             if alias1.name == alias2.name {
-                match (&alias1.type_params, &alias2.type_params) {
+                match (&alias1.type_args, &alias2.type_args) {
                     (Some(tp1), Some(tp2)) => {
                         let result: Result<Vec<_>, _> = tp1
                             .iter()

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -133,13 +133,16 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                     ..obj.to_owned()
                 })
             }
-            Type::Alias(TAlias { name, type_params }) => {
+            Type::Alias(TAlias {
+                name,
+                type_args: type_params,
+            }) => {
                 let type_params = type_params
                     .clone()
                     .map(|params| params.iter().map(|t| norm_type(t, mapping, ctx)).collect());
                 Type::Alias(TAlias {
                     name: name.to_owned(),
-                    type_params,
+                    type_args: type_params,
                 })
             }
             Type::Tuple(types) => {

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -12,25 +12,25 @@ use crate::prim::TPrim;
 pub struct TApp {
     pub args: Vec<Type>,
     pub ret: Box<Type>,
-    // TODO: use type_args instead of type_params
+    // TODO: add type_args property to support explicit specification of type args
 }
 
 #[derive(Clone, Debug, Eq)]
 pub struct TAlias {
     pub name: String,
-    pub type_params: Option<Vec<Type>>, // TODO: rename to type_args
+    pub type_args: Option<Vec<Type>>,
 }
 
 impl PartialEq for TAlias {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.type_params == other.type_params
+        self.name == other.name && self.type_args == other.type_args
     }
 }
 
 impl Hash for TAlias {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
-        self.type_params.hash(state);
+        self.type_args.hash(state);
     }
 }
 
@@ -96,7 +96,9 @@ impl fmt::Display for Type {
                 }
             }
             Type::Alias(TAlias {
-                name, type_params, ..
+                name,
+                type_args: type_params,
+                ..
             }) => match type_params {
                 Some(params) => write!(f, "{name}<{}>", join(params, ", ")),
                 None => write!(f, "{name}"),


### PR DESCRIPTION
`type_params` is now being used only for generic type parameters whereas alias types (which are actually type references) are passed type args.  We should probably just rename `TAlias` to `TypeRef` to more closely align with TypeScript.