### PR TITLE
Parse indexers in object types annotations

### DIFF
--- a/crates/crochet_ast/src/type_ann.rs
+++ b/crates/crochet_ast/src/type_ann.rs
@@ -3,7 +3,6 @@ use crate::expr::Expr;
 use crate::ident::Ident;
 use crate::keyword::Keyword;
 use crate::lit::Lit;
-use crate::pattern::{BindingIdent, RestPat};
 use crate::prim::Primitive;
 use crate::span::Span;
 
@@ -20,13 +19,6 @@ pub struct LamType {
     pub params: Vec<TypeAnnFnParam>,
     pub ret: Box<TypeAnn>,
     pub type_params: Option<Vec<TypeParam>>,
-}
-
-// TODO: replace this with FnParam from expr
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FnParam {
-    Ident(BindingIdent),
-    Rest(RestPat),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -52,7 +44,19 @@ pub struct TypeRef {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectType {
     pub span: Span,
-    pub props: Vec<TProp>,
+    // TODO: update this to support indexers and callables as well.
+    pub elems: Vec<TObjElem>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TObjElem {
+    // Call(TLam),
+    // Constructor(TLam),
+    Index(TIndex),
+    Prop(TProp),
+    // Getter
+    // Setter
+    // RestSpread - we can use this instead of converting {a, ...x} to {a} & tvar
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -60,6 +64,15 @@ pub struct TProp {
     pub span: Span,
     pub name: String,
     pub optional: bool,
+    pub mutable: bool,
+    pub type_ann: Box<TypeAnn>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TIndex {
+    pub span: Span,
+    // TODO: update this to only allow `<ident>: string` or `<ident>: number`
+    pub key: TypeAnnFnParam,
     pub mutable: bool,
     pub type_ann: Box<TypeAnn>,
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2312,4 +2312,22 @@ mod tests {
         assert_eq!(get_type_type("B", &ctx), "{c: string}");
         assert_eq!(get_type_type("C", &ctx), "string");
     }
+
+    #[test]
+    fn test_indexed_access_with_indexer_elements() {
+        let src = r#"
+        type ReadonlyArray<T> = {
+            [key: string]: T
+        }
+        type MyRecord = {[key: string]: number};
+        type MyArray = boolean[];
+        type RecVal = MyRecord["foo"];
+        type ArrVal = MyArray["bar"];
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_type_type("RecVal", &ctx), "number");
+        assert_eq!(get_type_type("ArrVal", &ctx), "boolean");
+    }
 }

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
@@ -52,31 +52,35 @@ Ok(
                                         Object(
                                             ObjectType {
                                                 span: 19..41,
-                                                props: [
-                                                    TProp {
-                                                        span: 20..29,
-                                                        name: "a",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: Prim(
-                                                            PrimType {
-                                                                span: 23..29,
-                                                                prim: Str,
-                                                            },
-                                                        ),
-                                                    },
-                                                    TProp {
-                                                        span: 31..40,
-                                                        name: "b",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: Prim(
-                                                            PrimType {
-                                                                span: 34..40,
-                                                                prim: Num,
-                                                            },
-                                                        ),
-                                                    },
+                                                elems: [
+                                                    Prop(
+                                                        TProp {
+                                                            span: 20..29,
+                                                            name: "a",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: Prim(
+                                                                PrimType {
+                                                                    span: 23..29,
+                                                                    prim: Str,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    Prop(
+                                                        TProp {
+                                                            span: 31..40,
+                                                            name: "b",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: Prim(
+                                                                PrimType {
+                                                                    span: 34..40,
+                                                                    prim: Num,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
                                                 ],
                                             },
                                         ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-11.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-11.snap
@@ -1,0 +1,69 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type Array<T> = {[key: number]: T}\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..34,
+                declare: false,
+                id: Ident {
+                    span: 5..10,
+                    name: "Array",
+                },
+                type_ann: Object(
+                    ObjectType {
+                        span: 16..34,
+                        elems: [
+                            Index(
+                                TIndex {
+                                    span: 17..33,
+                                    key: TypeAnnFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
+                                                span: 18..21,
+                                                id: Ident {
+                                                    span: 18..21,
+                                                    name: "key",
+                                                },
+                                            },
+                                        ),
+                                        type_ann: Prim(
+                                            PrimType {
+                                                span: 23..29,
+                                                prim: Num,
+                                            },
+                                        ),
+                                        optional: false,
+                                    },
+                                    mutable: false,
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 32..33,
+                                            name: "T",
+                                            type_params: None,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 11..12,
+                            name: Ident {
+                                span: 11..12,
+                                name: "T",
+                            },
+                            constraint: None,
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-2.snap
@@ -15,31 +15,35 @@ Ok(
                 type_ann: Object(
                     ObjectType {
                         span: 13..35,
-                        props: [
-                            TProp {
-                                span: 14..23,
-                                name: "x",
-                                optional: false,
-                                mutable: false,
-                                type_ann: Prim(
-                                    PrimType {
-                                        span: 17..23,
-                                        prim: Num,
-                                    },
-                                ),
-                            },
-                            TProp {
-                                span: 25..34,
-                                name: "y",
-                                optional: false,
-                                mutable: false,
-                                type_ann: Prim(
-                                    PrimType {
-                                        span: 28..34,
-                                        prim: Num,
-                                    },
-                                ),
-                            },
+                        elems: [
+                            Prop(
+                                TProp {
+                                    span: 14..23,
+                                    name: "x",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: Prim(
+                                        PrimType {
+                                            span: 17..23,
+                                            prim: Num,
+                                        },
+                                    ),
+                                },
+                            ),
+                            Prop(
+                                TProp {
+                                    span: 25..34,
+                                    name: "y",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: Prim(
+                                        PrimType {
+                                            span: 28..34,
+                                            prim: Num,
+                                        },
+                                    ),
+                                },
+                            ),
                         ],
                     },
                 ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-3.snap
@@ -15,20 +15,22 @@ Ok(
                 type_ann: Object(
                     ObjectType {
                         span: 14..22,
-                        props: [
-                            TProp {
-                                span: 15..21,
-                                name: "bar",
-                                optional: false,
-                                mutable: false,
-                                type_ann: TypeRef(
-                                    TypeRef {
-                                        span: 20..21,
-                                        name: "T",
-                                        type_params: None,
-                                    },
-                                ),
-                            },
+                        elems: [
+                            Prop(
+                                TProp {
+                                    span: 15..21,
+                                    name: "bar",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 20..21,
+                                            name: "T",
+                                            type_params: None,
+                                        },
+                                    ),
+                                },
+                            ),
                         ],
                     },
                 ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-4.snap
@@ -15,20 +15,22 @@ Ok(
                 type_ann: Object(
                     ObjectType {
                         span: 29..37,
-                        props: [
-                            TProp {
-                                span: 30..36,
-                                name: "bar",
-                                optional: false,
-                                mutable: false,
-                                type_ann: TypeRef(
-                                    TypeRef {
-                                        span: 35..36,
-                                        name: "T",
-                                        type_params: None,
-                                    },
-                                ),
-                            },
+                        elems: [
+                            Prop(
+                                TProp {
+                                    span: 30..36,
+                                    name: "bar",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 35..36,
+                                            name: "T",
+                                            type_params: None,
+                                        },
+                                    ),
+                                },
+                            ),
                         ],
                     },
                 ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-5.snap
@@ -15,20 +15,22 @@ Ok(
                 type_ann: Object(
                     ObjectType {
                         span: 22..30,
-                        props: [
-                            TProp {
-                                span: 23..29,
-                                name: "bar",
-                                optional: false,
-                                mutable: false,
-                                type_ann: TypeRef(
-                                    TypeRef {
-                                        span: 28..29,
-                                        name: "T",
-                                        type_params: None,
-                                    },
-                                ),
-                            },
+                        elems: [
+                            Prop(
+                                TProp {
+                                    span: 23..29,
+                                    name: "bar",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 28..29,
+                                            name: "T",
+                                            type_params: None,
+                                        },
+                                    ),
+                                },
+                            ),
                         ],
                     },
                 ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-6.snap
@@ -15,20 +15,22 @@ Ok(
                 type_ann: Object(
                     ObjectType {
                         span: 37..45,
-                        props: [
-                            TProp {
-                                span: 38..44,
-                                name: "bar",
-                                optional: false,
-                                mutable: false,
-                                type_ann: TypeRef(
-                                    TypeRef {
-                                        span: 43..44,
-                                        name: "T",
-                                        type_params: None,
-                                    },
-                                ),
-                            },
+                        elems: [
+                            Prop(
+                                TProp {
+                                    span: 38..44,
+                                    name: "bar",
+                                    optional: false,
+                                    mutable: false,
+                                    type_ann: TypeRef(
+                                        TypeRef {
+                                            span: 43..44,
+                                            name: "T",
+                                            type_params: None,
+                                        },
+                                    ),
+                                },
+                            ),
                         ],
                     },
                 ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-8.snap
@@ -23,45 +23,51 @@ Ok(
                                         Object(
                                             ObjectType {
                                                 span: 35..76,
-                                                props: [
-                                                    TProp {
-                                                        span: 36..53,
-                                                        name: "type",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: Lit(
-                                                            Str(
-                                                                Str {
-                                                                    span: 42..53,
-                                                                    value: "mousedown",
+                                                elems: [
+                                                    Prop(
+                                                        TProp {
+                                                            span: 36..53,
+                                                            name: "type",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        span: 42..53,
+                                                                        value: "mousedown",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    ),
+                                                    Prop(
+                                                        TProp {
+                                                            span: 55..64,
+                                                            name: "x",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: Prim(
+                                                                PrimType {
+                                                                    span: 58..64,
+                                                                    prim: Num,
                                                                 },
                                                             ),
-                                                        ),
-                                                    },
-                                                    TProp {
-                                                        span: 55..64,
-                                                        name: "x",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: Prim(
-                                                            PrimType {
-                                                                span: 58..64,
-                                                                prim: Num,
-                                                            },
-                                                        ),
-                                                    },
-                                                    TProp {
-                                                        span: 66..75,
-                                                        name: "y",
-                                                        optional: false,
-                                                        mutable: false,
-                                                        type_ann: Prim(
-                                                            PrimType {
-                                                                span: 69..75,
-                                                                prim: Num,
-                                                            },
-                                                        ),
-                                                    },
+                                                        },
+                                                    ),
+                                                    Prop(
+                                                        TProp {
+                                                            span: 66..75,
+                                                            name: "y",
+                                                            optional: false,
+                                                            mutable: false,
+                                                            type_ann: Prim(
+                                                                PrimType {
+                                                                    span: 69..75,
+                                                                    prim: Num,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
                                                 ],
                                             },
                                         ),
@@ -71,33 +77,37 @@ Ok(
                             Object(
                                 ObjectType {
                                     span: 89..119,
-                                    props: [
-                                        TProp {
-                                            span: 90..105,
-                                            name: "type",
-                                            optional: false,
-                                            mutable: false,
-                                            type_ann: Lit(
-                                                Str(
-                                                    Str {
-                                                        span: 96..105,
-                                                        value: "keydown",
+                                    elems: [
+                                        Prop(
+                                            TProp {
+                                                span: 90..105,
+                                                name: "type",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: Lit(
+                                                    Str(
+                                                        Str {
+                                                            span: 96..105,
+                                                            value: "keydown",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                        Prop(
+                                            TProp {
+                                                span: 107..118,
+                                                name: "key",
+                                                optional: false,
+                                                mutable: false,
+                                                type_ann: Prim(
+                                                    PrimType {
+                                                        span: 112..118,
+                                                        prim: Str,
                                                     },
                                                 ),
-                                            ),
-                                        },
-                                        TProp {
-                                            span: 107..118,
-                                            name: "key",
-                                            optional: false,
-                                            mutable: false,
-                                            type_ann: Prim(
-                                                PrimType {
-                                                    span: 112..118,
-                                                    prim: Str,
-                                                },
-                                            ),
-                                        },
+                                            },
+                                        ),
                                     ],
                                 },
                             ),

--- a/crates/crochet_types/src/obj.rs
+++ b/crates/crochet_types/src/obj.rs
@@ -28,7 +28,8 @@ impl fmt::Display for TObjElem {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TIndex {
-    pub key: TFnParam, // identifier + type
+    // TODO: update this to only allow `<ident>: string` or `<ident>: number`
+    pub key: TFnParam,
     pub mutable: bool,
     pub t: Type,
 }


### PR DESCRIPTION
This allows us to define object types in Crochet that include indexers.