### PR TITLE
Add support for `keyof` operator

### DIFF
--- a/crates/crochet_ast/src/type_ann.rs
+++ b/crates/crochet_ast/src/type_ann.rs
@@ -86,6 +86,12 @@ pub struct ArrayType {
     pub elem_type: Box<TypeAnn>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyOfType {
+    pub span: Span,
+    pub type_ann: Box<TypeAnn>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
     Lam(LamType),
@@ -98,6 +104,7 @@ pub enum TypeAnn {
     Intersection(IntersectionType),
     Tuple(TupleType),
     Array(ArrayType),
+    KeyOf(KeyOfType),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -398,7 +398,7 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
 /// `expr` should be the original expression that `t` was inferred
 /// from if it exists.
 pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
-    match &t {
+    match t {
         Type::Var(id) => {
             let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 .chars()
@@ -432,6 +432,7 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
                 types::TKeyword::Null => TsKeywordTypeKind::TsNullKeyword,
                 types::TKeyword::Symbol => TsKeywordTypeKind::TsSymbolKeyword,
                 types::TKeyword::Undefined => TsKeywordTypeKind::TsUndefinedKeyword,
+                types::TKeyword::Never => TsKeywordTypeKind::TsNeverKeyword,
             };
 
             TsType::TsKeywordType(TsKeywordType {
@@ -562,6 +563,7 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
         }),
         Type::Rest(_) => todo!(),
         Type::This => TsType::TsThisType(TsThisType { span: DUMMY_SP }),
+        Type::KeyOf(_) => todo!(),
     }
 }
 

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -122,6 +122,7 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, i32>) -> Type {
         Type::Array(t) => Type::Array(Box::from(replace_aliases_rec(t, map))),
         Type::Rest(t) => Type::Rest(Box::from(replace_aliases_rec(t, map))),
         Type::This => Type::This,
+        Type::KeyOf(t) => Type::KeyOf(Box::from(replace_aliases_rec(t, map))),
     }
 }
 

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -540,6 +540,7 @@ fn is_promise(t: &Type) -> bool {
     matches!(&t, Type::Ref(types::TRef { name, .. }) if name == "Promise")
 }
 
+// TODO: try to dedupe with key_of()
 fn infer_property_type(
     obj_t: &Type,
     prop: &MemberProp,
@@ -585,7 +586,8 @@ fn infer_property_type(
                 infer_property_type(&t, prop, ctx)
             }
             TKeyword::Null => Err("Cannot read property on 'null'".to_owned()),
-            TKeyword::Undefined => Err("Cannot read property on 'null'".to_owned()),
+            TKeyword::Undefined => Err("Cannot read property on 'undefined'".to_owned()),
+            TKeyword::Never => Err("Cannot read property on 'never'".to_owned()),
         },
         Type::Array(type_param) => {
             // TODO: Do this for all interfaces that we lookup

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -46,20 +46,9 @@ pub fn infer_scheme_with_type_params(
 
     // set type_params
     match type_ann_ty {
-        Type::Var(_) => type_ann_ty,
-        Type::App(_) => type_ann_ty,
         Type::Lam(lam) => Type::Lam(TLam { type_params, ..lam }),
-        Type::Prim(_) => type_ann_ty,
-        Type::Lit(_) => type_ann_ty,
-        Type::Keyword(_) => type_ann_ty,
-        Type::Union(_) => type_ann_ty,
-        Type::Intersection(_) => type_ann_ty,
         Type::Object(obj) => Type::Object(TObject { type_params, ..obj }),
-        Type::Ref(_) => type_ann_ty,
-        Type::Tuple(_) => type_ann_ty,
-        Type::Array(_) => type_ann_ty,
-        Type::Rest(_) => type_ann_ty,
-        Type::This => type_ann_ty,
+        _ => type_ann_ty,
     }
 }
 
@@ -157,5 +146,8 @@ fn infer_type_ann_rec(
             ctx,
             type_param_map,
         ))),
+        TypeAnn::KeyOf(KeyOfType { type_ann, .. }) => {
+            Type::KeyOf(Box::from(infer_type_ann_rec(type_ann, ctx, type_param_map)))
+        }
     }
 }

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -1,0 +1,200 @@
+use super::context::Context;
+use super::util::union_many_types;
+use crochet_types::{TKeyword, TLit, TObjElem, TObject, TPrim, Type};
+
+// TODO: try to dedupe with infer_property_type()
+pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
+    match t {
+        Type::Var(_) => Err(String::from(
+            "There isn't a way to infer a type from its keys",
+        )),
+        Type::Ref(alias) => {
+            let t = ctx.lookup_alias(alias)?;
+            key_of(&t, ctx)
+        }
+        Type::Object(TObject {
+            elems,
+            type_params: _,
+        }) => {
+            let elems: Vec<_> = elems
+                .iter()
+                .filter_map(|elem| match elem {
+                    TObjElem::Call(_) => None,
+                    TObjElem::Constructor(_) => None,
+                    TObjElem::Index(_) => todo!(),
+                    TObjElem::Prop(prop) => Some(Type::Lit(TLit::Str(prop.name.to_owned()))),
+                })
+                .collect();
+
+            Ok(union_many_types(&elems))
+        }
+        Type::Prim(prim) => match prim {
+            TPrim::Num => key_of(&ctx.lookup_type_and_instantiate("Number")?, ctx),
+            TPrim::Bool => key_of(&ctx.lookup_type_and_instantiate("Boolean")?, ctx),
+            TPrim::Str => key_of(&ctx.lookup_type_and_instantiate("String")?, ctx),
+        },
+        Type::Lit(lit) => match lit {
+            TLit::Num(_) => key_of(&ctx.lookup_type_and_instantiate("Number")?, ctx),
+            TLit::Bool(_) => key_of(&ctx.lookup_type_and_instantiate("Boolean")?, ctx),
+            TLit::Str(_) => key_of(&ctx.lookup_type_and_instantiate("String")?, ctx),
+        },
+        Type::Tuple(tuple) => {
+            let mut elems: Vec<Type> = vec![];
+            for i in 0..tuple.len() {
+                elems.push(Type::Lit(TLit::Num(i.to_string())))
+            }
+            elems.push(key_of(
+                &ctx.lookup_type_and_instantiate("ReadonlyArray")?,
+                ctx,
+            )?);
+            Ok(union_many_types(&elems))
+        }
+        Type::Array(_) => Ok(union_many_types(&[
+            Type::Prim(TPrim::Num),
+            key_of(&ctx.lookup_type_and_instantiate("ReadonlyArray")?, ctx)?,
+        ])),
+        Type::Lam(_) => key_of(&ctx.lookup_type_and_instantiate("Function")?, ctx),
+        Type::App(_) => {
+            todo!() // What does this even mean?
+        }
+        Type::Keyword(keyword) => match keyword {
+            crochet_types::TKeyword::Null => Ok(Type::Keyword(TKeyword::Never)),
+            crochet_types::TKeyword::Symbol => {
+                key_of(&ctx.lookup_type_and_instantiate("Symbol")?, ctx)
+            }
+            crochet_types::TKeyword::Undefined => Ok(Type::Keyword(TKeyword::Never)),
+            crochet_types::TKeyword::Never => Ok(Type::Keyword(TKeyword::Never)),
+        },
+        Type::Union(_) => todo!(),
+        Type::Intersection(elems) => {
+            let elems: Result<Vec<_>, String> =
+                elems.iter().map(|elem| key_of(elem, ctx)).collect();
+            Ok(union_many_types(&elems?))
+        }
+        Type::Rest(_) => {
+            todo!() // What does this even mean?
+        }
+        Type::This => {
+            todo!() // Depends on what this is referencing
+        }
+        Type::KeyOf(t) => key_of(&key_of(t, ctx)?, ctx),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infer;
+    use crochet_parser::*;
+
+    fn infer_prog(input: &str) -> Context {
+        let prog = parse(input).unwrap();
+        let mut ctx: Context = Context::default();
+        infer::infer_prog(&prog, &mut ctx).unwrap()
+    }
+
+    fn get_key_of(name: &str, ctx: &Context) -> String {
+        match ctx.lookup_type(name) {
+            Ok(t) => {
+                let t = key_of(&t, ctx).unwrap();
+                format!("{t}")
+            }
+            Err(_) => panic!("Couldn't find type with name '{name}'"),
+        }
+    }
+
+    #[test]
+    fn test_object() {
+        let src = r#"
+        type t = {x: number, y: number};
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""x" | "y""#);
+    }
+
+    #[test]
+    fn test_intersection() {
+        let src = r#"
+        type t = {a: number, b: boolean} & {b: string, c: number};
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""a" | "b" | "c""#);
+    }
+
+    #[test]
+    fn test_number() {
+        let src = r#"
+        type Number = {
+            toFixed: () => string,
+            toString: () => string,
+        };
+        type t = number;
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""toFixed" | "toString""#);
+    }
+
+    #[test]
+    fn test_string() {
+        let src = r#"
+        type String = {
+            length: () => number,
+            toLowerCase: () => string,
+            toUpperCase: () => string,
+        };
+        type t = string;
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(
+            get_key_of("t", &ctx),
+            r#""length" | "toLowerCase" | "toUpperCase""#
+        );
+    }
+
+    #[test]
+    fn test_array() {
+        let src = r#"
+        type ReadonlyArray<T> = {
+            length: number,
+            map: (item: T, index: number, array: ReadonlyArray<T>) => null,
+        };
+        type t = number[];
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""length" | "map" | number"#);
+    }
+
+    #[test]
+    fn test_tuple() {
+        let src = r#"
+        type ReadonlyArray<T> = {
+            length: number,
+            map: (item: T, index: number, array: ReadonlyArray<T>) => null,
+        };
+        type t = [1, 2, 3];
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""length" | "map" | 0 | 1 | 2"#);
+    }
+
+    #[test]
+    fn test_function() {
+        let src = r#"
+        type Function = {
+            call: () => null,
+            apply: () => null,
+            bind: () => null,
+        };
+        type t = () => boolean;
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_key_of("t", &ctx), r#""apply" | "bind" | "call""#);
+    }
+}

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3,6 +3,7 @@ mod infer_expr;
 mod infer_fn_param;
 mod infer_pattern;
 mod infer_type_ann;
+mod key_of;
 mod substitutable;
 mod unify;
 mod util;
@@ -2220,5 +2221,29 @@ mod tests {
         let ctx = infer_prog(src);
 
         assert_eq!(get_type("tree", &ctx), "Tree");
+    }
+
+    #[test]
+    fn keyof() {
+        let src = r#"
+        type Point = {
+            x: number,
+            y: number,
+        };
+        type CoordName = keyof Point;
+
+        let x: CoordName = "x";
+        let y: CoordName = "y";
+        "#;
+
+        let ctx = infer_prog(src);
+
+        let name = "CoordName";
+        let t = match ctx.lookup_type(name) {
+            Ok(t) => format!("{t}"),
+            Err(_) => panic!("Couldn't find type with name '{name}'"),
+        };
+
+        assert_eq!(t, "keyof Point");
     }
 }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -51,6 +51,7 @@ impl Substitutable for Type {
             Type::Array(t) => Type::Array(Box::from(t.apply(sub))),
             Type::Rest(arg) => Type::Rest(Box::from(arg.apply(sub))),
             Type::This => Type::This,
+            Type::KeyOf(t) => Type::KeyOf(Box::from(t.apply(sub))),
         };
         norm_type(result)
     }
@@ -81,6 +82,7 @@ impl Substitutable for Type {
             Type::Array(t) => t.ftv(),
             Type::Rest(arg) => arg.ftv(),
             Type::This => HashSet::new(),
+            Type::KeyOf(t) => t.ftv(),
         }
     }
 }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -151,6 +151,7 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
             Type::Array(t) => Type::Array(Box::from(norm_type(t, mapping, ctx))),
             Type::Rest(arg) => Type::Rest(Box::from(norm_type(arg, mapping, ctx))),
             Type::This => Type::This,
+            Type::KeyOf(t) => Type::KeyOf(Box::from(norm_type(t, mapping, ctx))),
         }
     }
 
@@ -301,7 +302,7 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         .filter(|t| matches!(t, Type::Keyword(_)))
         .collect();
 
-    let rest_types: HashSet<_> = types_set
+    let other_types: HashSet<_> = types_set
         .iter()
         .cloned()
         .filter(|t| !matches!(t, Type::Prim(_) | Type::Lit(_) | Type::Keyword(_)))
@@ -311,7 +312,7 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         .iter()
         .chain(lit_types.iter())
         .chain(keyword_types.iter())
-        .chain(rest_types.iter())
+        .chain(other_types.iter())
         .cloned()
         .collect();
 
@@ -367,44 +368,22 @@ pub fn get_property_type(prop: &TProp) -> Type {
 
 pub fn get_type_params(t: &Type) -> Vec<i32> {
     match t {
-        Type::Var(_) => vec![],
-        Type::App(_) => vec![],
         Type::Lam(lam) => lam.type_params.to_owned(),
-        Type::Prim(_) => vec![],
-        Type::Lit(_) => vec![],
-        Type::Keyword(_) => vec![],
-        Type::Union(_) => vec![],
-        Type::Intersection(_) => vec![],
         Type::Object(obj) => obj.type_params.to_owned(),
-        Type::Ref(_) => vec![],
-        Type::Tuple(_) => vec![],
-        Type::Array(_) => vec![],
-        Type::Rest(_) => vec![],
-        Type::This => vec![],
+        _ => vec![],
     }
 }
 
 pub fn set_type_params(t: &Type, type_params: &[i32]) -> Type {
     match t {
-        Type::Var(_) => t.to_owned(),
-        Type::App(_) => t.to_owned(),
         Type::Lam(lam) => Type::Lam(TLam {
             type_params: type_params.to_owned(),
             ..lam.to_owned()
         }),
-        Type::Prim(_) => t.to_owned(),
-        Type::Lit(_) => t.to_owned(),
-        Type::Keyword(_) => t.to_owned(),
-        Type::Union(_) => t.to_owned(),
-        Type::Intersection(_) => t.to_owned(),
         Type::Object(obj) => Type::Object(TObject {
             type_params: type_params.to_owned(),
             ..obj.to_owned()
         }),
-        Type::Ref(_) => t.to_owned(),
-        Type::Tuple(_) => t.to_owned(),
-        Type::Array(_) => t.to_owned(),
-        Type::Rest(_) => t.to_owned(),
-        Type::This => t.to_owned(),
+        _ => t.to_owned(),
     }
 }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1211,7 +1211,15 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> TypeAnn {
         }
         "flow_maybe_type" => todo!(),
         "type_query" => todo!(),
-        "index_type_query" => todo!(),
+        "index_type_query" => {
+            let type_ann = node.named_child(0).unwrap();
+            let type_ann = parse_type_ann(&type_ann, src);
+
+            TypeAnn::KeyOf(KeyOfType {
+                span: node.byte_range(),
+                type_ann: Box::from(type_ann),
+            })
+        }
         // alias($.this, $.this_type),
         "existential_type" => todo!(),
         "literal_type" => {
@@ -1718,6 +1726,7 @@ mod tests {
         insta::assert_debug_snapshot!(parse("type Foo<T extends string> = {bar: T};"));
         insta::assert_debug_snapshot!(parse(r#"type Foo<T = "foo"> = {bar: T};"#));
         insta::assert_debug_snapshot!(parse(r#"type Foo<T extends string = "foo"> = {bar: T};"#));
+        insta::assert_debug_snapshot!(parse("type CoordNames = keyof Point;"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-7.snap
@@ -1,0 +1,31 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type CoordNames = keyof Point;\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..30,
+                declare: false,
+                id: Ident {
+                    span: 5..15,
+                    name: "CoordNames",
+                },
+                type_ann: KeyOf(
+                    KeyOfType {
+                        span: 18..29,
+                        type_ann: TypeRef(
+                            TypeRef {
+                                span: 24..29,
+                                name: "Point",
+                                type_params: None,
+                            },
+                        ),
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_types/src/keyword.rs
+++ b/crates/crochet_types/src/keyword.rs
@@ -6,6 +6,7 @@ pub enum TKeyword {
     Null,
     Symbol,
     Undefined,
+    Never,
 }
 
 impl fmt::Display for TKeyword {
@@ -14,6 +15,7 @@ impl fmt::Display for TKeyword {
             TKeyword::Null => write!(f, "null"),
             TKeyword::Symbol => write!(f, "symbol"),
             TKeyword::Undefined => write!(f, "undefined"),
+            TKeyword::Never => write!(f, "never"),
         }
     }
 }

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -57,6 +57,7 @@ pub enum Type {
     Array(Box<Type>),
     Rest(Box<Type>), // TODO: rename this to Spread
     This,
+    KeyOf(Box<Type>),
 }
 
 impl From<TLit> for Type {
@@ -107,6 +108,9 @@ impl fmt::Display for Type {
             Type::Array(t) => write!(f, "{t}[]"),
             Type::Rest(arg) => write!(f, "...{arg}"),
             Type::This => write!(f, "this"),
+            Type::KeyOf(t) => write!(f, "keyof {t}"),
         }
     }
 }
+
+// TODO: add unit tests to verify the fmt::Display output


### PR DESCRIPTION
This is a pre-req for supporting mapped types since many of the utility types defined using mapped types make use of `keyof`.