### PR TITLE
Implement 'typeof' type query operator

### DIFF
--- a/crates/crochet_ast/src/type_ann.rs
+++ b/crates/crochet_ast/src/type_ann.rs
@@ -1,4 +1,5 @@
 use crate::expr::EFnParamPat;
+use crate::expr::Expr;
 use crate::ident::Ident;
 use crate::keyword::Keyword;
 use crate::lit::Lit;
@@ -93,6 +94,15 @@ pub struct KeyOfType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryType {
+    pub span: Span,
+    // TypeScript only supports typeof on (qualified) identifiers.
+    // We could modify the parser if we wanted to support taking
+    // the type of arbitrary expressions.
+    pub expr: Box<Expr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnn {
     Lam(LamType),
     Lit(Lit),
@@ -103,8 +113,9 @@ pub enum TypeAnn {
     Union(UnionType),
     Intersection(IntersectionType),
     Tuple(TupleType),
-    Array(ArrayType),
-    KeyOf(KeyOfType),
+    Array(ArrayType), // T[]
+    KeyOf(KeyOfType), // keyof
+    Query(QueryType), // typeof
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -101,7 +101,7 @@ pub fn infer_prog(prog: &Program, ctx: &mut Context) -> Result<Context, String> 
                 type_params,
                 ..
             } => {
-                let scheme = infer_scheme_with_type_params(type_ann, type_params, ctx);
+                let scheme = infer_qualified_type_ann(type_ann, type_params, ctx);
                 ctx.insert_type(id.name.to_owned(), scheme);
             }
             Statement::Expr { expr, .. } => {

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -14,7 +14,7 @@ pub type Assump = HashMap<String, Type>;
 // into the appropriate context.
 pub fn infer_fn_param(
     param: &EFnParam,
-    ctx: &Context,
+    ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
 ) -> Result<(Subst, Assump, TFnParam), String> {
     // Keeps track of all of the variables the need to be introduced by this pattern.

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -17,7 +17,7 @@ pub type Assump = HashMap<String, Type>;
 fn infer_pattern(
     pat: &Pattern,
     type_ann: &Option<TypeAnn>,
-    ctx: &Context,
+    ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
 ) -> Result<(Subst, Assump, Type), String> {
     // Keeps track of all of the variables the need to be introduced by this pattern.

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1210,7 +1210,15 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> TypeAnn {
             })
         }
         "flow_maybe_type" => todo!(),
-        "type_query" => todo!(),
+        "type_query" => {
+            let expr = node.named_child(0).unwrap();
+            let expr = parse_expression(&expr, src);
+
+            TypeAnn::Query(QueryType {
+                span: node.byte_range(),
+                expr: Box::from(expr),
+            })
+        }
         "index_type_query" => {
             let type_ann = node.named_child(0).unwrap();
             let type_ann = parse_type_ann(&type_ann, src);
@@ -1727,6 +1735,8 @@ mod tests {
         insta::assert_debug_snapshot!(parse(r#"type Foo<T = "foo"> = {bar: T};"#));
         insta::assert_debug_snapshot!(parse(r#"type Foo<T extends string = "foo"> = {bar: T};"#));
         insta::assert_debug_snapshot!(parse("type CoordNames = keyof Point;"));
+        insta::assert_debug_snapshot!(parse("type Foo = typeof foo;"));
+        insta::assert_debug_snapshot!(parse("type FooBar = typeof foo.bar;"));
     }
 
     #[test]

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-8.snap
@@ -1,0 +1,30 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type Foo = typeof foo;\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..22,
+                declare: false,
+                id: Ident {
+                    span: 5..8,
+                    name: "Foo",
+                },
+                type_ann: Query(
+                    QueryType {
+                        span: 11..21,
+                        expr: Ident(
+                            Ident {
+                                span: 18..21,
+                                name: "foo",
+                            },
+                        ),
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-9.snap
@@ -1,0 +1,41 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type FooBar = typeof foo.bar;\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..29,
+                declare: false,
+                id: Ident {
+                    span: 5..11,
+                    name: "FooBar",
+                },
+                type_ann: Query(
+                    QueryType {
+                        span: 14..28,
+                        expr: Member(
+                            Member {
+                                span: 21..28,
+                                obj: Ident(
+                                    Ident {
+                                        span: 21..24,
+                                        name: "foo",
+                                    },
+                                ),
+                                prop: Ident(
+                                    Ident {
+                                        span: 25..28,
+                                        name: "bar",
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ),
+                type_params: None,
+            },
+        ],
+    },
+)


### PR DESCRIPTION
This PR also does some renaming of functions in infer_type_ann.rs and updates their signatures to require a mutable `Context`.