### PR TITLE
Handle merging generic interfaces correctly

### DIFF
--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -97,7 +97,7 @@ impl Context {
         Err(format!("Can't find value type: {name}"))
     }
 
-    pub fn lookup_value_scheme(&self, name: &str) -> Result<Type, String> {
+    pub fn lookup_value(&self, name: &str) -> Result<Type, String> {
         for scope in self.scopes.iter().rev() {
             match scope.values.get(name) {
                 Some(t) => return Ok(t.to_owned()),
@@ -118,7 +118,7 @@ impl Context {
         Err(format!("Can't find type: {name}"))
     }
 
-    pub fn lookup_type_scheme(&self, name: &str) -> Result<Type, String> {
+    pub fn lookup_type(&self, name: &str) -> Result<Type, String> {
         for scope in self.scopes.iter().rev() {
             match scope.types.get(name) {
                 Some(t) => return Ok(t.to_owned()),

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -589,7 +589,7 @@ fn infer_property_type(
         },
         Type::Array(type_param) => {
             // TODO: Do this for all interfaces that we lookup
-            let t = ctx.lookup_type_scheme("ReadonlyArray")?;
+            let t = ctx.lookup_type("ReadonlyArray")?;
             let type_params = get_type_params(&t);
             // TODO: Instead of instantiating the whole interface for one method, do
             // the lookup call first and then instantiate the method.
@@ -602,7 +602,7 @@ fn infer_property_type(
                 // TODO: lookup methods on Array.prototype
                 MemberProp::Ident(_) => {
                     // TODO: Do this for all interfaces that we lookup
-                    let t = ctx.lookup_type_scheme("ReadonlyArray")?;
+                    let t = ctx.lookup_type("ReadonlyArray")?;
                     println!("ReadonlyArray = {t}");
                     // TODO: Instead of instantiating the whole interface for one method, do
                     // the lookup call first and then instantiate the method.

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
     }
 
     fn get_type(name: &str, ctx: &Context) -> String {
-        match ctx.lookup_value_scheme(name) {
+        match ctx.lookup_value(name) {
             Ok(t) => format!("{t}"),
             Err(_) => panic!("Couldn't find type with name '{name}'"),
         }
@@ -351,8 +351,8 @@ mod tests {
 
         assert_eq!(get_type("a", &ctx), "5");
         assert_eq!(get_type("b", &ctx), "10");
-        assert!(ctx.lookup_value_scheme("x").is_err());
-        assert!(ctx.lookup_value_scheme("y").is_err());
+        assert!(ctx.lookup_value("x").is_err());
+        assert!(ctx.lookup_value("y").is_err());
     }
 
     #[test]
@@ -366,8 +366,8 @@ mod tests {
     fn nested_destructure_obj() {
         let ctx = infer_prog("let {a: {b: {c}}} = {a: {b: {c: \"hello\"}}};");
 
-        assert!(ctx.lookup_value_scheme("a").is_err());
-        assert!(ctx.lookup_value_scheme("b").is_err());
+        assert!(ctx.lookup_value("a").is_err());
+        assert!(ctx.lookup_value("b").is_err());
         assert_eq!(get_type("c", &ctx), "\"hello\"");
     }
 
@@ -487,7 +487,7 @@ mod tests {
         "#;
         let ctx = infer_prog(src);
 
-        let x = format!("{}", ctx.lookup_value_scheme("x").unwrap());
+        let x = format!("{}", ctx.lookup_value("x").unwrap());
         assert_eq!(x, "number | undefined");
     }
 
@@ -553,8 +553,8 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
-        assert!(ctx.lookup_value_scheme("y").is_err());
+        assert!(ctx.lookup_value("x").is_err());
+        assert!(ctx.lookup_value("y").is_err());
     }
 
     #[test]
@@ -601,8 +601,8 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "0 | 1 | 5");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
-        assert!(ctx.lookup_value_scheme("y").is_err());
+        assert!(ctx.lookup_value("x").is_err());
+        assert!(ctx.lookup_value("y").is_err());
     }
 
     #[test]
@@ -641,7 +641,7 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value("x").is_err());
     }
 
     #[test]
@@ -662,8 +662,8 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number | string | true");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
-        assert!(ctx.lookup_value_scheme("y").is_err());
+        assert!(ctx.lookup_value("x").is_err());
+        assert!(ctx.lookup_value("y").is_err());
     }
 
     #[test]
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(get_type("sum", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value("x").is_err());
     }
 
     #[test]
@@ -750,7 +750,7 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value("x").is_err());
     }
 
     #[test]
@@ -771,7 +771,7 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number | string | true");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
+        assert!(ctx.lookup_value("x").is_err());
     }
 
     #[test]
@@ -820,8 +820,8 @@ mod tests {
         assert_eq!(get_type("result", &ctx), "number");
 
         // Ensures we aren't polluting the outside context
-        assert!(ctx.lookup_value_scheme("x").is_err());
-        assert!(ctx.lookup_value_scheme("y").is_err());
+        assert!(ctx.lookup_value("x").is_err());
+        assert!(ctx.lookup_value("y").is_err());
     }
 
     // TODO: handle refutable patterns in if-else
@@ -852,7 +852,7 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        assert!(ctx.lookup_value_scheme("_").is_err());
+        assert!(ctx.lookup_value("_").is_err());
     }
 
     #[test]


### PR DESCRIPTION
This is necessary for `Promise<T>` whose definition is spread across multiple .d.ts files.