### PR TITLE
Re-org Expr struct

### DIFF
--- a/crates/crochet_ast/src/expr.rs
+++ b/crates/crochet_ast/src/expr.rs
@@ -40,20 +40,17 @@ pub enum Statement {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct App {
-    pub span: Span,
     pub lam: Box<Expr>,
     pub args: Vec<ExprOrSpread>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Fix {
-    pub span: Span,
     pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IfElse {
-    pub span: Span,
     pub cond: Box<Expr>,
     pub consequent: Box<Expr>,
     pub alternate: Option<Box<Expr>>,
@@ -61,14 +58,12 @@ pub struct IfElse {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LetExpr {
-    pub span: Span,
     pub pat: Pattern,
     pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Lambda {
-    pub span: Span,
     pub params: Vec<EFnParam>,
     pub body: Box<Expr>,
     pub is_async: bool,
@@ -157,7 +152,6 @@ pub struct EFnParamAssignPatProp {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Let {
-    pub span: Span,
     pub pattern: Option<Pattern>,
     pub type_ann: Option<TypeAnn>,
     pub init: Box<Expr>,
@@ -166,7 +160,6 @@ pub struct Let {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryExpr {
-    pub span: Span,
     pub op: BinOp,
     pub left: Box<Expr>,
     pub right: Box<Expr>,
@@ -174,14 +167,12 @@ pub struct BinaryExpr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnaryExpr {
-    pub span: Span,
     pub op: UnaryOp,
     pub arg: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Obj {
-    pub span: Span,
     pub props: Vec<PropOrSpread>,
 }
 
@@ -193,7 +184,6 @@ pub enum PropOrSpread {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpreadElement {
-    pub span: Span,
     pub expr: Box<Expr>,
 }
 
@@ -205,20 +195,17 @@ pub enum Prop {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyValueProp {
-    pub span: Span,
     pub name: String,
     pub value: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Await {
-    pub span: Span,
     pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tuple {
-    pub span: Span,
     pub elems: Vec<ExprOrSpread>,
 }
 
@@ -230,7 +217,6 @@ pub struct ExprOrSpread {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Member {
-    pub span: Span,
     pub obj: Box<Expr>,
     pub prop: MemberProp,
 }
@@ -257,11 +243,6 @@ pub struct ComputedPropName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Empty {
-    pub span: Span,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TemplateElem {
     pub span: Span,
     pub raw: Lit,
@@ -270,21 +251,19 @@ pub struct TemplateElem {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TemplateLiteral {
-    pub span: Span,
     pub exprs: Vec<Expr>,
     pub quasis: Vec<TemplateElem>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaggedTemplateLiteral {
-    pub span: Span,
     pub tag: Ident,
+    // TODO: figure out how to track the span of the `template` part
     pub template: TemplateLiteral,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Match {
-    pub span: Span,
     pub expr: Box<Expr>,
     pub arms: Vec<Arm>,
 }
@@ -298,7 +277,7 @@ pub struct Arm {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Expr {
+pub enum ExprKind {
     App(App),
     Fix(Fix),
     Ident(Ident),
@@ -314,36 +293,16 @@ pub enum Expr {
     Await(Await),
     Tuple(Tuple),
     Member(Member),
-    Empty(Empty),
+    Empty,
     TemplateLiteral(TemplateLiteral),
     TaggedTemplateLiteral(TaggedTemplateLiteral),
     Match(Match),
 }
 
-impl Expr {
-    pub fn span(&self) -> Span {
-        match &self {
-            Expr::App(app) => app.span.to_owned(),
-            Expr::Fix(fix) => fix.span.to_owned(),
-            Expr::Ident(ident) => ident.span.to_owned(),
-            Expr::IfElse(if_else) => if_else.span.to_owned(),
-            Expr::JSXElement(elem) => elem.span.to_owned(),
-            Expr::Lambda(lam) => lam.span.to_owned(),
-            Expr::Let(r#let) => r#let.span.to_owned(),
-            Expr::Lit(lit) => lit.span(),
-            Expr::BinaryExpr(op) => op.span.to_owned(),
-            Expr::UnaryExpr(ue) => ue.span.to_owned(),
-            Expr::Obj(obj) => obj.span.to_owned(),
-            Expr::Await(r#await) => r#await.span.to_owned(),
-            Expr::Tuple(tuple) => tuple.span.to_owned(),
-            Expr::Member(member) => member.span.to_owned(),
-            Expr::Empty(empty) => empty.span.to_owned(),
-            Expr::LetExpr(let_expr) => let_expr.span.to_owned(),
-            Expr::TemplateLiteral(tl) => tl.span.to_owned(),
-            Expr::TaggedTemplateLiteral(ttl) => ttl.span.to_owned(),
-            Expr::Match(m) => m.span.to_owned(),
-        }
-    }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Expr {
+    pub span: Span,
+    pub kind: ExprKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_ast/src/jsx.rs
+++ b/crates/crochet_ast/src/jsx.rs
@@ -12,7 +12,7 @@ pub struct JSXText {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JSXExprContainer {
     pub span: Span,
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread-2.snap
@@ -18,33 +18,41 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 12..21,
-                            elems: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Ident(
-                                        Ident {
+                    Expr {
+                        span: 12..21,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
                                             span: 13..14,
-                                            name: "a",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 13..14,
+                                                    name: "a",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: Some(
-                                        16..20,
-                                    ),
-                                    expr: Ident(
-                                        Ident {
+                                    },
+                                    ExprOrSpread {
+                                        spread: Some(
+                                            16..20,
+                                        ),
+                                        expr: Expr {
                                             span: 19..20,
-                                            name: "b",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 19..20,
+                                                    name: "b",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread-3.snap
@@ -18,58 +18,71 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 12..26,
-                            elems: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 13..14,
-                                                value: "1",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: Some(
-                                        16..25,
-                                    ),
-                                    expr: Tuple(
-                                        Tuple {
-                                            span: 19..25,
-                                            elems: [
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Lit(
-                                                        Num(
-                                                            Num {
-                                                                span: 20..21,
-                                                                value: "2",
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Lit(
-                                                        Num(
-                                                            Num {
-                                                                span: 23..24,
-                                                                value: "3",
-                                                            },
-                                                        ),
-                                                    ),
-                                                },
-                                            ],
+                    Expr {
+                        span: 12..26,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 13..14,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 13..14,
+                                                        value: "1",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                    ExprOrSpread {
+                                        spread: Some(
+                                            16..25,
+                                        ),
+                                        expr: Expr {
+                                            span: 19..25,
+                                            kind: Tuple(
+                                                Tuple {
+                                                    elems: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                span: 20..21,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            span: 20..21,
+                                                                            value: "2",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                span: 23..24,
+                                                                kind: Lit(
+                                                                    Num(
+                                                                        Num {
+                                                                            span: 23..24,
+                                                                            value: "3",
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__array_spread.snap
@@ -18,33 +18,41 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 12..21,
-                            elems: [
-                                ExprOrSpread {
-                                    spread: Some(
-                                        13..17,
-                                    ),
-                                    expr: Ident(
-                                        Ident {
+                    Expr {
+                        span: 12..21,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [
+                                    ExprOrSpread {
+                                        spread: Some(
+                                            13..17,
+                                        ),
+                                        expr: Expr {
                                             span: 16..17,
-                                            name: "a",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 16..17,
+                                                    name: "a",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Ident(
-                                        Ident {
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
                                             span: 19..20,
-                                            name: "b",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 19..20,
+                                                    name: "b",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-2.snap
@@ -18,28 +18,35 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..34,
-                            params: [],
-                            body: Await(
-                                Await {
+                    Expr {
+                        span: 10..34,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 24..32,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
+                                    kind: Await(
+                                        Await {
+                                            expr: Expr {
                                                 span: 30..32,
-                                                value: "10",
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 30..32,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
                                             },
-                                        ),
+                                        },
                                     ),
                                 },
-                            ),
-                            is_async: true,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: true,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-3.snap
@@ -18,43 +18,57 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..39,
-                            params: [],
-                            body: BinaryExpr(
-                                BinaryExpr {
+                    Expr {
+                        span: 10..39,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 22..39,
-                                    op: Add,
-                                    left: Await(
-                                        Await {
-                                            span: 22..29,
-                                            expr: Ident(
-                                                Ident {
-                                                    span: 28..29,
-                                                    name: "a",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    right: Await(
-                                        Await {
-                                            span: 32..39,
-                                            expr: Ident(
-                                                Ident {
-                                                    span: 38..39,
-                                                    name: "b",
-                                                },
-                                            ),
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                span: 22..29,
+                                                kind: Await(
+                                                    Await {
+                                                        expr: Expr {
+                                                            span: 28..29,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 28..29,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                            right: Expr {
+                                                span: 32..39,
+                                                kind: Await(
+                                                    Await {
+                                                        expr: Expr {
+                                                            span: 38..39,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 38..39,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                            is_async: true,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: true,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await-4.snap
@@ -18,32 +18,41 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..33,
-                            params: [],
-                            body: Await(
-                                Await {
+                    Expr {
+                        span: 10..33,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 22..33,
-                                    expr: App(
-                                        App {
-                                            span: 28..33,
-                                            lam: Ident(
-                                                Ident {
-                                                    span: 28..31,
-                                                    name: "bar",
-                                                },
-                                            ),
-                                            args: [],
+                                    kind: Await(
+                                        Await {
+                                            expr: Expr {
+                                                span: 28..33,
+                                                kind: App(
+                                                    App {
+                                                        lam: Expr {
+                                                            span: 28..31,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 28..31,
+                                                                    name: "bar",
+                                                                },
+                                                            ),
+                                                        },
+                                                        args: [],
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                            is_async: true,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: true,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__async_await.snap
@@ -7,23 +7,28 @@ Ok(
         body: [
             Expr {
                 span: 0..15,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..14,
-                        params: [],
-                        body: Lit(
-                            Num(
-                                Num {
-                                    span: 12..14,
-                                    value: "10",
-                                },
-                            ),
-                        ),
-                        is_async: true,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                expr: Expr {
+                    span: 0..14,
+                    kind: Lambda(
+                        Lambda {
+                            params: [],
+                            body: Expr {
+                                span: 12..14,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            span: 12..14,
+                                            value: "10",
+                                        },
+                                    ),
+                                ),
+                            },
+                            is_async: true,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-2.snap
@@ -18,74 +18,92 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Let(
-                        Let {
-                            span: 14..24,
-                            pattern: Some(
-                                Ident(
-                                    BindingIdent {
-                                        span: 18..19,
-                                        id: Ident {
+                    Expr {
+                        span: 14..24,
+                        kind: Let(
+                            Let {
+                                pattern: Some(
+                                    Ident(
+                                        BindingIdent {
                                             span: 18..19,
-                                            name: "x",
-                                        },
-                                    },
-                                ),
-                            ),
-                            type_ann: None,
-                            init: Lit(
-                                Num(
-                                    Num {
-                                        span: 22..23,
-                                        value: "5",
-                                    },
-                                ),
-                            ),
-                            body: Let(
-                                Let {
-                                    span: 25..36,
-                                    pattern: Some(
-                                        Ident(
-                                            BindingIdent {
-                                                span: 29..30,
-                                                id: Ident {
-                                                    span: 29..30,
-                                                    name: "y",
-                                                },
+                                            id: Ident {
+                                                span: 18..19,
+                                                name: "x",
                                             },
-                                        ),
+                                        },
                                     ),
-                                    type_ann: None,
-                                    init: Lit(
+                                ),
+                                type_ann: None,
+                                init: Expr {
+                                    span: 22..23,
+                                    kind: Lit(
                                         Num(
                                             Num {
-                                                span: 33..35,
-                                                value: "10",
+                                                span: 22..23,
+                                                value: "5",
                                             },
                                         ),
                                     ),
-                                    body: BinaryExpr(
-                                        BinaryExpr {
-                                            span: 37..42,
-                                            op: Add,
-                                            left: Ident(
-                                                Ident {
-                                                    span: 37..38,
-                                                    name: "x",
-                                                },
+                                },
+                                body: Expr {
+                                    span: 25..36,
+                                    kind: Let(
+                                        Let {
+                                            pattern: Some(
+                                                Ident(
+                                                    BindingIdent {
+                                                        span: 29..30,
+                                                        id: Ident {
+                                                            span: 29..30,
+                                                            name: "y",
+                                                        },
+                                                    },
+                                                ),
                                             ),
-                                            right: Ident(
-                                                Ident {
-                                                    span: 41..42,
-                                                    name: "y",
-                                                },
-                                            ),
+                                            type_ann: None,
+                                            init: Expr {
+                                                span: 33..35,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 33..35,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            body: Expr {
+                                                span: 37..42,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Add,
+                                                        left: Expr {
+                                                            span: 37..38,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 37..38,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                        },
+                                                        right: Expr {
+                                                            span: 41..42,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 41..42,
+                                                                    name: "y",
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-3.snap
@@ -7,74 +7,92 @@ Ok(
         body: [
             Expr {
                 span: 0..34,
-                expr: Let(
-                    Let {
-                        span: 4..14,
-                        pattern: Some(
-                            Ident(
-                                BindingIdent {
-                                    span: 8..9,
-                                    id: Ident {
+                expr: Expr {
+                    span: 4..14,
+                    kind: Let(
+                        Let {
+                            pattern: Some(
+                                Ident(
+                                    BindingIdent {
                                         span: 8..9,
-                                        name: "x",
-                                    },
-                                },
-                            ),
-                        ),
-                        type_ann: None,
-                        init: Lit(
-                            Num(
-                                Num {
-                                    span: 12..13,
-                                    value: "5",
-                                },
-                            ),
-                        ),
-                        body: Let(
-                            Let {
-                                span: 15..26,
-                                pattern: Some(
-                                    Ident(
-                                        BindingIdent {
-                                            span: 19..20,
-                                            id: Ident {
-                                                span: 19..20,
-                                                name: "y",
-                                            },
+                                        id: Ident {
+                                            span: 8..9,
+                                            name: "x",
                                         },
-                                    ),
+                                    },
                                 ),
-                                type_ann: None,
-                                init: Lit(
+                            ),
+                            type_ann: None,
+                            init: Expr {
+                                span: 12..13,
+                                kind: Lit(
                                     Num(
                                         Num {
-                                            span: 23..25,
-                                            value: "10",
+                                            span: 12..13,
+                                            value: "5",
                                         },
                                     ),
                                 ),
-                                body: BinaryExpr(
-                                    BinaryExpr {
-                                        span: 27..32,
-                                        op: Add,
-                                        left: Ident(
-                                            Ident {
-                                                span: 27..28,
-                                                name: "x",
-                                            },
+                            },
+                            body: Expr {
+                                span: 15..26,
+                                kind: Let(
+                                    Let {
+                                        pattern: Some(
+                                            Ident(
+                                                BindingIdent {
+                                                    span: 19..20,
+                                                    id: Ident {
+                                                        span: 19..20,
+                                                        name: "y",
+                                                    },
+                                                },
+                                            ),
                                         ),
-                                        right: Ident(
-                                            Ident {
-                                                span: 31..32,
-                                                name: "y",
-                                            },
-                                        ),
+                                        type_ann: None,
+                                        init: Expr {
+                                            span: 23..25,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 23..25,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                        body: Expr {
+                                            span: 27..32,
+                                            kind: BinaryExpr(
+                                                BinaryExpr {
+                                                    op: Add,
+                                                    left: Expr {
+                                                        span: 27..28,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 27..28,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                    },
+                                                    right: Expr {
+                                                        span: 31..32,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 31..32,
+                                                                name: "y",
+                                                            },
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-4.snap
@@ -7,97 +7,120 @@ Ok(
         body: [
             Expr {
                 span: 0..54,
-                expr: Let(
-                    Let {
-                        span: 4..48,
-                        pattern: Some(
-                            Ident(
-                                BindingIdent {
-                                    span: 8..11,
-                                    id: Ident {
+                expr: Expr {
+                    span: 4..48,
+                    kind: Let(
+                        Let {
+                            pattern: Some(
+                                Ident(
+                                    BindingIdent {
                                         span: 8..11,
-                                        name: "sum",
+                                        id: Ident {
+                                            span: 8..11,
+                                            name: "sum",
+                                        },
                                     },
-                                },
+                                ),
                             ),
-                        ),
-                        type_ann: None,
-                        init: Let(
-                            Let {
+                            type_ann: None,
+                            init: Expr {
                                 span: 18..28,
-                                pattern: Some(
-                                    Ident(
-                                        BindingIdent {
-                                            span: 22..23,
-                                            id: Ident {
-                                                span: 22..23,
-                                                name: "x",
-                                            },
-                                        },
-                                    ),
-                                ),
-                                type_ann: None,
-                                init: Lit(
-                                    Num(
-                                        Num {
-                                            span: 26..27,
-                                            value: "5",
-                                        },
-                                    ),
-                                ),
-                                body: Let(
+                                kind: Let(
                                     Let {
-                                        span: 29..40,
                                         pattern: Some(
                                             Ident(
                                                 BindingIdent {
-                                                    span: 33..34,
+                                                    span: 22..23,
                                                     id: Ident {
-                                                        span: 33..34,
-                                                        name: "y",
+                                                        span: 22..23,
+                                                        name: "x",
                                                     },
                                                 },
                                             ),
                                         ),
                                         type_ann: None,
-                                        init: Lit(
-                                            Num(
-                                                Num {
-                                                    span: 37..39,
-                                                    value: "10",
+                                        init: Expr {
+                                            span: 26..27,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 26..27,
+                                                        value: "5",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                        body: Expr {
+                                            span: 29..40,
+                                            kind: Let(
+                                                Let {
+                                                    pattern: Some(
+                                                        Ident(
+                                                            BindingIdent {
+                                                                span: 33..34,
+                                                                id: Ident {
+                                                                    span: 33..34,
+                                                                    name: "y",
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    type_ann: None,
+                                                    init: Expr {
+                                                        span: 37..39,
+                                                        kind: Lit(
+                                                            Num(
+                                                                Num {
+                                                                    span: 37..39,
+                                                                    value: "10",
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                    body: Expr {
+                                                        span: 41..46,
+                                                        kind: BinaryExpr(
+                                                            BinaryExpr {
+                                                                op: Add,
+                                                                left: Expr {
+                                                                    span: 41..42,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            span: 41..42,
+                                                                            name: "x",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                right: Expr {
+                                                                    span: 45..46,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            span: 45..46,
+                                                                            name: "y",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
                                                 },
                                             ),
-                                        ),
-                                        body: BinaryExpr(
-                                            BinaryExpr {
-                                                span: 41..46,
-                                                op: Add,
-                                                left: Ident(
-                                                    Ident {
-                                                        span: 41..42,
-                                                        name: "x",
-                                                    },
-                                                ),
-                                                right: Ident(
-                                                    Ident {
-                                                        span: 45..46,
-                                                        name: "y",
-                                                    },
-                                                ),
-                                            },
-                                        ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        body: Ident(
-                            Ident {
+                            body: Expr {
                                 span: 49..52,
-                                name: "sum",
+                                kind: Ident(
+                                    Ident {
+                                        span: 49..52,
+                                        name: "sum",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-5.snap
@@ -18,77 +18,97 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Let(
-                        Let {
-                            span: 14..24,
-                            pattern: Some(
-                                Ident(
-                                    BindingIdent {
-                                        span: 18..19,
-                                        id: Ident {
+                    Expr {
+                        span: 14..24,
+                        kind: Let(
+                            Let {
+                                pattern: Some(
+                                    Ident(
+                                        BindingIdent {
                                             span: 18..19,
-                                            name: "x",
-                                        },
-                                    },
-                                ),
-                            ),
-                            type_ann: None,
-                            init: Lit(
-                                Num(
-                                    Num {
-                                        span: 22..23,
-                                        value: "5",
-                                    },
-                                ),
-                            ),
-                            body: Let(
-                                Let {
-                                    span: 25..40,
-                                    pattern: None,
-                                    type_ann: None,
-                                    init: App(
-                                        App {
-                                            span: 25..39,
-                                            lam: Member(
-                                                Member {
-                                                    span: 25..36,
-                                                    obj: Ident(
-                                                        Ident {
-                                                            span: 25..32,
-                                                            name: "console",
-                                                        },
-                                                    ),
-                                                    prop: Ident(
-                                                        Ident {
-                                                            span: 33..36,
-                                                            name: "log",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            args: [
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Ident(
-                                                        Ident {
-                                                            span: 37..38,
-                                                            name: "x",
-                                                        },
-                                                    ),
-                                                },
-                                            ],
+                                            id: Ident {
+                                                span: 18..19,
+                                                name: "x",
+                                            },
                                         },
                                     ),
-                                    body: Ident(
-                                        Ident {
-                                            span: 41..42,
-                                            name: "x",
+                                ),
+                                type_ann: None,
+                                init: Expr {
+                                    span: 22..23,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                span: 22..23,
+                                                value: "5",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                body: Expr {
+                                    span: 25..40,
+                                    kind: Let(
+                                        Let {
+                                            pattern: None,
+                                            type_ann: None,
+                                            init: Expr {
+                                                span: 25..39,
+                                                kind: App(
+                                                    App {
+                                                        lam: Expr {
+                                                            span: 25..36,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
+                                                                        span: 25..32,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                span: 25..32,
+                                                                                name: "console",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    prop: Ident(
+                                                                        Ident {
+                                                                            span: 33..36,
+                                                                            name: "log",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                        args: [
+                                                            ExprOrSpread {
+                                                                spread: None,
+                                                                expr: Expr {
+                                                                    span: 37..38,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            span: 37..38,
+                                                                            name: "x",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            },
+                                                        ],
+                                                    },
+                                                ),
+                                            },
+                                            body: Expr {
+                                                span: 41..42,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 41..42,
+                                                        name: "x",
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks-6.snap
@@ -18,52 +18,67 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Let(
-                        Let {
-                            span: 14..29,
-                            pattern: None,
-                            type_ann: None,
-                            init: App(
-                                App {
+                    Expr {
+                        span: 14..29,
+                        kind: Let(
+                            Let {
+                                pattern: None,
+                                type_ann: None,
+                                init: Expr {
                                     span: 14..28,
-                                    lam: Member(
-                                        Member {
-                                            span: 14..25,
-                                            obj: Ident(
-                                                Ident {
-                                                    span: 14..21,
-                                                    name: "console",
+                                    kind: App(
+                                        App {
+                                            lam: Expr {
+                                                span: 14..25,
+                                                kind: Member(
+                                                    Member {
+                                                        obj: Expr {
+                                                            span: 14..21,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 14..21,
+                                                                    name: "console",
+                                                                },
+                                                            ),
+                                                        },
+                                                        prop: Ident(
+                                                            Ident {
+                                                                span: 22..25,
+                                                                name: "log",
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            },
+                                            args: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Expr {
+                                                        span: 26..27,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 26..27,
+                                                                name: "x",
+                                                            },
+                                                        ),
+                                                    },
                                                 },
-                                            ),
-                                            prop: Ident(
-                                                Ident {
-                                                    span: 22..25,
-                                                    name: "log",
-                                                },
-                                            ),
+                                            ],
                                         },
                                     ),
-                                    args: [
-                                        ExprOrSpread {
-                                            spread: None,
-                                            expr: Ident(
-                                                Ident {
-                                                    span: 26..27,
-                                                    name: "x",
-                                                },
-                                            ),
-                                        },
-                                    ],
                                 },
-                            ),
-                            body: Ident(
-                                Ident {
+                                body: Expr {
                                     span: 30..31,
-                                    name: "x",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 30..31,
+                                            name: "x",
+                                        },
+                                    ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__blocks.snap
@@ -18,37 +18,45 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Let(
-                        Let {
-                            span: 14..24,
-                            pattern: Some(
-                                Ident(
-                                    BindingIdent {
-                                        span: 18..19,
-                                        id: Ident {
+                    Expr {
+                        span: 14..24,
+                        kind: Let(
+                            Let {
+                                pattern: Some(
+                                    Ident(
+                                        BindingIdent {
                                             span: 18..19,
+                                            id: Ident {
+                                                span: 18..19,
+                                                name: "x",
+                                            },
+                                        },
+                                    ),
+                                ),
+                                type_ann: None,
+                                init: Expr {
+                                    span: 22..23,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                span: 22..23,
+                                                value: "5",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                body: Expr {
+                                    span: 25..26,
+                                    kind: Ident(
+                                        Ident {
+                                            span: 25..26,
                                             name: "x",
                                         },
-                                    },
-                                ),
-                            ),
-                            type_ann: None,
-                            init: Lit(
-                                Num(
-                                    Num {
-                                        span: 22..23,
-                                        value: "5",
-                                    },
-                                ),
-                            ),
-                            body: Ident(
-                                Ident {
-                                    span: 25..26,
-                                    name: "x",
+                                    ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-2.snap
@@ -18,62 +18,72 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 8..23,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 9..10,
-                                            id: Ident {
+                    Expr {
+                        span: 8..23,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 9..10,
-                                                name: "a",
+                                                id: Ident {
+                                                    span: 9..10,
+                                                    name: "a",
+                                                },
                                             },
-                                        },
-                                    ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
-                                },
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 12..13,
-                                            id: Ident {
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 12..13,
-                                                name: "b",
+                                                id: Ident {
+                                                    span: 12..13,
+                                                    name: "b",
+                                                },
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 18..23,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                span: 18..19,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 18..19,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                            },
+                                            right: Expr {
+                                                span: 22..23,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 22..23,
+                                                        name: "b",
+                                                    },
+                                                ),
                                             },
                                         },
                                     ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
                                 },
-                            ],
-                            body: BinaryExpr(
-                                BinaryExpr {
-                                    span: 18..23,
-                                    op: Add,
-                                    left: Ident(
-                                        Ident {
-                                            span: 18..19,
-                                            name: "a",
-                                        },
-                                    ),
-                                    right: Ident(
-                                        Ident {
-                                            span: 22..23,
-                                            name: "b",
-                                        },
-                                    ),
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-3.snap
@@ -18,37 +18,45 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Let(
-                        Let {
-                            span: 14..24,
-                            pattern: Some(
-                                Ident(
-                                    BindingIdent {
-                                        span: 18..19,
-                                        id: Ident {
+                    Expr {
+                        span: 14..24,
+                        kind: Let(
+                            Let {
+                                pattern: Some(
+                                    Ident(
+                                        BindingIdent {
                                             span: 18..19,
+                                            id: Ident {
+                                                span: 18..19,
+                                                name: "x",
+                                            },
+                                        },
+                                    ),
+                                ),
+                                type_ann: None,
+                                init: Expr {
+                                    span: 22..23,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                span: 22..23,
+                                                value: "5",
+                                            },
+                                        ),
+                                    ),
+                                },
+                                body: Expr {
+                                    span: 25..26,
+                                    kind: Ident(
+                                        Ident {
+                                            span: 25..26,
                                             name: "x",
                                         },
-                                    },
-                                ),
-                            ),
-                            type_ann: None,
-                            init: Lit(
-                                Num(
-                                    Num {
-                                        span: 22..23,
-                                        value: "5",
-                                    },
-                                ),
-                            ),
-                            body: Ident(
-                                Ident {
-                                    span: 25..26,
-                                    name: "x",
+                                    ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations-4.snap
@@ -18,56 +18,67 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Fix(
-                        Fix {
-                            span: 8..21,
-                            expr: Lambda(
-                                Lambda {
+                    Expr {
+                        span: 8..21,
+                        kind: Fix(
+                            Fix {
+                                expr: Expr {
                                     span: 8..21,
-                                    params: [
-                                        EFnParam {
-                                            pat: Ident(
-                                                EFnParamBindingIdent {
-                                                    span: 0..0,
-                                                    id: Ident {
-                                                        span: 8..9,
-                                                        name: "f",
-                                                    },
-                                                },
-                                            ),
-                                            type_ann: None,
-                                            optional: false,
-                                            mutable: false,
-                                        },
-                                    ],
-                                    body: Lambda(
+                                    kind: Lambda(
                                         Lambda {
-                                            span: 12..21,
-                                            params: [],
-                                            body: App(
-                                                App {
-                                                    span: 18..21,
-                                                    lam: Ident(
-                                                        Ident {
-                                                            span: 18..19,
-                                                            name: "f",
+                                            params: [
+                                                EFnParam {
+                                                    pat: Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 0..0,
+                                                            id: Ident {
+                                                                span: 8..9,
+                                                                name: "f",
+                                                            },
                                                         },
                                                     ),
-                                                    args: [],
+                                                    type_ann: None,
+                                                    optional: false,
+                                                    mutable: false,
                                                 },
-                                            ),
+                                            ],
+                                            body: Expr {
+                                                span: 12..21,
+                                                kind: Lambda(
+                                                    Lambda {
+                                                        params: [],
+                                                        body: Expr {
+                                                            span: 18..21,
+                                                            kind: App(
+                                                                App {
+                                                                    lam: Expr {
+                                                                        span: 18..19,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                span: 18..19,
+                                                                                name: "f",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    args: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        is_async: false,
+                                                        return_type: None,
+                                                        type_params: None,
+                                                    },
+                                                ),
+                                            },
                                             is_async: false,
                                             return_type: None,
                                             type_params: None,
                                         },
                                     ),
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__declarations.snap
@@ -18,14 +18,17 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lit(
-                        Num(
-                            Num {
-                                span: 8..9,
-                                value: "5",
-                            },
+                    Expr {
+                        span: 8..9,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    span: 8..9,
+                                    value: "5",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__decls-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__decls-2.snap
@@ -18,14 +18,17 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lit(
-                        Num(
-                            Num {
-                                span: 11..12,
-                                value: "5",
-                            },
+                    Expr {
+                        span: 11..12,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    span: 11..12,
+                                    value: "5",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__decls.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__decls.snap
@@ -18,14 +18,17 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lit(
-                        Num(
-                            Num {
-                                span: 8..9,
-                                value: "5",
-                            },
+                    Expr {
+                        span: 8..9,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    span: 8..9,
+                                    value: "5",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-2.snap
@@ -51,12 +51,15 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Ident(
-                        Ident {
-                            span: 22..29,
-                            name: "letters",
-                        },
-                    ),
+                    Expr {
+                        span: 22..29,
+                        kind: Ident(
+                            Ident {
+                                span: 22..29,
+                                name: "letters",
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
@@ -89,12 +89,15 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Ident(
-                        Ident {
-                            span: 31..35,
-                            name: "line",
-                        },
-                    ),
+                    Expr {
+                        span: 31..35,
+                        kind: Ident(
+                            Ident {
+                                span: 31..35,
+                                name: "line",
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-4.snap
@@ -55,12 +55,15 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Ident(
-                        Ident {
-                            span: 22..29,
-                            name: "letters",
-                        },
-                    ),
+                    Expr {
+                        span: 22..29,
+                        kind: Ident(
+                            Ident {
+                                span: 22..29,
+                                name: "letters",
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-5.snap
@@ -70,12 +70,15 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Ident(
-                        Ident {
-                            span: 31..34,
-                            name: "baz",
-                        },
-                    ),
+                    Expr {
+                        span: 31..34,
+                        kind: Ident(
+                            Ident {
+                                span: 31..34,
+                                name: "baz",
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-6.snap
@@ -18,56 +18,61 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..23,
-                            params: [
-                                EFnParam {
-                                    pat: Array(
-                                        EFnParamArrayPat {
-                                            span: 11..17,
-                                            elems: [
-                                                Some(
-                                                    Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 12..13,
-                                                            id: Ident {
+                    Expr {
+                        span: 10..23,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Array(
+                                            EFnParamArrayPat {
+                                                span: 11..17,
+                                                elems: [
+                                                    Some(
+                                                        Ident(
+                                                            EFnParamBindingIdent {
                                                                 span: 12..13,
-                                                                name: "a",
+                                                                id: Ident {
+                                                                    span: 12..13,
+                                                                    name: "a",
+                                                                },
                                                             },
-                                                        },
+                                                        ),
                                                     ),
-                                                ),
-                                                Some(
-                                                    Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 15..16,
-                                                            id: Ident {
+                                                    Some(
+                                                        Ident(
+                                                            EFnParamBindingIdent {
                                                                 span: 15..16,
-                                                                name: "b",
+                                                                id: Ident {
+                                                                    span: 15..16,
+                                                                    name: "b",
+                                                                },
                                                             },
-                                                        },
+                                                        ),
                                                     ),
-                                                ),
-                                            ],
+                                                ],
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 22..23,
+                                    kind: Ident(
+                                        Ident {
+                                            span: 22..23,
+                                            name: "a",
                                         },
                                     ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
                                 },
-                            ],
-                            body: Ident(
-                                Ident {
-                                    span: 22..23,
-                                    name: "a",
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-7.snap
@@ -18,76 +18,81 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..41,
-                            params: [
-                                EFnParam {
-                                    pat: Array(
-                                        EFnParamArrayPat {
-                                            span: 11..17,
-                                            elems: [
-                                                Some(
-                                                    Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 12..13,
-                                                            id: Ident {
+                    Expr {
+                        span: 10..41,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Array(
+                                            EFnParamArrayPat {
+                                                span: 11..17,
+                                                elems: [
+                                                    Some(
+                                                        Ident(
+                                                            EFnParamBindingIdent {
                                                                 span: 12..13,
-                                                                name: "a",
+                                                                id: Ident {
+                                                                    span: 12..13,
+                                                                    name: "a",
+                                                                },
                                                             },
-                                                        },
+                                                        ),
                                                     ),
-                                                ),
-                                                Some(
-                                                    Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 15..16,
-                                                            id: Ident {
+                                                    Some(
+                                                        Ident(
+                                                            EFnParamBindingIdent {
                                                                 span: 15..16,
-                                                                name: "b",
+                                                                id: Ident {
+                                                                    span: 15..16,
+                                                                    name: "b",
+                                                                },
                                                             },
-                                                        },
-                                                    ),
-                                                ),
-                                            ],
-                                        },
-                                    ),
-                                    type_ann: Some(
-                                        Tuple(
-                                            TupleType {
-                                                span: 19..35,
-                                                types: [
-                                                    Prim(
-                                                        PrimType {
-                                                            span: 20..26,
-                                                            prim: Str,
-                                                        },
-                                                    ),
-                                                    Prim(
-                                                        PrimType {
-                                                            span: 28..34,
-                                                            prim: Num,
-                                                        },
+                                                        ),
                                                     ),
                                                 ],
                                             },
                                         ),
-                                    ),
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: Ident(
-                                Ident {
+                                        type_ann: Some(
+                                            Tuple(
+                                                TupleType {
+                                                    span: 19..35,
+                                                    types: [
+                                                        Prim(
+                                                            PrimType {
+                                                                span: 20..26,
+                                                                prim: Str,
+                                                            },
+                                                        ),
+                                                        Prim(
+                                                            PrimType {
+                                                                span: 28..34,
+                                                                prim: Num,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ),
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
                                     span: 40..41,
-                                    name: "a",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 40..41,
+                                            name: "a",
+                                        },
+                                    ),
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-8.snap
@@ -18,52 +18,57 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..23,
-                            params: [
-                                EFnParam {
-                                    pat: Object(
-                                        EFnParamObjectPat {
-                                            span: 11..17,
-                                            props: [
-                                                Assign(
-                                                    EFnParamAssignPatProp {
-                                                        key: Ident {
-                                                            span: 12..13,
-                                                            name: "a",
+                    Expr {
+                        span: 10..23,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Object(
+                                            EFnParamObjectPat {
+                                                span: 11..17,
+                                                props: [
+                                                    Assign(
+                                                        EFnParamAssignPatProp {
+                                                            key: Ident {
+                                                                span: 12..13,
+                                                                name: "a",
+                                                            },
+                                                            value: None,
                                                         },
-                                                        value: None,
-                                                    },
-                                                ),
-                                                Assign(
-                                                    EFnParamAssignPatProp {
-                                                        key: Ident {
-                                                            span: 15..16,
-                                                            name: "b",
+                                                    ),
+                                                    Assign(
+                                                        EFnParamAssignPatProp {
+                                                            key: Ident {
+                                                                span: 15..16,
+                                                                name: "b",
+                                                            },
+                                                            value: None,
                                                         },
-                                                        value: None,
-                                                    },
-                                                ),
-                                            ],
+                                                    ),
+                                                ],
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 22..23,
+                                    kind: Ident(
+                                        Ident {
+                                            span: 22..23,
+                                            name: "b",
                                         },
                                     ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
                                 },
-                            ],
-                            body: Ident(
-                                Ident {
-                                    span: 22..23,
-                                    name: "b",
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
@@ -18,88 +18,93 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..47,
-                            params: [
-                                EFnParam {
-                                    pat: Object(
-                                        EFnParamObjectPat {
-                                            span: 11..17,
-                                            props: [
-                                                Assign(
-                                                    EFnParamAssignPatProp {
-                                                        key: Ident {
-                                                            span: 12..13,
-                                                            name: "a",
-                                                        },
-                                                        value: None,
-                                                    },
-                                                ),
-                                                Assign(
-                                                    EFnParamAssignPatProp {
-                                                        key: Ident {
-                                                            span: 15..16,
-                                                            name: "b",
-                                                        },
-                                                        value: None,
-                                                    },
-                                                ),
-                                            ],
-                                        },
-                                    ),
-                                    type_ann: Some(
-                                        Object(
-                                            ObjectType {
-                                                span: 19..41,
-                                                elems: [
-                                                    Prop(
-                                                        TProp {
-                                                            span: 20..29,
-                                                            name: "a",
-                                                            optional: false,
-                                                            mutable: false,
-                                                            type_ann: Prim(
-                                                                PrimType {
-                                                                    span: 23..29,
-                                                                    prim: Str,
-                                                                },
-                                                            ),
+                    Expr {
+                        span: 10..47,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Object(
+                                            EFnParamObjectPat {
+                                                span: 11..17,
+                                                props: [
+                                                    Assign(
+                                                        EFnParamAssignPatProp {
+                                                            key: Ident {
+                                                                span: 12..13,
+                                                                name: "a",
+                                                            },
+                                                            value: None,
                                                         },
                                                     ),
-                                                    Prop(
-                                                        TProp {
-                                                            span: 31..40,
-                                                            name: "b",
-                                                            optional: false,
-                                                            mutable: false,
-                                                            type_ann: Prim(
-                                                                PrimType {
-                                                                    span: 34..40,
-                                                                    prim: Num,
-                                                                },
-                                                            ),
+                                                    Assign(
+                                                        EFnParamAssignPatProp {
+                                                            key: Ident {
+                                                                span: 15..16,
+                                                                name: "b",
+                                                            },
+                                                            value: None,
                                                         },
                                                     ),
                                                 ],
                                             },
                                         ),
-                                    ),
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: Ident(
-                                Ident {
+                                        type_ann: Some(
+                                            Object(
+                                                ObjectType {
+                                                    span: 19..41,
+                                                    elems: [
+                                                        Prop(
+                                                            TProp {
+                                                                span: 20..29,
+                                                                name: "a",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: Prim(
+                                                                    PrimType {
+                                                                        span: 23..29,
+                                                                        prim: Str,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                        Prop(
+                                                            TProp {
+                                                                span: 31..40,
+                                                                name: "b",
+                                                                optional: false,
+                                                                mutable: false,
+                                                                type_ann: Prim(
+                                                                    PrimType {
+                                                                        span: 34..40,
+                                                                        prim: Num,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ),
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
                                     span: 46..47,
-                                    name: "b",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 46..47,
+                                            name: "b",
+                                        },
+                                    ),
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
@@ -37,12 +37,15 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Ident(
-                        Ident {
-                            span: 13..18,
-                            name: "point",
-                        },
-                    ),
+                    Expr {
+                        span: 13..18,
+                        kind: Ident(
+                            Ident {
+                                span: 13..18,
+                                name: "point",
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-2.snap
@@ -7,37 +7,48 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: App(
-                    App {
-                        span: 0..9,
-                        lam: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..9,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..3,
-                                name: "foo",
-                            },
-                        ),
-                        args: [
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Ident(
+                                kind: Ident(
                                     Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
+                                ),
+                            },
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
                                         span: 4..5,
-                                        name: "a",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 4..5,
+                                                name: "a",
+                                            },
+                                        ),
                                     },
-                                ),
-                            },
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Ident(
-                                    Ident {
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
                                         span: 7..8,
-                                        name: "b",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 7..8,
+                                                name: "b",
+                                            },
+                                        ),
                                     },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-3.snap
@@ -7,41 +7,52 @@ Ok(
         body: [
             Expr {
                 span: 0..17,
-                expr: App(
-                    App {
-                        span: 0..16,
-                        lam: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..16,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..3,
-                                name: "foo",
-                            },
-                        ),
-                        args: [
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Lit(
-                                    Num(
-                                        Num {
-                                            span: 4..6,
-                                            value: "10",
-                                        },
-                                    ),
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
                                 ),
                             },
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Lit(
-                                    Str(
-                                        Str {
-                                            span: 8..15,
-                                            value: "hello",
-                                        },
-                                    ),
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 4..6,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 4..6,
+                                                    value: "10",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 8..15,
+                                        kind: Lit(
+                                            Str(
+                                                Str {
+                                                    span: 8..15,
+                                                    value: "hello",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-4.snap
@@ -7,60 +7,78 @@ Ok(
         body: [
             Expr {
                 span: 0..11,
-                expr: App(
-                    App {
-                        span: 0..10,
-                        lam: App(
-                            App {
+                expr: Expr {
+                    span: 0..10,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..4,
-                                lam: Ident(
-                                    Ident {
-                                        span: 0..1,
-                                        name: "f",
-                                    },
-                                ),
-                                args: [
-                                    ExprOrSpread {
-                                        spread: None,
-                                        expr: Ident(
-                                            Ident {
-                                                span: 2..3,
-                                                name: "x",
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                        ),
-                        args: [
-                            ExprOrSpread {
-                                spread: None,
-                                expr: App(
+                                kind: App(
                                     App {
-                                        span: 5..9,
-                                        lam: Ident(
-                                            Ident {
-                                                span: 5..6,
-                                                name: "g",
-                                            },
-                                        ),
+                                        lam: Expr {
+                                            span: 0..1,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..1,
+                                                    name: "f",
+                                                },
+                                            ),
+                                        },
                                         args: [
                                             ExprOrSpread {
                                                 spread: None,
-                                                expr: Ident(
-                                                    Ident {
-                                                        span: 7..8,
-                                                        name: "x",
-                                                    },
-                                                ),
+                                                expr: Expr {
+                                                    span: 2..3,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 2..3,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                },
                                             },
                                         ],
                                     },
                                 ),
                             },
-                        ],
-                    },
-                ),
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 5..9,
+                                        kind: App(
+                                            App {
+                                                lam: Expr {
+                                                    span: 5..6,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 5..6,
+                                                            name: "g",
+                                                        },
+                                                    ),
+                                                },
+                                                args: [
+                                                    ExprOrSpread {
+                                                        spread: None,
+                                                        expr: Expr {
+                                                            span: 7..8,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 7..8,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                    },
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-5.snap
@@ -7,39 +7,50 @@ Ok(
         body: [
             Expr {
                 span: 0..13,
-                expr: App(
-                    App {
-                        span: 0..12,
-                        lam: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..12,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..3,
-                                name: "foo",
-                            },
-                        ),
-                        args: [
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Ident(
+                                kind: Ident(
                                     Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
+                                ),
+                            },
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
                                         span: 4..5,
-                                        name: "a",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 4..5,
+                                                name: "a",
+                                            },
+                                        ),
                                     },
-                                ),
-                            },
-                            ExprOrSpread {
-                                spread: Some(
-                                    7..10,
-                                ),
-                                expr: Ident(
-                                    Ident {
+                                },
+                                ExprOrSpread {
+                                    spread: Some(
+                                        7..10,
+                                    ),
+                                    expr: Expr {
                                         span: 10..11,
-                                        name: "b",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 10..11,
+                                                name: "b",
+                                            },
+                                        ),
                                     },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application-6.snap
@@ -18,55 +18,38 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 17..48,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 18..19,
-                                            id: Ident {
+                    Expr {
+                        span: 17..48,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 18..19,
-                                                name: "f",
-                                            },
-                                        },
-                                    ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: Lambda(
-                                Lambda {
-                                    span: 24..48,
-                                    params: [
-                                        EFnParam {
-                                            pat: Ident(
-                                                EFnParamBindingIdent {
-                                                    span: 25..26,
-                                                    id: Ident {
-                                                        span: 25..26,
-                                                        name: "g",
-                                                    },
+                                                id: Ident {
+                                                    span: 18..19,
+                                                    name: "f",
                                                 },
-                                            ),
-                                            type_ann: None,
-                                            optional: false,
-                                            mutable: false,
-                                        },
-                                    ],
-                                    body: Lambda(
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 24..48,
+                                    kind: Lambda(
                                         Lambda {
-                                            span: 31..48,
                                             params: [
                                                 EFnParam {
                                                     pat: Ident(
                                                         EFnParamBindingIdent {
-                                                            span: 32..33,
+                                                            span: 25..26,
                                                             id: Ident {
-                                                                span: 32..33,
-                                                                name: "x",
+                                                                span: 25..26,
+                                                                name: "g",
                                                             },
                                                         },
                                                     ),
@@ -75,75 +58,116 @@ Ok(
                                                     mutable: false,
                                                 },
                                             ],
-                                            body: App(
-                                                App {
-                                                    span: 38..48,
-                                                    lam: App(
-                                                        App {
-                                                            span: 38..42,
-                                                            lam: Ident(
-                                                                Ident {
-                                                                    span: 38..39,
-                                                                    name: "f",
-                                                                },
-                                                            ),
-                                                            args: [
-                                                                ExprOrSpread {
-                                                                    spread: None,
-                                                                    expr: Ident(
-                                                                        Ident {
-                                                                            span: 40..41,
+                                            body: Expr {
+                                                span: 31..48,
+                                                kind: Lambda(
+                                                    Lambda {
+                                                        params: [
+                                                            EFnParam {
+                                                                pat: Ident(
+                                                                    EFnParamBindingIdent {
+                                                                        span: 32..33,
+                                                                        id: Ident {
+                                                                            span: 32..33,
                                                                             name: "x",
                                                                         },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                    args: [
-                                                        ExprOrSpread {
-                                                            spread: None,
-                                                            expr: App(
+                                                                    },
+                                                                ),
+                                                                type_ann: None,
+                                                                optional: false,
+                                                                mutable: false,
+                                                            },
+                                                        ],
+                                                        body: Expr {
+                                                            span: 38..48,
+                                                            kind: App(
                                                                 App {
-                                                                    span: 43..47,
-                                                                    lam: Ident(
-                                                                        Ident {
-                                                                            span: 43..44,
-                                                                            name: "g",
-                                                                        },
-                                                                    ),
+                                                                    lam: Expr {
+                                                                        span: 38..42,
+                                                                        kind: App(
+                                                                            App {
+                                                                                lam: Expr {
+                                                                                    span: 38..39,
+                                                                                    kind: Ident(
+                                                                                        Ident {
+                                                                                            span: 38..39,
+                                                                                            name: "f",
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                                args: [
+                                                                                    ExprOrSpread {
+                                                                                        spread: None,
+                                                                                        expr: Expr {
+                                                                                            span: 40..41,
+                                                                                            kind: Ident(
+                                                                                                Ident {
+                                                                                                    span: 40..41,
+                                                                                                    name: "x",
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ),
+                                                                    },
                                                                     args: [
                                                                         ExprOrSpread {
                                                                             spread: None,
-                                                                            expr: Ident(
-                                                                                Ident {
-                                                                                    span: 45..46,
-                                                                                    name: "x",
-                                                                                },
-                                                                            ),
+                                                                            expr: Expr {
+                                                                                span: 43..47,
+                                                                                kind: App(
+                                                                                    App {
+                                                                                        lam: Expr {
+                                                                                            span: 43..44,
+                                                                                            kind: Ident(
+                                                                                                Ident {
+                                                                                                    span: 43..44,
+                                                                                                    name: "g",
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                        args: [
+                                                                                            ExprOrSpread {
+                                                                                                spread: None,
+                                                                                                expr: Expr {
+                                                                                                    span: 45..46,
+                                                                                                    kind: Ident(
+                                                                                                        Ident {
+                                                                                                            span: 45..46,
+                                                                                                            name: "x",
+                                                                                                        },
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                ),
+                                                                            },
                                                                         },
                                                                     ],
                                                                 },
                                                             ),
                                                         },
-                                                    ],
-                                                },
-                                            ),
+                                                        is_async: false,
+                                                        return_type: None,
+                                                        type_params: None,
+                                                    },
+                                                ),
+                                            },
                                             is_async: false,
                                             return_type: None,
                                             type_params: None,
                                         },
                                     ),
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },
@@ -160,60 +184,67 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 66..81,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 67..68,
-                                            id: Ident {
+                    Expr {
+                        span: 66..81,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 67..68,
-                                                name: "x",
-                                            },
-                                        },
-                                    ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: Lambda(
-                                Lambda {
-                                    span: 73..81,
-                                    params: [
-                                        EFnParam {
-                                            pat: Ident(
-                                                EFnParamBindingIdent {
-                                                    span: 74..75,
-                                                    id: Ident {
-                                                        span: 74..75,
-                                                        name: "y",
-                                                    },
+                                                id: Ident {
+                                                    span: 67..68,
+                                                    name: "x",
                                                 },
-                                            ),
-                                            type_ann: None,
-                                            optional: false,
-                                            mutable: false,
-                                        },
-                                    ],
-                                    body: Ident(
-                                        Ident {
-                                            span: 80..81,
-                                            name: "x",
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 73..81,
+                                    kind: Lambda(
+                                        Lambda {
+                                            params: [
+                                                EFnParam {
+                                                    pat: Ident(
+                                                        EFnParamBindingIdent {
+                                                            span: 74..75,
+                                                            id: Ident {
+                                                                span: 74..75,
+                                                                name: "y",
+                                                            },
+                                                        },
+                                                    ),
+                                                    type_ann: None,
+                                                    optional: false,
+                                                    mutable: false,
+                                                },
+                                            ],
+                                            body: Expr {
+                                                span: 80..81,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 80..81,
+                                                        name: "x",
+                                                    },
+                                                ),
+                                            },
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
                                         },
                                     ),
-                                    is_async: false,
-                                    return_type: None,
-                                    type_params: None,
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },
@@ -230,44 +261,57 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    App(
-                        App {
-                            span: 99..106,
-                            lam: App(
-                                App {
+                    Expr {
+                        span: 99..106,
+                        kind: App(
+                            App {
+                                lam: Expr {
                                     span: 99..103,
-                                    lam: Ident(
-                                        Ident {
-                                            span: 99..100,
-                                            name: "S",
+                                    kind: App(
+                                        App {
+                                            lam: Expr {
+                                                span: 99..100,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 99..100,
+                                                        name: "S",
+                                                    },
+                                                ),
+                                            },
+                                            args: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Expr {
+                                                        span: 101..102,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 101..102,
+                                                                name: "K",
+                                                            },
+                                                        ),
+                                                    },
+                                                },
+                                            ],
                                         },
                                     ),
-                                    args: [
-                                        ExprOrSpread {
-                                            spread: None,
-                                            expr: Ident(
+                                },
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 104..105,
+                                            kind: Ident(
                                                 Ident {
-                                                    span: 101..102,
+                                                    span: 104..105,
                                                     name: "K",
                                                 },
                                             ),
                                         },
-                                    ],
-                                },
-                            ),
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Ident(
-                                        Ident {
-                                            span: 104..105,
-                                            name: "K",
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_application.snap
@@ -7,18 +7,23 @@ Ok(
         body: [
             Expr {
                 span: 0..6,
-                expr: App(
-                    App {
-                        span: 0..5,
-                        lam: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..5,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..3,
-                                name: "foo",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
+                                ),
                             },
-                        ),
-                        args: [],
-                    },
-                ),
+                            args: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-2.snap
@@ -7,23 +7,28 @@ Ok(
         body: [
             Expr {
                 span: 0..9,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..8,
-                        params: [],
-                        body: Lit(
-                            Num(
-                                Num {
-                                    span: 6..8,
-                                    value: "10",
-                                },
-                            ),
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                expr: Expr {
+                    span: 0..8,
+                    kind: Lambda(
+                        Lambda {
+                            params: [],
+                            body: Expr {
+                                span: 6..8,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            span: 6..8,
+                                            value: "10",
+                                        },
+                                    ),
+                                ),
+                            },
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-3.snap
@@ -7,38 +7,43 @@ Ok(
         body: [
             Expr {
                 span: 0..15,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..14,
-                        params: [
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 1..2,
-                                        id: Ident {
+                expr: Expr {
+                    span: 0..14,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 1..2,
-                                            name: "a",
+                                            id: Ident {
+                                                span: 1..2,
+                                                name: "a",
+                                            },
                                         },
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                        ],
-                        body: Lit(
-                            Str(
-                                Str {
-                                    span: 7..14,
-                                    value: "hello",
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
                                 },
-                            ),
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                            ],
+                            body: Expr {
+                                span: 7..14,
+                                kind: Lit(
+                                    Str(
+                                        Str {
+                                            span: 7..14,
+                                            value: "hello",
+                                        },
+                                    ),
+                                ),
+                            },
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-4.snap
@@ -7,57 +7,62 @@ Ok(
         body: [
             Expr {
                 span: 0..18,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..17,
-                        params: [
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 1..2,
-                                        id: Ident {
+                expr: Expr {
+                    span: 0..17,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 1..2,
-                                            name: "a",
-                                        },
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                            EFnParam {
-                                pat: Rest(
-                                    EFnParamRestPat {
-                                        span: 4..8,
-                                        arg: Ident(
-                                            EFnParamBindingIdent {
-                                                span: 7..8,
-                                                id: Ident {
-                                                    span: 7..8,
-                                                    name: "b",
-                                                },
+                                            id: Ident {
+                                                span: 1..2,
+                                                name: "a",
                                             },
-                                        ),
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                        ],
-                        body: Lit(
-                            Bool(
-                                Bool {
-                                    span: 13..17,
-                                    value: true,
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
                                 },
-                            ),
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                                EFnParam {
+                                    pat: Rest(
+                                        EFnParamRestPat {
+                                            span: 4..8,
+                                            arg: Ident(
+                                                EFnParamBindingIdent {
+                                                    span: 7..8,
+                                                    id: Ident {
+                                                        span: 7..8,
+                                                        name: "b",
+                                                    },
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Expr {
+                                span: 13..17,
+                                kind: Lit(
+                                    Bool(
+                                        Bool {
+                                            span: 13..17,
+                                            value: true,
+                                        },
+                                    ),
+                                ),
+                            },
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
@@ -7,64 +7,74 @@ Ok(
         body: [
             Expr {
                 span: 0..18,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..17,
-                        params: [
-                            EFnParam {
-                                pat: Object(
-                                    EFnParamObjectPat {
-                                        span: 1..7,
-                                        props: [
-                                            Assign(
-                                                EFnParamAssignPatProp {
-                                                    key: Ident {
-                                                        span: 2..3,
-                                                        name: "x",
+                expr: Expr {
+                    span: 0..17,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Object(
+                                        EFnParamObjectPat {
+                                            span: 1..7,
+                                            props: [
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 2..3,
+                                                            name: "x",
+                                                        },
+                                                        value: None,
                                                     },
-                                                    value: None,
-                                                },
-                                            ),
-                                            Assign(
-                                                EFnParamAssignPatProp {
-                                                    key: Ident {
-                                                        span: 5..6,
-                                                        name: "y",
+                                                ),
+                                                Assign(
+                                                    EFnParamAssignPatProp {
+                                                        key: Ident {
+                                                            span: 5..6,
+                                                            name: "y",
+                                                        },
+                                                        value: None,
                                                     },
-                                                    value: None,
-                                                },
-                                            ),
-                                        ],
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                        ],
-                        body: BinaryExpr(
-                            BinaryExpr {
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Expr {
                                 span: 12..17,
-                                op: Add,
-                                left: Ident(
-                                    Ident {
-                                        span: 12..13,
-                                        name: "x",
-                                    },
-                                ),
-                                right: Ident(
-                                    Ident {
-                                        span: 16..17,
-                                        name: "y",
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Add,
+                                        left: Expr {
+                                            span: 12..13,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 12..13,
+                                                    name: "x",
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 16..17,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 16..17,
+                                                    name: "y",
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-6.snap
@@ -7,80 +7,90 @@ Ok(
         body: [
             Expr {
                 span: 0..24,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..23,
-                        params: [
-                            EFnParam {
-                                pat: Object(
-                                    EFnParamObjectPat {
-                                        span: 1..13,
-                                        props: [
-                                            KeyValue(
-                                                EFnParamKeyValuePatProp {
-                                                    key: Ident {
-                                                        span: 2..3,
-                                                        name: "x",
-                                                    },
-                                                    value: Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 5..6,
-                                                            id: Ident {
+                expr: Expr {
+                    span: 0..23,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Object(
+                                        EFnParamObjectPat {
+                                            span: 1..13,
+                                            props: [
+                                                KeyValue(
+                                                    EFnParamKeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 2..3,
+                                                            name: "x",
+                                                        },
+                                                        value: Ident(
+                                                            EFnParamBindingIdent {
                                                                 span: 5..6,
-                                                                name: "p",
+                                                                id: Ident {
+                                                                    span: 5..6,
+                                                                    name: "p",
+                                                                },
                                                             },
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            KeyValue(
-                                                EFnParamKeyValuePatProp {
-                                                    key: Ident {
-                                                        span: 8..9,
-                                                        name: "y",
+                                                        ),
                                                     },
-                                                    value: Ident(
-                                                        EFnParamBindingIdent {
-                                                            span: 11..12,
-                                                            id: Ident {
-                                                                span: 11..12,
-                                                                name: "q",
-                                                            },
+                                                ),
+                                                KeyValue(
+                                                    EFnParamKeyValuePatProp {
+                                                        key: Ident {
+                                                            span: 8..9,
+                                                            name: "y",
                                                         },
-                                                    ),
+                                                        value: Ident(
+                                                            EFnParamBindingIdent {
+                                                                span: 11..12,
+                                                                id: Ident {
+                                                                    span: 11..12,
+                                                                    name: "q",
+                                                                },
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Expr {
+                                span: 18..23,
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Add,
+                                        left: Expr {
+                                            span: 18..19,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 18..19,
+                                                    name: "p",
                                                 },
                                             ),
-                                        ],
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                        ],
-                        body: BinaryExpr(
-                            BinaryExpr {
-                                span: 18..23,
-                                op: Add,
-                                left: Ident(
-                                    Ident {
-                                        span: 18..19,
-                                        name: "p",
-                                    },
-                                ),
-                                right: Ident(
-                                    Ident {
-                                        span: 22..23,
-                                        name: "q",
+                                        },
+                                        right: Expr {
+                                            span: 22..23,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 22..23,
+                                                    name: "q",
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-7.snap
@@ -7,57 +7,62 @@ Ok(
         body: [
             Expr {
                 span: 0..23,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..22,
-                        params: [
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 1..2,
-                                        id: Ident {
+                expr: Expr {
+                    span: 0..22,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 1..2,
-                                            name: "a",
-                                        },
-                                    },
-                                ),
-                                type_ann: Some(
-                                    Prim(
-                                        PrimType {
-                                            span: 5..12,
-                                            prim: Bool,
+                                            id: Ident {
+                                                span: 1..2,
+                                                name: "a",
+                                            },
                                         },
                                     ),
-                                ),
-                                optional: true,
-                                mutable: false,
-                            },
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 14..15,
-                                        id: Ident {
+                                    type_ann: Some(
+                                        Prim(
+                                            PrimType {
+                                                span: 5..12,
+                                                prim: Bool,
+                                            },
+                                        ),
+                                    ),
+                                    optional: true,
+                                    mutable: false,
+                                },
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 14..15,
-                                            name: "b",
+                                            id: Ident {
+                                                span: 14..15,
+                                                name: "b",
+                                            },
                                         },
+                                    ),
+                                    type_ann: None,
+                                    optional: true,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Expr {
+                                span: 21..22,
+                                kind: Ident(
+                                    Ident {
+                                        span: 21..22,
+                                        name: "c",
                                     },
                                 ),
-                                type_ann: None,
-                                optional: true,
-                                mutable: false,
                             },
-                        ],
-                        body: Ident(
-                            Ident {
-                                span: 21..22,
-                                name: "c",
-                            },
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition.snap
@@ -7,50 +7,55 @@ Ok(
         body: [
             Expr {
                 span: 0..12,
-                expr: Lambda(
-                    Lambda {
-                        span: 0..11,
-                        params: [
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 1..2,
-                                        id: Ident {
+                expr: Expr {
+                    span: 0..11,
+                    kind: Lambda(
+                        Lambda {
+                            params: [
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 1..2,
-                                            name: "a",
+                                            id: Ident {
+                                                span: 1..2,
+                                                name: "a",
+                                            },
                                         },
-                                    },
-                                ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
-                            },
-                            EFnParam {
-                                pat: Ident(
-                                    EFnParamBindingIdent {
-                                        span: 4..5,
-                                        id: Ident {
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                                EFnParam {
+                                    pat: Ident(
+                                        EFnParamBindingIdent {
                                             span: 4..5,
-                                            name: "b",
+                                            id: Ident {
+                                                span: 4..5,
+                                                name: "b",
+                                            },
                                         },
+                                    ),
+                                    type_ann: None,
+                                    optional: false,
+                                    mutable: false,
+                                },
+                            ],
+                            body: Expr {
+                                span: 10..11,
+                                kind: Ident(
+                                    Ident {
+                                        span: 10..11,
+                                        name: "c",
                                     },
                                 ),
-                                type_ann: None,
-                                optional: false,
-                                mutable: false,
                             },
-                        ],
-                        body: Ident(
-                            Ident {
-                                span: 10..11,
-                                name: "c",
-                            },
-                        ),
-                        is_async: false,
-                        return_type: None,
-                        type_params: None,
-                    },
-                ),
+                            is_async: false,
+                            return_type: None,
+                            type_params: None,
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_else-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_else-2.snap
@@ -7,56 +7,75 @@ Ok(
         body: [
             Expr {
                 span: 0..44,
-                expr: IfElse(
-                    IfElse {
-                        span: 0..43,
-                        cond: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..43,
+                    kind: IfElse(
+                        IfElse {
+                            cond: Expr {
                                 span: 4..5,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        consequent: Lit(
-                            Num(
-                                Num {
-                                    span: 9..10,
-                                    value: "5",
-                                },
-                            ),
-                        ),
-                        alternate: Some(
-                            IfElse(
-                                IfElse {
-                                    span: 18..43,
-                                    cond: Ident(
-                                        Ident {
-                                            span: 22..23,
-                                            name: "b",
+                            consequent: Expr {
+                                span: 9..10,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            span: 9..10,
+                                            value: "5",
                                         },
                                     ),
-                                    consequent: Lit(
-                                        Num(
-                                            Num {
-                                                span: 27..29,
-                                                value: "10",
+                                ),
+                            },
+                            alternate: Some(
+                                Expr {
+                                    span: 18..43,
+                                    kind: IfElse(
+                                        IfElse {
+                                            cond: Expr {
+                                                span: 22..23,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 22..23,
+                                                        name: "b",
+                                                    },
+                                                ),
                                             },
-                                        ),
-                                    ),
-                                    alternate: Some(
-                                        Lit(
-                                            Num(
-                                                Num {
+                                            consequent: Expr {
+                                                span: 27..29,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 27..29,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                            alternate: Some(
+                                                Expr {
                                                     span: 39..41,
-                                                    value: "20",
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 39..41,
+                                                                value: "20",
+                                                            },
+                                                        ),
+                                                    ),
                                                 },
                                             ),
-                                        ),
+                                        },
                                     ),
                                 },
                             ),
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_else.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_else.snap
@@ -7,37 +7,48 @@ Ok(
         body: [
             Expr {
                 span: 0..28,
-                expr: IfElse(
-                    IfElse {
-                        span: 0..27,
-                        cond: Lit(
-                            Bool(
-                                Bool {
-                                    span: 4..8,
-                                    value: true,
-                                },
-                            ),
-                        ),
-                        consequent: Lit(
-                            Num(
-                                Num {
-                                    span: 12..13,
-                                    value: "5",
-                                },
-                            ),
-                        ),
-                        alternate: Some(
-                            Lit(
-                                Num(
-                                    Num {
-                                        span: 23..25,
-                                        value: "10",
-                                    },
+                expr: Expr {
+                    span: 0..27,
+                    kind: IfElse(
+                        IfElse {
+                            cond: Expr {
+                                span: 4..8,
+                                kind: Lit(
+                                    Bool(
+                                        Bool {
+                                            span: 4..8,
+                                            value: true,
+                                        },
+                                    ),
                                 ),
+                            },
+                            consequent: Expr {
+                                span: 12..13,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            span: 12..13,
+                                            value: "5",
+                                        },
+                                    ),
+                                ),
+                            },
+                            alternate: Some(
+                                Expr {
+                                    span: 23..25,
+                                    kind: Lit(
+                                        Num(
+                                            Num {
+                                                span: 23..25,
+                                                value: "10",
+                                            },
+                                        ),
+                                    ),
+                                },
                             ),
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
@@ -18,141 +18,164 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    IfElse(
-                        IfElse {
-                            span: 23..225,
-                            cond: LetExpr(
-                                LetExpr {
+                    Expr {
+                        span: 23..225,
+                        kind: IfElse(
+                            IfElse {
+                                cond: Expr {
                                     span: 27..53,
-                                    pat: Object(
-                                        ObjectPat {
-                                            span: 31..47,
-                                            props: [
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 32..33,
-                                                            name: "x",
-                                                        },
-                                                        value: Is(
-                                                            IsPat {
-                                                                span: 35..46,
-                                                                id: Ident {
-                                                                    span: 35..36,
+                                    kind: LetExpr(
+                                        LetExpr {
+                                            pat: Object(
+                                                ObjectPat {
+                                                    span: 31..47,
+                                                    props: [
+                                                        KeyValue(
+                                                            KeyValuePatProp {
+                                                                key: Ident {
+                                                                    span: 32..33,
                                                                     name: "x",
                                                                 },
-                                                                is_id: Ident {
-                                                                    span: 40..46,
-                                                                    name: "string",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            optional: false,
-                                        },
-                                    ),
-                                    expr: Ident(
-                                        Ident {
-                                            span: 50..53,
-                                            name: "foo",
-                                        },
-                                    ),
-                                },
-                            ),
-                            consequent: Lit(
-                                Str(
-                                    Str {
-                                        span: 73..81,
-                                        value: "object",
-                                    },
-                                ),
-                            ),
-                            alternate: Some(
-                                IfElse(
-                                    IfElse {
-                                        span: 101..225,
-                                        cond: LetExpr(
-                                            LetExpr {
-                                                span: 105..139,
-                                                pat: Array(
-                                                    ArrayPat {
-                                                        span: 109..133,
-                                                        elems: [
-                                                            Some(
-                                                                Is(
+                                                                value: Is(
                                                                     IsPat {
-                                                                        span: 110..120,
+                                                                        span: 35..46,
                                                                         id: Ident {
-                                                                            span: 110..111,
-                                                                            name: "a",
+                                                                            span: 35..36,
+                                                                            name: "x",
                                                                         },
                                                                         is_id: Ident {
-                                                                            span: 115..120,
-                                                                            name: "Array",
+                                                                            span: 40..46,
+                                                                            name: "string",
                                                                         },
                                                                     },
                                                                 ),
-                                                            ),
-                                                            Some(
-                                                                Wildcard(
-                                                                    WildcardPat {
-                                                                        span: 122..123,
-                                                                    },
-                                                                ),
-                                                            ),
-                                                            Some(
-                                                                Rest(
-                                                                    RestPat {
-                                                                        span: 125..132,
-                                                                        arg: Ident(
-                                                                            BindingIdent {
-                                                                                span: 128..132,
-                                                                                id: Ident {
-                                                                                    span: 128..132,
-                                                                                    name: "rest",
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        ],
-                                                        optional: false,
-                                                    },
-                                                ),
-                                                expr: Ident(
+                                                            },
+                                                        ),
+                                                    ],
+                                                    optional: false,
+                                                },
+                                            ),
+                                            expr: Expr {
+                                                span: 50..53,
+                                                kind: Ident(
                                                     Ident {
-                                                        span: 136..139,
+                                                        span: 50..53,
                                                         name: "foo",
                                                     },
                                                 ),
                                             },
+                                        },
+                                    ),
+                                },
+                                consequent: Expr {
+                                    span: 73..81,
+                                    kind: Lit(
+                                        Str(
+                                            Str {
+                                                span: 73..81,
+                                                value: "object",
+                                            },
                                         ),
-                                        consequent: Lit(
-                                            Str(
-                                                Str {
-                                                    span: 159..166,
-                                                    value: "array",
+                                    ),
+                                },
+                                alternate: Some(
+                                    Expr {
+                                        span: 101..225,
+                                        kind: IfElse(
+                                            IfElse {
+                                                cond: Expr {
+                                                    span: 105..139,
+                                                    kind: LetExpr(
+                                                        LetExpr {
+                                                            pat: Array(
+                                                                ArrayPat {
+                                                                    span: 109..133,
+                                                                    elems: [
+                                                                        Some(
+                                                                            Is(
+                                                                                IsPat {
+                                                                                    span: 110..120,
+                                                                                    id: Ident {
+                                                                                        span: 110..111,
+                                                                                        name: "a",
+                                                                                    },
+                                                                                    is_id: Ident {
+                                                                                        span: 115..120,
+                                                                                        name: "Array",
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        Some(
+                                                                            Wildcard(
+                                                                                WildcardPat {
+                                                                                    span: 122..123,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        Some(
+                                                                            Rest(
+                                                                                RestPat {
+                                                                                    span: 125..132,
+                                                                                    arg: Ident(
+                                                                                        BindingIdent {
+                                                                                            span: 128..132,
+                                                                                            id: Ident {
+                                                                                                span: 128..132,
+                                                                                                name: "rest",
+                                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    ],
+                                                                    optional: false,
+                                                                },
+                                                            ),
+                                                            expr: Expr {
+                                                                span: 136..139,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 136..139,
+                                                                        name: "foo",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
                                                 },
-                                            ),
-                                        ),
-                                        alternate: Some(
-                                            Lit(
-                                                Str(
-                                                    Str {
+                                                consequent: Expr {
+                                                    span: 159..166,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                span: 159..166,
+                                                                value: "array",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                                alternate: Some(
+                                                    Expr {
                                                         span: 204..211,
-                                                        value: "other",
+                                                        kind: Lit(
+                                                            Str(
+                                                                Str {
+                                                                    span: 204..211,
+                                                                    value: "other",
+                                                                },
+                                                            ),
+                                                        ),
                                                     },
                                                 ),
-                                            ),
+                                            },
                                         ),
                                     },
                                 ),
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
@@ -18,157 +18,180 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    IfElse(
-                        IfElse {
-                            span: 23..218,
-                            cond: LetExpr(
-                                LetExpr {
+                    Expr {
+                        span: 23..218,
+                        kind: IfElse(
+                            IfElse {
+                                cond: Expr {
                                     span: 27..55,
-                                    pat: Object(
-                                        ObjectPat {
-                                            span: 31..49,
-                                            props: [
-                                                Assign(
-                                                    AssignPatProp {
-                                                        span: 32..33,
-                                                        key: Ident {
-                                                            span: 32..33,
-                                                            name: "x",
-                                                        },
-                                                        value: None,
-                                                    },
-                                                ),
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 35..36,
-                                                            name: "y",
-                                                        },
-                                                        value: Ident(
-                                                            BindingIdent {
-                                                                span: 38..39,
-                                                                id: Ident {
-                                                                    span: 38..39,
-                                                                    name: "b",
+                                    kind: LetExpr(
+                                        LetExpr {
+                                            pat: Object(
+                                                ObjectPat {
+                                                    span: 31..49,
+                                                    props: [
+                                                        Assign(
+                                                            AssignPatProp {
+                                                                span: 32..33,
+                                                                key: Ident {
+                                                                    span: 32..33,
+                                                                    name: "x",
                                                                 },
+                                                                value: None,
                                                             },
                                                         ),
-                                                    },
-                                                ),
-                                                Rest(
-                                                    RestPat {
-                                                        span: 41..48,
-                                                        arg: Ident(
-                                                            BindingIdent {
-                                                                span: 44..48,
-                                                                id: Ident {
-                                                                    span: 44..48,
-                                                                    name: "rest",
+                                                        KeyValue(
+                                                            KeyValuePatProp {
+                                                                key: Ident {
+                                                                    span: 35..36,
+                                                                    name: "y",
                                                                 },
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            optional: false,
-                                        },
-                                    ),
-                                    expr: Ident(
-                                        Ident {
-                                            span: 52..55,
-                                            name: "foo",
-                                        },
-                                    ),
-                                },
-                            ),
-                            consequent: Lit(
-                                Str(
-                                    Str {
-                                        span: 75..83,
-                                        value: "object",
-                                    },
-                                ),
-                            ),
-                            alternate: Some(
-                                IfElse(
-                                    IfElse {
-                                        span: 103..218,
-                                        cond: LetExpr(
-                                            LetExpr {
-                                                span: 107..132,
-                                                pat: Array(
-                                                    ArrayPat {
-                                                        span: 111..126,
-                                                        elems: [
-                                                            Some(
-                                                                Ident(
+                                                                value: Ident(
                                                                     BindingIdent {
-                                                                        span: 112..113,
+                                                                        span: 38..39,
                                                                         id: Ident {
-                                                                            span: 112..113,
-                                                                            name: "a",
+                                                                            span: 38..39,
+                                                                            name: "b",
                                                                         },
                                                                     },
                                                                 ),
-                                                            ),
-                                                            Some(
-                                                                Wildcard(
-                                                                    WildcardPat {
-                                                                        span: 115..116,
+                                                            },
+                                                        ),
+                                                        Rest(
+                                                            RestPat {
+                                                                span: 41..48,
+                                                                arg: Ident(
+                                                                    BindingIdent {
+                                                                        span: 44..48,
+                                                                        id: Ident {
+                                                                            span: 44..48,
+                                                                            name: "rest",
+                                                                        },
                                                                     },
                                                                 ),
-                                                            ),
-                                                            Some(
-                                                                Rest(
-                                                                    RestPat {
-                                                                        span: 118..125,
-                                                                        arg: Ident(
-                                                                            BindingIdent {
-                                                                                span: 121..125,
-                                                                                id: Ident {
-                                                                                    span: 121..125,
-                                                                                    name: "rest",
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ),
-                                                        ],
-                                                        optional: false,
-                                                    },
-                                                ),
-                                                expr: Ident(
+                                                            },
+                                                        ),
+                                                    ],
+                                                    optional: false,
+                                                },
+                                            ),
+                                            expr: Expr {
+                                                span: 52..55,
+                                                kind: Ident(
                                                     Ident {
-                                                        span: 129..132,
+                                                        span: 52..55,
                                                         name: "foo",
                                                     },
                                                 ),
                                             },
+                                        },
+                                    ),
+                                },
+                                consequent: Expr {
+                                    span: 75..83,
+                                    kind: Lit(
+                                        Str(
+                                            Str {
+                                                span: 75..83,
+                                                value: "object",
+                                            },
                                         ),
-                                        consequent: Lit(
-                                            Str(
-                                                Str {
-                                                    span: 152..159,
-                                                    value: "array",
+                                    ),
+                                },
+                                alternate: Some(
+                                    Expr {
+                                        span: 103..218,
+                                        kind: IfElse(
+                                            IfElse {
+                                                cond: Expr {
+                                                    span: 107..132,
+                                                    kind: LetExpr(
+                                                        LetExpr {
+                                                            pat: Array(
+                                                                ArrayPat {
+                                                                    span: 111..126,
+                                                                    elems: [
+                                                                        Some(
+                                                                            Ident(
+                                                                                BindingIdent {
+                                                                                    span: 112..113,
+                                                                                    id: Ident {
+                                                                                        span: 112..113,
+                                                                                        name: "a",
+                                                                                    },
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        Some(
+                                                                            Wildcard(
+                                                                                WildcardPat {
+                                                                                    span: 115..116,
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                        Some(
+                                                                            Rest(
+                                                                                RestPat {
+                                                                                    span: 118..125,
+                                                                                    arg: Ident(
+                                                                                        BindingIdent {
+                                                                                            span: 121..125,
+                                                                                            id: Ident {
+                                                                                                span: 121..125,
+                                                                                                name: "rest",
+                                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    ],
+                                                                    optional: false,
+                                                                },
+                                                            ),
+                                                            expr: Expr {
+                                                                span: 129..132,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 129..132,
+                                                                        name: "foo",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
                                                 },
-                                            ),
-                                        ),
-                                        alternate: Some(
-                                            Lit(
-                                                Str(
-                                                    Str {
+                                                consequent: Expr {
+                                                    span: 152..159,
+                                                    kind: Lit(
+                                                        Str(
+                                                            Str {
+                                                                span: 152..159,
+                                                                value: "array",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                                alternate: Some(
+                                                    Expr {
                                                         span: 197..204,
-                                                        value: "other",
+                                                        kind: Lit(
+                                                            Str(
+                                                                Str {
+                                                                    span: 197..204,
+                                                                    value: "other",
+                                                                },
+                                                            ),
+                                                        ),
                                                     },
                                                 ),
-                                            ),
+                                            },
                                         ),
                                     },
                                 ),
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__it_works.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__it_works.snap
@@ -18,62 +18,72 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 19..34,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 20..21,
-                                            id: Ident {
+                    Expr {
+                        span: 19..34,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 20..21,
-                                                name: "a",
+                                                id: Ident {
+                                                    span: 20..21,
+                                                    name: "a",
+                                                },
                                             },
-                                        },
-                                    ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
-                                },
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 23..24,
-                                            id: Ident {
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 23..24,
-                                                name: "b",
+                                                id: Ident {
+                                                    span: 23..24,
+                                                    name: "b",
+                                                },
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 29..34,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                span: 29..30,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 29..30,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                            },
+                                            right: Expr {
+                                                span: 33..34,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 33..34,
+                                                        name: "b",
+                                                    },
+                                                ),
                                             },
                                         },
                                     ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
                                 },
-                            ],
-                            body: BinaryExpr(
-                                BinaryExpr {
-                                    span: 29..34,
-                                    op: Add,
-                                    left: Ident(
-                                        Ident {
-                                            span: 29..30,
-                                            name: "a",
-                                        },
-                                    ),
-                                    right: Ident(
-                                        Ident {
-                                            span: 33..34,
-                                            name: "b",
-                                        },
-                                    ),
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },
@@ -90,62 +100,72 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 54..69,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 55..56,
-                                            id: Ident {
+                    Expr {
+                        span: 54..69,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 55..56,
-                                                name: "a",
+                                                id: Ident {
+                                                    span: 55..56,
+                                                    name: "a",
+                                                },
                                             },
-                                        },
-                                    ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
-                                },
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 58..59,
-                                            id: Ident {
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 58..59,
-                                                name: "b",
+                                                id: Ident {
+                                                    span: 58..59,
+                                                    name: "b",
+                                                },
+                                            },
+                                        ),
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 64..69,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Sub,
+                                            left: Expr {
+                                                span: 64..65,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 64..65,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                            },
+                                            right: Expr {
+                                                span: 68..69,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 68..69,
+                                                        name: "b",
+                                                    },
+                                                ),
                                             },
                                         },
                                     ),
-                                    type_ann: None,
-                                    optional: false,
-                                    mutable: false,
                                 },
-                            ],
-                            body: BinaryExpr(
-                                BinaryExpr {
-                                    span: 64..69,
-                                    op: Sub,
-                                    left: Ident(
-                                        Ident {
-                                            span: 64..65,
-                                            name: "a",
-                                        },
-                                    ),
-                                    right: Ident(
-                                        Ident {
-                                            span: 68..69,
-                                            name: "b",
-                                        },
-                                    ),
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },
@@ -162,41 +182,52 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    App(
-                        App {
-                            span: 89..99,
-                            lam: Ident(
-                                Ident {
+                    Expr {
+                        span: 89..99,
+                        kind: App(
+                            App {
+                                lam: Expr {
                                     span: 89..92,
-                                    name: "add",
-                                },
-                            ),
-                            args: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 93..94,
-                                                value: "5",
-                                            },
-                                        ),
+                                    kind: Ident(
+                                        Ident {
+                                            span: 89..92,
+                                            name: "add",
+                                        },
                                     ),
                                 },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 96..98,
-                                                value: "10",
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                args: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 93..94,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 93..94,
+                                                        value: "5",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 96..98,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 96..98,
+                                                        value: "10",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-10.snap
@@ -18,66 +18,75 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    JSXElement(
-                        JSXElement {
-                            span: 11..59,
-                            name: "div",
-                            attrs: [
-                                JSXAttr {
-                                    span: 16..29,
-                                    ident: Ident {
-                                        span: 16..21,
-                                        name: "point",
-                                    },
-                                    value: JSXExprContainer(
-                                        JSXExprContainer {
-                                            span: 22..29,
-                                            expr: Ident(
-                                                Ident {
+                    Expr {
+                        span: 11..59,
+                        kind: JSXElement(
+                            JSXElement {
+                                span: 11..59,
+                                name: "div",
+                                attrs: [
+                                    JSXAttr {
+                                        span: 16..29,
+                                        ident: Ident {
+                                            span: 16..21,
+                                            name: "point",
+                                        },
+                                        value: JSXExprContainer(
+                                            JSXExprContainer {
+                                                span: 22..29,
+                                                expr: Expr {
                                                     span: 23..28,
-                                                    name: "point",
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 23..28,
+                                                            name: "point",
+                                                        },
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                    JSXAttr {
+                                        span: 30..40,
+                                        ident: Ident {
+                                            span: 30..32,
+                                            name: "id",
+                                        },
+                                        value: Lit(
+                                            Str(
+                                                Str {
+                                                    span: 33..40,
+                                                    value: "point",
                                                 },
                                             ),
+                                        ),
+                                    },
+                                ],
+                                children: [
+                                    JSXText(
+                                        JSXText {
+                                            span: 41..48,
+                                            value: "Hello, ",
                                         },
                                     ),
-                                },
-                                JSXAttr {
-                                    span: 30..40,
-                                    ident: Ident {
-                                        span: 30..32,
-                                        name: "id",
-                                    },
-                                    value: Lit(
-                                        Str(
-                                            Str {
-                                                span: 33..40,
-                                                value: "point",
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ],
-                            children: [
-                                JSXText(
-                                    JSXText {
-                                        span: 41..48,
-                                        value: "Hello, ",
-                                    },
-                                ),
-                                JSXExprContainer(
-                                    JSXExprContainer {
-                                        span: 48..53,
-                                        expr: Ident(
-                                            Ident {
+                                    JSXExprContainer(
+                                        JSXExprContainer {
+                                            span: 48..53,
+                                            expr: Expr {
                                                 span: 49..52,
-                                                name: "msg",
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 49..52,
+                                                        name: "msg",
+                                                    },
+                                                ),
                                             },
-                                        ),
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-2.snap
@@ -7,26 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..16,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..16,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXExprContainer(
-                                JSXExprContainer {
-                                    span: 5..10,
-                                    expr: Ident(
-                                        Ident {
+                expr: Expr {
+                    span: 0..16,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..16,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 5..10,
+                                        expr: Expr {
                                             span: 6..9,
-                                            name: "bar",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 6..9,
+                                                    name: "bar",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-3.snap
@@ -7,38 +7,44 @@ Ok(
         body: [
             Expr {
                 span: 0..25,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..25,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXText(
-                                JSXText {
-                                    span: 5..11,
-                                    value: "Hello ",
-                                },
-                            ),
-                            JSXExprContainer(
-                                JSXExprContainer {
-                                    span: 11..18,
-                                    expr: Ident(
-                                        Ident {
+                expr: Expr {
+                    span: 0..25,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..25,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXText(
+                                    JSXText {
+                                        span: 5..11,
+                                        value: "Hello ",
+                                    },
+                                ),
+                                JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 11..18,
+                                        expr: Expr {
                                             span: 12..17,
-                                            name: "world",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 12..17,
+                                                    name: "world",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ),
-                            JSXText(
-                                JSXText {
-                                    span: 18..19,
-                                    value: "!",
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                                    },
+                                ),
+                                JSXText(
+                                    JSXText {
+                                        span: 18..19,
+                                        value: "!",
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-4.snap
@@ -7,40 +7,49 @@ Ok(
         body: [
             Expr {
                 span: 0..29,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..29,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXExprContainer(
-                                JSXExprContainer {
-                                    span: 5..23,
-                                    expr: JSXElement(
-                                        JSXElement {
+                expr: Expr {
+                    span: 0..29,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..29,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 5..23,
+                                        expr: Expr {
                                             span: 6..22,
-                                            name: "Bar",
-                                            attrs: [],
-                                            children: [
-                                                JSXExprContainer(
-                                                    JSXExprContainer {
-                                                        span: 11..16,
-                                                        expr: Ident(
-                                                            Ident {
-                                                                span: 12..15,
-                                                                name: "baz",
+                                            kind: JSXElement(
+                                                JSXElement {
+                                                    span: 6..22,
+                                                    name: "Bar",
+                                                    attrs: [],
+                                                    children: [
+                                                        JSXExprContainer(
+                                                            JSXExprContainer {
+                                                                span: 11..16,
+                                                                expr: Expr {
+                                                                    span: 12..15,
+                                                                    kind: Ident(
+                                                                        Ident {
+                                                                            span: 12..15,
+                                                                            name: "baz",
+                                                                        },
+                                                                    ),
+                                                                },
                                                             },
                                                         ),
-                                                    },
-                                                ),
-                                            ],
+                                                    ],
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-5.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..11,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..11,
-                        name: "Foo",
-                        attrs: [],
-                        children: [],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..11,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..11,
+                            name: "Foo",
+                            attrs: [],
+                            children: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-6.snap
@@ -7,33 +7,39 @@ Ok(
         body: [
             Expr {
                 span: 0..17,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..17,
-                        name: "Foo",
-                        attrs: [
-                            JSXAttr {
-                                span: 5..14,
-                                ident: Ident {
-                                    span: 5..8,
-                                    name: "bar",
-                                },
-                                value: JSXExprContainer(
-                                    JSXExprContainer {
-                                        span: 9..14,
-                                        expr: Ident(
-                                            Ident {
-                                                span: 10..13,
-                                                name: "baz",
-                                            },
-                                        ),
+                expr: Expr {
+                    span: 0..17,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..17,
+                            name: "Foo",
+                            attrs: [
+                                JSXAttr {
+                                    span: 5..14,
+                                    ident: Ident {
+                                        span: 5..8,
+                                        name: "bar",
                                     },
-                                ),
-                            },
-                        ],
-                        children: [],
-                    },
-                ),
+                                    value: JSXExprContainer(
+                                        JSXExprContainer {
+                                            span: 9..14,
+                                            expr: Expr {
+                                                span: 10..13,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 10..13,
+                                                        name: "baz",
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                },
+                            ],
+                            children: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-7.snap
@@ -7,48 +7,54 @@ Ok(
         body: [
             Expr {
                 span: 0..33,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..33,
-                        name: "Foo",
-                        attrs: [
-                            JSXAttr {
-                                span: 5..16,
-                                ident: Ident {
-                                    span: 5..8,
-                                    name: "msg",
-                                },
-                                value: Lit(
-                                    Str(
-                                        Str {
-                                            span: 9..16,
-                                            value: "hello",
-                                        },
-                                    ),
-                                ),
-                            },
-                            JSXAttr {
-                                span: 17..26,
-                                ident: Ident {
-                                    span: 17..20,
-                                    name: "bar",
-                                },
-                                value: JSXExprContainer(
-                                    JSXExprContainer {
-                                        span: 21..26,
-                                        expr: Ident(
-                                            Ident {
-                                                span: 22..25,
-                                                name: "baz",
+                expr: Expr {
+                    span: 0..33,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..33,
+                            name: "Foo",
+                            attrs: [
+                                JSXAttr {
+                                    span: 5..16,
+                                    ident: Ident {
+                                        span: 5..8,
+                                        name: "msg",
+                                    },
+                                    value: Lit(
+                                        Str(
+                                            Str {
+                                                span: 9..16,
+                                                value: "hello",
                                             },
                                         ),
+                                    ),
+                                },
+                                JSXAttr {
+                                    span: 17..26,
+                                    ident: Ident {
+                                        span: 17..20,
+                                        name: "bar",
                                     },
-                                ),
-                            },
-                        ],
-                        children: [],
-                    },
-                ),
+                                    value: JSXExprContainer(
+                                        JSXExprContainer {
+                                            span: 21..26,
+                                            expr: Expr {
+                                                span: 22..25,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 22..25,
+                                                        name: "baz",
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                },
+                            ],
+                            children: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-8.snap
@@ -7,35 +7,41 @@ Ok(
         body: [
             Expr {
                 span: 0..27,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..27,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXElement(
-                                JSXElement {
-                                    span: 5..21,
-                                    name: "Bar",
-                                    attrs: [],
-                                    children: [
-                                        JSXExprContainer(
-                                            JSXExprContainer {
-                                                span: 10..15,
-                                                expr: Ident(
-                                                    Ident {
+                expr: Expr {
+                    span: 0..27,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..27,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXElement(
+                                    JSXElement {
+                                        span: 5..21,
+                                        name: "Bar",
+                                        attrs: [],
+                                        children: [
+                                            JSXExprContainer(
+                                                JSXExprContainer {
+                                                    span: 10..15,
+                                                    expr: Expr {
                                                         span: 11..14,
-                                                        name: "baz",
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 11..14,
+                                                                name: "baz",
+                                                            },
+                                                        ),
                                                     },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx-9.snap
@@ -7,48 +7,54 @@ Ok(
         body: [
             Expr {
                 span: 0..35,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..35,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXText(
-                                JSXText {
-                                    span: 5..10,
-                                    value: "hello",
-                                },
-                            ),
-                            JSXElement(
-                                JSXElement {
-                                    span: 10..16,
-                                    name: "Bar",
-                                    attrs: [],
-                                    children: [],
-                                },
-                            ),
-                            JSXExprContainer(
-                                JSXExprContainer {
-                                    span: 16..23,
-                                    expr: Ident(
-                                        Ident {
+                expr: Expr {
+                    span: 0..35,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..35,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXText(
+                                    JSXText {
+                                        span: 5..10,
+                                        value: "hello",
+                                    },
+                                ),
+                                JSXElement(
+                                    JSXElement {
+                                        span: 10..16,
+                                        name: "Bar",
+                                        attrs: [],
+                                        children: [],
+                                    },
+                                ),
+                                JSXExprContainer(
+                                    JSXExprContainer {
+                                        span: 16..23,
+                                        expr: Expr {
                                             span: 17..22,
-                                            name: "world",
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 17..22,
+                                                    name: "world",
+                                                },
+                                            ),
                                         },
-                                    ),
-                                },
-                            ),
-                            JSXElement(
-                                JSXElement {
-                                    span: 23..29,
-                                    name: "Baz",
-                                    attrs: [],
-                                    children: [],
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                                    },
+                                ),
+                                JSXElement(
+                                    JSXElement {
+                                        span: 23..29,
+                                        name: "Baz",
+                                        attrs: [],
+                                        children: [],
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__jsx.snap
@@ -7,21 +7,24 @@ Ok(
         body: [
             Expr {
                 span: 0..16,
-                expr: JSXElement(
-                    JSXElement {
-                        span: 0..16,
-                        name: "Foo",
-                        attrs: [],
-                        children: [
-                            JSXText(
-                                JSXText {
-                                    span: 5..10,
-                                    value: "Hello",
-                                },
-                            ),
-                        ],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..16,
+                    kind: JSXElement(
+                        JSXElement {
+                            span: 0..16,
+                            name: "Foo",
+                            attrs: [],
+                            children: [
+                                JSXText(
+                                    JSXText {
+                                        span: 5..10,
+                                        value: "Hello",
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-2.snap
@@ -7,29 +7,36 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: App(
-                    App {
-                        span: 0..9,
-                        lam: Member(
-                            Member {
+                expr: Expr {
+                    span: 0..9,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..7,
-                                obj: Ident(
-                                    Ident {
-                                        span: 0..3,
-                                        name: "foo",
-                                    },
-                                ),
-                                prop: Ident(
-                                    Ident {
-                                        span: 4..7,
-                                        name: "bar",
+                                kind: Member(
+                                    Member {
+                                        obj: Expr {
+                                            span: 0..3,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..3,
+                                                    name: "foo",
+                                                },
+                                            ),
+                                        },
+                                        prop: Ident(
+                                            Ident {
+                                                span: 4..7,
+                                                name: "bar",
+                                            },
+                                        ),
                                     },
                                 ),
                             },
-                        ),
-                        args: [],
-                    },
-                ),
+                            args: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-3.snap
@@ -7,92 +7,118 @@ Ok(
         body: [
             Expr {
                 span: 0..22,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..21,
-                        op: Add,
-                        left: BinaryExpr(
-                            BinaryExpr {
+                expr: Expr {
+                    span: 0..21,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Add,
+                            left: Expr {
                                 span: 0..9,
-                                op: Mul,
-                                left: Member(
-                                    Member {
-                                        span: 0..3,
-                                        obj: Ident(
-                                            Ident {
-                                                span: 0..1,
-                                                name: "p",
-                                            },
-                                        ),
-                                        prop: Ident(
-                                            Ident {
-                                                span: 2..3,
-                                                name: "x",
-                                            },
-                                        ),
-                                    },
-                                ),
-                                right: Member(
-                                    Member {
-                                        span: 6..9,
-                                        obj: Ident(
-                                            Ident {
-                                                span: 6..7,
-                                                name: "p",
-                                            },
-                                        ),
-                                        prop: Ident(
-                                            Ident {
-                                                span: 8..9,
-                                                name: "x",
-                                            },
-                                        ),
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Mul,
+                                        left: Expr {
+                                            span: 0..3,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
+                                                        span: 0..1,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 0..1,
+                                                                name: "p",
+                                                            },
+                                                        ),
+                                                    },
+                                                    prop: Ident(
+                                                        Ident {
+                                                            span: 2..3,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 6..9,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
+                                                        span: 6..7,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 6..7,
+                                                                name: "p",
+                                                            },
+                                                        ),
+                                                    },
+                                                    prop: Ident(
+                                                        Ident {
+                                                            span: 8..9,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        right: BinaryExpr(
-                            BinaryExpr {
+                            right: Expr {
                                 span: 12..21,
-                                op: Mul,
-                                left: Member(
-                                    Member {
-                                        span: 12..15,
-                                        obj: Ident(
-                                            Ident {
-                                                span: 12..13,
-                                                name: "p",
-                                            },
-                                        ),
-                                        prop: Ident(
-                                            Ident {
-                                                span: 14..15,
-                                                name: "y",
-                                            },
-                                        ),
-                                    },
-                                ),
-                                right: Member(
-                                    Member {
-                                        span: 18..21,
-                                        obj: Ident(
-                                            Ident {
-                                                span: 18..19,
-                                                name: "p",
-                                            },
-                                        ),
-                                        prop: Ident(
-                                            Ident {
-                                                span: 20..21,
-                                                name: "y",
-                                            },
-                                        ),
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Mul,
+                                        left: Expr {
+                                            span: 12..15,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
+                                                        span: 12..13,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 12..13,
+                                                                name: "p",
+                                                            },
+                                                        ),
+                                                    },
+                                                    prop: Ident(
+                                                        Ident {
+                                                            span: 14..15,
+                                                            name: "y",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 18..21,
+                                            kind: Member(
+                                                Member {
+                                                    obj: Expr {
+                                                        span: 18..19,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 18..19,
+                                                                name: "p",
+                                                            },
+                                                        ),
+                                                    },
+                                                    prop: Ident(
+                                                        Ident {
+                                                            span: 20..21,
+                                                            name: "y",
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-4.snap
@@ -7,35 +7,44 @@ Ok(
         body: [
             Expr {
                 span: 0..12,
-                expr: App(
-                    App {
-                        span: 0..11,
-                        lam: Member(
-                            Member {
+                expr: Expr {
+                    span: 0..11,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..9,
-                                obj: App(
-                                    App {
-                                        span: 0..5,
-                                        lam: Ident(
+                                kind: Member(
+                                    Member {
+                                        obj: Expr {
+                                            span: 0..5,
+                                            kind: App(
+                                                App {
+                                                    lam: Expr {
+                                                        span: 0..3,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 0..3,
+                                                                name: "foo",
+                                                            },
+                                                        ),
+                                                    },
+                                                    args: [],
+                                                },
+                                            ),
+                                        },
+                                        prop: Ident(
                                             Ident {
-                                                span: 0..3,
-                                                name: "foo",
+                                                span: 6..9,
+                                                name: "bar",
                                             },
                                         ),
-                                        args: [],
-                                    },
-                                ),
-                                prop: Ident(
-                                    Ident {
-                                        span: 6..9,
-                                        name: "bar",
                                     },
                                 ),
                             },
-                        ),
-                        args: [],
-                    },
-                ),
+                            args: [],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-5.snap
@@ -7,48 +7,61 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: Member(
-                    Member {
-                        span: 0..9,
-                        obj: Member(
-                            Member {
+                expr: Expr {
+                    span: 0..9,
+                    kind: Member(
+                        Member {
+                            obj: Expr {
                                 span: 0..6,
-                                obj: Ident(
-                                    Ident {
-                                        span: 0..3,
-                                        name: "arr",
-                                    },
-                                ),
-                                prop: Computed(
-                                    ComputedPropName {
-                                        span: 4..5,
-                                        expr: Lit(
-                                            Num(
-                                                Num {
-                                                    span: 4..5,
-                                                    value: "0",
+                                kind: Member(
+                                    Member {
+                                        obj: Expr {
+                                            span: 0..3,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..3,
+                                                    name: "arr",
                                                 },
                                             ),
+                                        },
+                                        prop: Computed(
+                                            ComputedPropName {
+                                                span: 4..5,
+                                                expr: Expr {
+                                                    span: 4..5,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 4..5,
+                                                                value: "0",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            },
                                         ),
                                     },
                                 ),
                             },
-                        ),
-                        prop: Computed(
-                            ComputedPropName {
-                                span: 7..8,
-                                expr: Lit(
-                                    Num(
-                                        Num {
-                                            span: 7..8,
-                                            value: "1",
-                                        },
-                                    ),
-                                ),
-                            },
-                        ),
-                    },
-                ),
+                            prop: Computed(
+                                ComputedPropName {
+                                    span: 7..8,
+                                    expr: Expr {
+                                        span: 7..8,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 7..8,
+                                                    value: "1",
+                                                },
+                                            ),
+                                        ),
+                                    },
+                                },
+                            ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-6.snap
@@ -7,44 +7,57 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: App(
-                    App {
-                        span: 0..9,
-                        lam: Member(
-                            Member {
+                expr: Expr {
+                    span: 0..9,
+                    kind: App(
+                        App {
+                            lam: Expr {
                                 span: 0..6,
-                                obj: Ident(
-                                    Ident {
-                                        span: 0..3,
-                                        name: "arr",
-                                    },
-                                ),
-                                prop: Computed(
-                                    ComputedPropName {
-                                        span: 4..5,
-                                        expr: Ident(
-                                            Ident {
+                                kind: Member(
+                                    Member {
+                                        obj: Expr {
+                                            span: 0..3,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..3,
+                                                    name: "arr",
+                                                },
+                                            ),
+                                        },
+                                        prop: Computed(
+                                            ComputedPropName {
                                                 span: 4..5,
-                                                name: "x",
+                                                expr: Expr {
+                                                    span: 4..5,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 4..5,
+                                                            name: "x",
+                                                        },
+                                                    ),
+                                                },
                                             },
                                         ),
                                     },
                                 ),
                             },
-                        ),
-                        args: [
-                            ExprOrSpread {
-                                spread: None,
-                                expr: Ident(
-                                    Ident {
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
                                         span: 7..8,
-                                        name: "y",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 7..8,
+                                                name: "y",
+                                            },
+                                        ),
                                     },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-7.snap
@@ -7,53 +7,68 @@ Ok(
         body: [
             Expr {
                 span: 0..20,
-                expr: Member(
-                    Member {
-                        span: 0..19,
-                        obj: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..19,
+                    kind: Member(
+                        Member {
+                            obj: Expr {
                                 span: 0..3,
-                                name: "arr",
-                            },
-                        ),
-                        prop: Computed(
-                            ComputedPropName {
-                                span: 4..18,
-                                expr: BinaryExpr(
-                                    BinaryExpr {
-                                        span: 4..18,
-                                        op: Sub,
-                                        left: Member(
-                                            Member {
-                                                span: 4..14,
-                                                obj: Ident(
-                                                    Ident {
-                                                        span: 4..7,
-                                                        name: "arr",
-                                                    },
-                                                ),
-                                                prop: Ident(
-                                                    Ident {
-                                                        span: 8..14,
-                                                        name: "length",
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                        right: Lit(
-                                            Num(
-                                                Num {
-                                                    span: 17..18,
-                                                    value: "1",
-                                                },
-                                            ),
-                                        ),
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "arr",
                                     },
                                 ),
                             },
-                        ),
-                    },
-                ),
+                            prop: Computed(
+                                ComputedPropName {
+                                    span: 4..18,
+                                    expr: Expr {
+                                        span: 4..18,
+                                        kind: BinaryExpr(
+                                            BinaryExpr {
+                                                op: Sub,
+                                                left: Expr {
+                                                    span: 4..14,
+                                                    kind: Member(
+                                                        Member {
+                                                            obj: Expr {
+                                                                span: 4..7,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 4..7,
+                                                                        name: "arr",
+                                                                    },
+                                                                ),
+                                                            },
+                                                            prop: Ident(
+                                                                Ident {
+                                                                    span: 8..14,
+                                                                    name: "length",
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                },
+                                                right: Expr {
+                                                    span: 17..18,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 17..18,
+                                                                value: "1",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
+                                    },
+                                },
+                            ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access-8.snap
@@ -7,52 +7,67 @@ Ok(
         body: [
             Expr {
                 span: 0..13,
-                expr: Member(
-                    Member {
-                        span: 0..12,
-                        obj: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..12,
+                    kind: Member(
+                        Member {
+                            obj: Expr {
                                 span: 0..3,
-                                name: "foo",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..3,
+                                        name: "foo",
+                                    },
+                                ),
                             },
-                        ),
-                        prop: Computed(
-                            ComputedPropName {
-                                span: 4..11,
-                                expr: Member(
-                                    Member {
+                            prop: Computed(
+                                ComputedPropName {
+                                    span: 4..11,
+                                    expr: Expr {
                                         span: 4..11,
-                                        obj: Ident(
-                                            Ident {
-                                                span: 4..7,
-                                                name: "bar",
-                                            },
-                                        ),
-                                        prop: Computed(
-                                            ComputedPropName {
-                                                span: 8..10,
-                                                expr: UnaryExpr(
-                                                    UnaryExpr {
+                                        kind: Member(
+                                            Member {
+                                                obj: Expr {
+                                                    span: 4..7,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 4..7,
+                                                            name: "bar",
+                                                        },
+                                                    ),
+                                                },
+                                                prop: Computed(
+                                                    ComputedPropName {
                                                         span: 8..10,
-                                                        op: Minus,
-                                                        arg: Lit(
-                                                            Num(
-                                                                Num {
-                                                                    span: 9..10,
-                                                                    value: "1",
+                                                        expr: Expr {
+                                                            span: 8..10,
+                                                            kind: UnaryExpr(
+                                                                UnaryExpr {
+                                                                    op: Minus,
+                                                                    arg: Expr {
+                                                                        span: 9..10,
+                                                                        kind: Lit(
+                                                                            Num(
+                                                                                Num {
+                                                                                    span: 9..10,
+                                                                                    value: "1",
+                                                                                },
+                                                                            ),
+                                                                        ),
+                                                                    },
                                                                 },
                                                             ),
-                                                        ),
+                                                        },
                                                     },
                                                 ),
                                             },
                                         ),
                                     },
-                                ),
-                            },
-                        ),
-                    },
-                ),
+                                },
+                            ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__member_access.snap
@@ -7,34 +7,41 @@ Ok(
         body: [
             Expr {
                 span: 0..6,
-                expr: Member(
-                    Member {
-                        span: 0..5,
-                        obj: Member(
-                            Member {
+                expr: Expr {
+                    span: 0..5,
+                    kind: Member(
+                        Member {
+                            obj: Expr {
                                 span: 0..3,
-                                obj: Ident(
-                                    Ident {
-                                        span: 0..1,
-                                        name: "a",
-                                    },
-                                ),
-                                prop: Ident(
-                                    Ident {
-                                        span: 2..3,
-                                        name: "b",
+                                kind: Member(
+                                    Member {
+                                        obj: Expr {
+                                            span: 0..1,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..1,
+                                                    name: "a",
+                                                },
+                                            ),
+                                        },
+                                        prop: Ident(
+                                            Ident {
+                                                span: 2..3,
+                                                name: "b",
+                                            },
+                                        ),
                                     },
                                 ),
                             },
-                        ),
-                        prop: Ident(
-                            Ident {
-                                span: 4..5,
-                                name: "c",
-                            },
-                        ),
-                    },
-                ),
+                            prop: Ident(
+                                Ident {
+                                    span: 4..5,
+                                    name: "c",
+                                },
+                            ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers-2.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..5,
-                expr: Lit(
-                    Num(
-                        Num {
-                            span: 0..4,
-                            value: "1.23",
-                        },
+                expr: Expr {
+                    span: 0..4,
+                    kind: Lit(
+                        Num(
+                            Num {
+                                span: 0..4,
+                                value: "1.23",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers-3.snap
@@ -7,20 +7,25 @@ Ok(
         body: [
             Expr {
                 span: 0..4,
-                expr: UnaryExpr(
-                    UnaryExpr {
-                        span: 0..3,
-                        op: Minus,
-                        arg: Lit(
-                            Num(
-                                Num {
-                                    span: 1..3,
-                                    value: "10",
-                                },
-                            ),
-                        ),
-                    },
-                ),
+                expr: Expr {
+                    span: 0..3,
+                    kind: UnaryExpr(
+                        UnaryExpr {
+                            op: Minus,
+                            arg: Expr {
+                                span: 1..3,
+                                kind: Lit(
+                                    Num(
+                                        Num {
+                                            span: 1..3,
+                                            value: "10",
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__numbers.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..3,
-                expr: Lit(
-                    Num(
-                        Num {
-                            span: 0..2,
-                            value: "10",
-                        },
+                expr: Expr {
+                    span: 0..2,
+                    kind: Lit(
+                        Num(
+                            Num {
+                                span: 0..2,
+                                value: "10",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-2.snap
@@ -18,29 +18,31 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Obj(
-                        Obj {
-                            span: 10..16,
-                            props: [
-                                Prop(
-                                    Shorthand(
-                                        Ident {
-                                            span: 10..16,
-                                            name: "x",
-                                        },
+                    Expr {
+                        span: 10..16,
+                        kind: Obj(
+                            Obj {
+                                props: [
+                                    Prop(
+                                        Shorthand(
+                                            Ident {
+                                                span: 10..16,
+                                                name: "x",
+                                            },
+                                        ),
                                     ),
-                                ),
-                                Prop(
-                                    Shorthand(
-                                        Ident {
-                                            span: 10..16,
-                                            name: "y",
-                                        },
+                                    Prop(
+                                        Shorthand(
+                                            Ident {
+                                                span: 10..16,
+                                                name: "y",
+                                            },
+                                        ),
                                     ),
-                                ),
-                            ],
-                        },
-                    ),
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects-3.snap
@@ -18,40 +18,44 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Obj(
-                        Obj {
-                            span: 10..27,
-                            props: [
-                                Prop(
-                                    Shorthand(
-                                        Ident {
-                                            span: 10..27,
-                                            name: "a",
-                                        },
-                                    ),
-                                ),
-                                Prop(
-                                    Shorthand(
-                                        Ident {
-                                            span: 10..27,
-                                            name: "b",
-                                        },
-                                    ),
-                                ),
-                                Spread(
-                                    SpreadElement {
-                                        span: 10..27,
-                                        expr: Ident(
+                    Expr {
+                        span: 10..27,
+                        kind: Obj(
+                            Obj {
+                                props: [
+                                    Prop(
+                                        Shorthand(
                                             Ident {
-                                                span: 20..26,
-                                                name: "others",
+                                                span: 10..27,
+                                                name: "a",
                                             },
                                         ),
-                                    },
-                                ),
-                            ],
-                        },
-                    ),
+                                    ),
+                                    Prop(
+                                        Shorthand(
+                                            Ident {
+                                                span: 10..27,
+                                                name: "b",
+                                            },
+                                        ),
+                                    ),
+                                    Spread(
+                                        SpreadElement {
+                                            expr: Expr {
+                                                span: 20..26,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 20..26,
+                                                        name: "others",
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__objects.snap
@@ -7,45 +7,51 @@ Ok(
         body: [
             Expr {
                 span: 0..14,
-                expr: Obj(
-                    Obj {
-                        span: 0..13,
-                        props: [
-                            Prop(
-                                KeyValue(
-                                    KeyValueProp {
-                                        span: 1..5,
-                                        name: "x",
-                                        value: Lit(
-                                            Num(
-                                                Num {
-                                                    span: 4..5,
-                                                    value: "5",
-                                                },
-                                            ),
-                                        ),
-                                    },
+                expr: Expr {
+                    span: 0..13,
+                    kind: Obj(
+                        Obj {
+                            props: [
+                                Prop(
+                                    KeyValue(
+                                        KeyValueProp {
+                                            name: "x",
+                                            value: Expr {
+                                                span: 4..5,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 4..5,
+                                                            value: "5",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        },
+                                    ),
                                 ),
-                            ),
-                            Prop(
-                                KeyValue(
-                                    KeyValueProp {
-                                        span: 7..12,
-                                        name: "y",
-                                        value: Lit(
-                                            Num(
-                                                Num {
-                                                    span: 10..12,
-                                                    value: "10",
-                                                },
-                                            ),
-                                        ),
-                                    },
+                                Prop(
+                                    KeyValue(
+                                        KeyValueProp {
+                                            name: "y",
+                                            value: Expr {
+                                                span: 10..12,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 10..12,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        },
+                                    ),
                                 ),
-                            ),
-                        ],
-                    },
-                ),
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-10.snap
@@ -18,24 +18,32 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    BinaryExpr(
-                        BinaryExpr {
-                            span: 11..17,
-                            op: NotEq,
-                            left: Ident(
-                                Ident {
+                    Expr {
+                        span: 11..17,
+                        kind: BinaryExpr(
+                            BinaryExpr {
+                                op: NotEq,
+                                left: Expr {
                                     span: 11..12,
-                                    name: "a",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 11..12,
+                                            name: "a",
+                                        },
+                                    ),
                                 },
-                            ),
-                            right: Ident(
-                                Ident {
+                                right: Expr {
                                     span: 16..17,
-                                    name: "b",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 16..17,
+                                            name: "b",
+                                        },
+                                    ),
                                 },
-                            ),
-                        },
-                    ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-11.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-11.snap
@@ -7,18 +7,23 @@ Ok(
         body: [
             Expr {
                 span: 0..3,
-                expr: UnaryExpr(
-                    UnaryExpr {
-                        span: 0..2,
-                        op: Minus,
-                        arg: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..2,
+                    kind: UnaryExpr(
+                        UnaryExpr {
+                            op: Minus,
+                            arg: Expr {
                                 span: 1..2,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 1..2,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-12.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-12.snap
@@ -7,30 +7,40 @@ Ok(
         body: [
             Expr {
                 span: 0..9,
-                expr: UnaryExpr(
-                    UnaryExpr {
-                        span: 0..8,
-                        op: Minus,
-                        arg: BinaryExpr(
-                            BinaryExpr {
+                expr: Expr {
+                    span: 0..8,
+                    kind: UnaryExpr(
+                        UnaryExpr {
+                            op: Minus,
+                            arg: Expr {
                                 span: 2..7,
-                                op: Add,
-                                left: Ident(
-                                    Ident {
-                                        span: 2..3,
-                                        name: "a",
-                                    },
-                                ),
-                                right: Ident(
-                                    Ident {
-                                        span: 6..7,
-                                        name: "b",
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Add,
+                                        left: Expr {
+                                            span: 2..3,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 2..3,
+                                                    name: "a",
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 6..7,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 6..7,
+                                                    name: "b",
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-2.snap
@@ -7,36 +7,49 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..9,
-                        op: Div,
-                        left: BinaryExpr(
-                            BinaryExpr {
+                expr: Expr {
+                    span: 0..9,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Div,
+                            left: Expr {
                                 span: 0..5,
-                                op: Mul,
-                                left: Ident(
-                                    Ident {
-                                        span: 0..1,
-                                        name: "x",
-                                    },
-                                ),
-                                right: Ident(
-                                    Ident {
-                                        span: 4..5,
-                                        name: "y",
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Mul,
+                                        left: Expr {
+                                            span: 0..1,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 0..1,
+                                                    name: "x",
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 4..5,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 4..5,
+                                                    name: "y",
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 8..9,
-                                name: "z",
+                                kind: Ident(
+                                    Ident {
+                                        span: 8..9,
+                                        name: "z",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-3.snap
@@ -7,36 +7,49 @@ Ok(
         body: [
             Expr {
                 span: 0..12,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..11,
-                        op: Mul,
-                        left: BinaryExpr(
-                            BinaryExpr {
+                expr: Expr {
+                    span: 0..11,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Mul,
+                            left: Expr {
                                 span: 1..6,
-                                op: Add,
-                                left: Ident(
-                                    Ident {
-                                        span: 1..2,
-                                        name: "a",
-                                    },
-                                ),
-                                right: Ident(
-                                    Ident {
-                                        span: 5..6,
-                                        name: "b",
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Add,
+                                        left: Expr {
+                                            span: 1..2,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 1..2,
+                                                    name: "a",
+                                                },
+                                            ),
+                                        },
+                                        right: Expr {
+                                            span: 5..6,
+                                            kind: Ident(
+                                                Ident {
+                                                    span: 5..6,
+                                                    name: "b",
+                                                },
+                                            ),
+                                        },
                                     },
                                 ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 10..11,
-                                name: "c",
+                                kind: Ident(
+                                    Ident {
+                                        span: 10..11,
+                                        name: "c",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-4.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..7,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..6,
-                        op: EqEq,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..6,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: EqEq,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 5..6,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 5..6,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-5.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..7,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..6,
-                        op: NotEq,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..6,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: NotEq,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 5..6,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 5..6,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-6.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..6,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..5,
-                        op: Gt,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..5,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Gt,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 4..5,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-7.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..7,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..6,
-                        op: GtEq,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..6,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: GtEq,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 5..6,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 5..6,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-8.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..6,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..5,
-                        op: Lt,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..5,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Lt,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 4..5,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations-9.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..7,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..6,
-                        op: LtEq,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..6,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: LtEq,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 5..6,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 5..6,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__operations.snap
@@ -7,42 +7,55 @@ Ok(
         body: [
             Expr {
                 span: 0..10,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..9,
-                        op: Sub,
-                        left: BinaryExpr(
-                            BinaryExpr {
+                expr: Expr {
+                    span: 0..9,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Sub,
+                            left: Expr {
                                 span: 0..5,
-                                op: Add,
-                                left: Lit(
-                                    Num(
-                                        Num {
+                                kind: BinaryExpr(
+                                    BinaryExpr {
+                                        op: Add,
+                                        left: Expr {
                                             span: 0..1,
-                                            value: "1",
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 0..1,
+                                                        value: "1",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
+                                        right: Expr {
+                                            span: 4..5,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 4..5,
+                                                        value: "2",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
                                 ),
-                                right: Lit(
+                            },
+                            right: Expr {
+                                span: 8..9,
+                                kind: Lit(
                                     Num(
                                         Num {
-                                            span: 4..5,
-                                            value: "2",
+                                            span: 8..9,
+                                            value: "3",
                                         },
                                     ),
                                 ),
                             },
-                        ),
-                        right: Lit(
-                            Num(
-                                Num {
-                                    span: 8..9,
-                                    value: "3",
-                                },
-                            ),
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
@@ -18,98 +18,109 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Match(
-                        Match {
-                            span: 23..128,
-                            expr: Ident(
-                                Ident {
+                    Expr {
+                        span: 23..128,
+                        kind: Match(
+                            Match {
+                                expr: Expr {
                                     span: 30..33,
-                                    name: "foo",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 30..33,
+                                            name: "foo",
+                                        },
+                                    ),
                                 },
-                            ),
-                            arms: [
-                                Arm {
-                                    span: 53..78,
-                                    pattern: Object(
-                                        ObjectPat {
-                                            span: 53..66,
-                                            props: [
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 54..55,
-                                                            name: "a",
-                                                        },
-                                                        value: Object(
-                                                            ObjectPat {
-                                                                span: 57..65,
-                                                                props: [
-                                                                    KeyValue(
-                                                                        KeyValuePatProp {
-                                                                            key: Ident {
-                                                                                span: 58..59,
-                                                                                name: "b",
-                                                                            },
-                                                                            value: Object(
-                                                                                ObjectPat {
-                                                                                    span: 61..64,
-                                                                                    props: [
-                                                                                        Assign(
-                                                                                            AssignPatProp {
-                                                                                                span: 62..63,
-                                                                                                key: Ident {
-                                                                                                    span: 62..63,
-                                                                                                    name: "c",
-                                                                                                },
-                                                                                                value: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    optional: false,
-                                                                                },
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                                optional: false,
+                                arms: [
+                                    Arm {
+                                        span: 53..78,
+                                        pattern: Object(
+                                            ObjectPat {
+                                                span: 53..66,
+                                                props: [
+                                                    KeyValue(
+                                                        KeyValuePatProp {
+                                                            key: Ident {
+                                                                span: 54..55,
+                                                                name: "a",
                                                             },
-                                                        ),
+                                                            value: Object(
+                                                                ObjectPat {
+                                                                    span: 57..65,
+                                                                    props: [
+                                                                        KeyValue(
+                                                                            KeyValuePatProp {
+                                                                                key: Ident {
+                                                                                    span: 58..59,
+                                                                                    name: "b",
+                                                                                },
+                                                                                value: Object(
+                                                                                    ObjectPat {
+                                                                                        span: 61..64,
+                                                                                        props: [
+                                                                                            Assign(
+                                                                                                AssignPatProp {
+                                                                                                    span: 62..63,
+                                                                                                    key: Ident {
+                                                                                                        span: 62..63,
+                                                                                                        name: "c",
+                                                                                                    },
+                                                                                                    value: None,
+                                                                                                },
+                                                                                            ),
+                                                                                        ],
+                                                                                        optional: false,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                    optional: false,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                                optional: false,
+                                            },
+                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 70..78,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 70..78,
+                                                        value: "object",
                                                     },
                                                 ),
-                                            ],
-                                            optional: false,
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 70..78,
-                                                value: "object",
+                                    },
+                                    Arm {
+                                        span: 96..114,
+                                        pattern: Wildcard(
+                                            WildcardPat {
+                                                span: 96..97,
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 96..114,
-                                    pattern: Wildcard(
-                                        WildcardPat {
-                                            span: 96..97,
+                                        guard: None,
+                                        body: Expr {
+                                            span: 101..114,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 101..114,
+                                                        value: "fallthrough",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 101..114,
-                                                value: "fallthrough",
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
@@ -18,102 +18,116 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Match(
-                        Match {
-                            span: 23..170,
-                            expr: Ident(
-                                Ident {
+                    Expr {
+                        span: 23..170,
+                        kind: Match(
+                            Match {
+                                expr: Expr {
                                     span: 30..33,
-                                    name: "foo",
-                                },
-                            ),
-                            arms: [
-                                Arm {
-                                    span: 53..76,
-                                    pattern: Is(
-                                        IsPat {
-                                            span: 53..64,
-                                            id: Ident {
-                                                span: 53..54,
-                                                name: "n",
-                                            },
-                                            is_id: Ident {
-                                                span: 58..64,
-                                                name: "number",
-                                            },
+                                    kind: Ident(
+                                        Ident {
+                                            span: 30..33,
+                                            name: "foo",
                                         },
                                     ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 68..76,
-                                                value: "number",
+                                },
+                                arms: [
+                                    Arm {
+                                        span: 53..76,
+                                        pattern: Is(
+                                            IsPat {
+                                                span: 53..64,
+                                                id: Ident {
+                                                    span: 53..54,
+                                                    name: "n",
+                                                },
+                                                is_id: Ident {
+                                                    span: 58..64,
+                                                    name: "number",
+                                                },
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 94..120,
-                                    pattern: Object(
-                                        ObjectPat {
-                                            span: 94..109,
-                                            props: [
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 95..96,
-                                                            name: "a",
-                                                        },
-                                                        value: Is(
-                                                            IsPat {
-                                                                span: 98..108,
-                                                                id: Ident {
-                                                                    span: 98..99,
-                                                                    name: "a",
-                                                                },
-                                                                is_id: Ident {
-                                                                    span: 103..108,
-                                                                    name: "Array",
-                                                                },
-                                                            },
-                                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 68..76,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 68..76,
+                                                        value: "number",
                                                     },
                                                 ),
-                                            ],
-                                            optional: false,
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 113..120,
-                                                value: "Array",
+                                    },
+                                    Arm {
+                                        span: 94..120,
+                                        pattern: Object(
+                                            ObjectPat {
+                                                span: 94..109,
+                                                props: [
+                                                    KeyValue(
+                                                        KeyValuePatProp {
+                                                            key: Ident {
+                                                                span: 95..96,
+                                                                name: "a",
+                                                            },
+                                                            value: Is(
+                                                                IsPat {
+                                                                    span: 98..108,
+                                                                    id: Ident {
+                                                                        span: 98..99,
+                                                                        name: "a",
+                                                                    },
+                                                                    is_id: Ident {
+                                                                        span: 103..108,
+                                                                        name: "Array",
+                                                                    },
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                                optional: false,
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 138..156,
-                                    pattern: Wildcard(
-                                        WildcardPat {
-                                            span: 138..139,
+                                        guard: None,
+                                        body: Expr {
+                                            span: 113..120,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 113..120,
+                                                        value: "Array",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 143..156,
-                                                value: "fallthrough",
+                                    },
+                                    Arm {
+                                        span: 138..156,
+                                        pattern: Wildcard(
+                                            WildcardPat {
+                                                span: 138..139,
                                             },
                                         ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 143..156,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 143..156,
+                                                        value: "fallthrough",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-4.snap
@@ -18,124 +18,149 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Match(
-                        Match {
-                            span: 23..173,
-                            expr: Ident(
-                                Ident {
+                    Expr {
+                        span: 23..173,
+                        kind: Match(
+                            Match {
+                                expr: Expr {
                                     span: 30..33,
-                                    name: "foo",
-                                },
-                            ),
-                            arms: [
-                                Arm {
-                                    span: 53..63,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 53..54,
-                                            lit: Num(
-                                                Num {
-                                                    span: 53..54,
-                                                    value: "1",
-                                                },
-                                            ),
+                                    kind: Ident(
+                                        Ident {
+                                            span: 30..33,
+                                            name: "foo",
                                         },
                                     ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 58..63,
-                                                value: "one",
-                                            },
-                                        ),
-                                    ),
                                 },
-                                Arm {
-                                    span: 81..91,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 81..82,
-                                            lit: Num(
-                                                Num {
-                                                    span: 81..82,
-                                                    value: "2",
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 86..91,
-                                                value: "two",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 109..130,
-                                    pattern: Ident(
-                                        BindingIdent {
-                                            span: 109..110,
-                                            id: Ident {
-                                                span: 109..110,
-                                                name: "n",
-                                            },
-                                        },
-                                    ),
-                                    guard: Some(
-                                        BinaryExpr(
-                                            BinaryExpr {
-                                                span: 115..120,
-                                                op: Lt,
-                                                left: Ident(
-                                                    Ident {
-                                                        span: 115..116,
-                                                        name: "n",
+                                arms: [
+                                    Arm {
+                                        span: 53..63,
+                                        pattern: Lit(
+                                            LitPat {
+                                                span: 53..54,
+                                                lit: Num(
+                                                    Num {
+                                                        span: 53..54,
+                                                        value: "1",
                                                     },
                                                 ),
-                                                right: Lit(
-                                                    Num(
-                                                        Num {
-                                                            span: 119..120,
-                                                            value: "5",
-                                                        },
-                                                    ),
+                                            },
+                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 58..63,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 58..63,
+                                                        value: "one",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    Arm {
+                                        span: 81..91,
+                                        pattern: Lit(
+                                            LitPat {
+                                                span: 81..82,
+                                                lit: Num(
+                                                    Num {
+                                                        span: 81..82,
+                                                        value: "2",
+                                                    },
                                                 ),
                                             },
                                         ),
-                                    ),
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 125..130,
-                                                value: "few",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 148..159,
-                                    pattern: Wildcard(
-                                        WildcardPat {
-                                            span: 148..149,
+                                        guard: None,
+                                        body: Expr {
+                                            span: 86..91,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 86..91,
+                                                        value: "two",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 153..159,
-                                                value: "many",
+                                    },
+                                    Arm {
+                                        span: 109..130,
+                                        pattern: Ident(
+                                            BindingIdent {
+                                                span: 109..110,
+                                                id: Ident {
+                                                    span: 109..110,
+                                                    name: "n",
+                                                },
                                             },
                                         ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                        guard: Some(
+                                            Expr {
+                                                span: 115..120,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Lt,
+                                                        left: Expr {
+                                                            span: 115..116,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 115..116,
+                                                                    name: "n",
+                                                                },
+                                                            ),
+                                                        },
+                                                        right: Expr {
+                                                            span: 119..120,
+                                                            kind: Lit(
+                                                                Num(
+                                                                    Num {
+                                                                        span: 119..120,
+                                                                        value: "5",
+                                                                    },
+                                                                ),
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        body: Expr {
+                                            span: 125..130,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 125..130,
+                                                        value: "few",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    Arm {
+                                        span: 148..159,
+                                        pattern: Wildcard(
+                                            WildcardPat {
+                                                span: 148..149,
+                                            },
+                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 153..159,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 153..159,
+                                                        value: "many",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
@@ -18,260 +18,286 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Match(
-                        Match {
-                            span: 23..317,
-                            expr: Ident(
-                                Ident {
+                    Expr {
+                        span: 23..317,
+                        kind: Match(
+                            Match {
+                                expr: Expr {
                                     span: 30..33,
-                                    name: "foo",
-                                },
-                            ),
-                            arms: [
-                                Arm {
-                                    span: 53..89,
-                                    pattern: Object(
-                                        ObjectPat {
-                                            span: 53..77,
-                                            props: [
-                                                Assign(
-                                                    AssignPatProp {
-                                                        span: 54..55,
-                                                        key: Ident {
-                                                            span: 54..55,
-                                                            name: "x",
-                                                        },
-                                                        value: None,
-                                                    },
-                                                ),
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 57..58,
-                                                            name: "y",
-                                                        },
-                                                        value: Ident(
-                                                            BindingIdent {
-                                                                span: 60..61,
-                                                                id: Ident {
-                                                                    span: 60..61,
-                                                                    name: "b",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                                KeyValue(
-                                                    KeyValuePatProp {
-                                                        key: Ident {
-                                                            span: 63..64,
-                                                            name: "z",
-                                                        },
-                                                        value: Lit(
-                                                            LitPat {
-                                                                span: 66..67,
-                                                                lit: Num(
-                                                                    Num {
-                                                                        span: 66..67,
-                                                                        value: "5",
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                                Rest(
-                                                    RestPat {
-                                                        span: 69..76,
-                                                        arg: Ident(
-                                                            BindingIdent {
-                                                                span: 72..76,
-                                                                id: Ident {
-                                                                    span: 72..76,
-                                                                    name: "rest",
-                                                                },
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            optional: false,
+                                    kind: Ident(
+                                        Ident {
+                                            span: 30..33,
+                                            name: "foo",
                                         },
                                     ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 81..89,
-                                                value: "object",
-                                            },
-                                        ),
-                                    ),
                                 },
-                                Arm {
-                                    span: 107..133,
-                                    pattern: Array(
-                                        ArrayPat {
-                                            span: 107..122,
-                                            elems: [
-                                                Some(
-                                                    Ident(
-                                                        BindingIdent {
-                                                            span: 108..109,
-                                                            id: Ident {
-                                                                span: 108..109,
-                                                                name: "a",
+                                arms: [
+                                    Arm {
+                                        span: 53..89,
+                                        pattern: Object(
+                                            ObjectPat {
+                                                span: 53..77,
+                                                props: [
+                                                    Assign(
+                                                        AssignPatProp {
+                                                            span: 54..55,
+                                                            key: Ident {
+                                                                span: 54..55,
+                                                                name: "x",
                                                             },
+                                                            value: None,
                                                         },
                                                     ),
-                                                ),
-                                                Some(
-                                                    Wildcard(
-                                                        WildcardPat {
-                                                            span: 111..112,
+                                                    KeyValue(
+                                                        KeyValuePatProp {
+                                                            key: Ident {
+                                                                span: 57..58,
+                                                                name: "y",
+                                                            },
+                                                            value: Ident(
+                                                                BindingIdent {
+                                                                    span: 60..61,
+                                                                    id: Ident {
+                                                                        span: 60..61,
+                                                                        name: "b",
+                                                                    },
+                                                                },
+                                                            ),
                                                         },
                                                     ),
-                                                ),
-                                                Some(
+                                                    KeyValue(
+                                                        KeyValuePatProp {
+                                                            key: Ident {
+                                                                span: 63..64,
+                                                                name: "z",
+                                                            },
+                                                            value: Lit(
+                                                                LitPat {
+                                                                    span: 66..67,
+                                                                    lit: Num(
+                                                                        Num {
+                                                                            span: 66..67,
+                                                                            value: "5",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
                                                     Rest(
                                                         RestPat {
-                                                            span: 114..121,
+                                                            span: 69..76,
                                                             arg: Ident(
                                                                 BindingIdent {
-                                                                    span: 117..121,
+                                                                    span: 72..76,
                                                                     id: Ident {
-                                                                        span: 117..121,
+                                                                        span: 72..76,
                                                                         name: "rest",
                                                                     },
                                                                 },
                                                             ),
                                                         },
                                                     ),
+                                                ],
+                                                optional: false,
+                                            },
+                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 81..89,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 81..89,
+                                                        value: "object",
+                                                    },
                                                 ),
-                                            ],
-                                            optional: false,
-                                        },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 126..133,
-                                                value: "array",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 151..171,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 151..159,
-                                            lit: Str(
-                                                Str {
-                                                    span: 151..159,
-                                                    value: "string",
-                                                },
                                             ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 163..171,
-                                                value: "string",
+                                    },
+                                    Arm {
+                                        span: 107..133,
+                                        pattern: Array(
+                                            ArrayPat {
+                                                span: 107..122,
+                                                elems: [
+                                                    Some(
+                                                        Ident(
+                                                            BindingIdent {
+                                                                span: 108..109,
+                                                                id: Ident {
+                                                                    span: 108..109,
+                                                                    name: "a",
+                                                                },
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Some(
+                                                        Wildcard(
+                                                            WildcardPat {
+                                                                span: 111..112,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    Some(
+                                                        Rest(
+                                                            RestPat {
+                                                                span: 114..121,
+                                                                arg: Ident(
+                                                                    BindingIdent {
+                                                                        span: 117..121,
+                                                                        id: Ident {
+                                                                            span: 117..121,
+                                                                            name: "rest",
+                                                                        },
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ),
+                                                ],
+                                                optional: false,
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 189..203,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 189..193,
-                                            lit: Bool(
-                                                Bool {
-                                                    span: 189..193,
-                                                    value: true,
-                                                },
+                                        guard: None,
+                                        body: Expr {
+                                            span: 126..133,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 126..133,
+                                                        value: "array",
+                                                    },
+                                                ),
                                             ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 197..203,
-                                                value: "true",
+                                    },
+                                    Arm {
+                                        span: 151..171,
+                                        pattern: Lit(
+                                            LitPat {
+                                                span: 151..159,
+                                                lit: Str(
+                                                    Str {
+                                                        span: 151..159,
+                                                        value: "string",
+                                                    },
+                                                ),
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 221..237,
-                                    pattern: Lit(
-                                        LitPat {
-                                            span: 221..226,
-                                            lit: Bool(
-                                                Bool {
-                                                    span: 221..226,
-                                                    value: false,
-                                                },
+                                        guard: None,
+                                        body: Expr {
+                                            span: 163..171,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 163..171,
+                                                        value: "string",
+                                                    },
+                                                ),
                                             ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 230..237,
-                                                value: "false",
+                                    },
+                                    Arm {
+                                        span: 189..203,
+                                        pattern: Lit(
+                                            LitPat {
+                                                span: 189..193,
+                                                lit: Bool(
+                                                    Bool {
+                                                        span: 189..193,
+                                                        value: true,
+                                                    },
+                                                ),
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 255..270,
-                                    pattern: Ident(
-                                        BindingIdent {
-                                            span: 255..256,
-                                            id: Ident {
+                                        guard: None,
+                                        body: Expr {
+                                            span: 197..203,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 197..203,
+                                                        value: "true",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    Arm {
+                                        span: 221..237,
+                                        pattern: Lit(
+                                            LitPat {
+                                                span: 221..226,
+                                                lit: Bool(
+                                                    Bool {
+                                                        span: 221..226,
+                                                        value: false,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 230..237,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 230..237,
+                                                        value: "false",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    Arm {
+                                        span: 255..270,
+                                        pattern: Ident(
+                                            BindingIdent {
                                                 span: 255..256,
-                                                name: "n",
-                                            },
-                                        },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 260..270,
-                                                value: "variable",
+                                                id: Ident {
+                                                    span: 255..256,
+                                                    name: "n",
+                                                },
                                             },
                                         ),
-                                    ),
-                                },
-                                Arm {
-                                    span: 288..303,
-                                    pattern: Wildcard(
-                                        WildcardPat {
-                                            span: 288..289,
+                                        guard: None,
+                                        body: Expr {
+                                            span: 260..270,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 260..270,
+                                                        value: "variable",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                    guard: None,
-                                    body: Lit(
-                                        Str(
-                                            Str {
-                                                span: 293..303,
-                                                value: "wildcard",
+                                    },
+                                    Arm {
+                                        span: 288..303,
+                                        pattern: Wildcard(
+                                            WildcardPat {
+                                                span: 288..289,
                                             },
                                         ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                        guard: None,
+                                        body: Expr {
+                                            span: 293..303,
+                                            kind: Lit(
+                                                Str(
+                                                    Str {
+                                                        span: 293..303,
+                                                        value: "wildcard",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions-2.snap
@@ -18,73 +18,88 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..45,
-                            params: [],
-                            body: Let(
-                                Let {
+                    Expr {
+                        span: 10..45,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 18..40,
-                                    pattern: Some(
-                                        Ident(
-                                            BindingIdent {
-                                                span: 22..23,
-                                                id: Ident {
-                                                    span: 22..23,
-                                                    name: "x",
-                                                },
-                                            },
-                                        ),
-                                    ),
-                                    type_ann: None,
-                                    init: App(
-                                        App {
-                                            span: 26..39,
-                                            lam: Member(
-                                                Member {
-                                                    span: 26..37,
-                                                    obj: Ident(
-                                                        Ident {
-                                                            span: 26..30,
-                                                            name: "Math",
-                                                        },
-                                                    ),
-                                                    prop: Ident(
-                                                        Ident {
-                                                            span: 31..37,
-                                                            name: "random",
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                            args: [],
-                                        },
-                                    ),
-                                    body: Let(
+                                    kind: Let(
                                         Let {
-                                            span: 41..43,
-                                            pattern: None,
+                                            pattern: Some(
+                                                Ident(
+                                                    BindingIdent {
+                                                        span: 22..23,
+                                                        id: Ident {
+                                                            span: 22..23,
+                                                            name: "x",
+                                                        },
+                                                    },
+                                                ),
+                                            ),
                                             type_ann: None,
-                                            init: Ident(
-                                                Ident {
-                                                    span: 41..42,
-                                                    name: "x",
-                                                },
-                                            ),
-                                            body: Empty(
-                                                Empty {
-                                                    span: 0..0,
-                                                },
-                                            ),
+                                            init: Expr {
+                                                span: 26..39,
+                                                kind: App(
+                                                    App {
+                                                        lam: Expr {
+                                                            span: 26..37,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
+                                                                        span: 26..30,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                span: 26..30,
+                                                                                name: "Math",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    prop: Ident(
+                                                                        Ident {
+                                                                            span: 31..37,
+                                                                            name: "random",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                        args: [],
+                                                    },
+                                                ),
+                                            },
+                                            body: Expr {
+                                                span: 41..43,
+                                                kind: Let(
+                                                    Let {
+                                                        pattern: None,
+                                                        type_ann: None,
+                                                        init: Expr {
+                                                            span: 41..42,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    span: 41..42,
+                                                                    name: "x",
+                                                                },
+                                                            ),
+                                                        },
+                                                        body: Expr {
+                                                            span: 0..0,
+                                                            kind: Empty,
+                                                        },
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions.snap
@@ -18,61 +18,75 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..44,
-                            params: [],
-                            body: Let(
-                                Let {
+                    Expr {
+                        span: 10..44,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 18..40,
-                                    pattern: Some(
-                                        Ident(
-                                            BindingIdent {
-                                                span: 22..23,
-                                                id: Ident {
-                                                    span: 22..23,
-                                                    name: "x",
-                                                },
-                                            },
-                                        ),
-                                    ),
-                                    type_ann: None,
-                                    init: App(
-                                        App {
-                                            span: 26..39,
-                                            lam: Member(
-                                                Member {
-                                                    span: 26..37,
-                                                    obj: Ident(
-                                                        Ident {
-                                                            span: 26..30,
-                                                            name: "Math",
+                                    kind: Let(
+                                        Let {
+                                            pattern: Some(
+                                                Ident(
+                                                    BindingIdent {
+                                                        span: 22..23,
+                                                        id: Ident {
+                                                            span: 22..23,
+                                                            name: "x",
                                                         },
-                                                    ),
-                                                    prop: Ident(
-                                                        Ident {
-                                                            span: 31..37,
-                                                            name: "random",
-                                                        },
-                                                    ),
-                                                },
+                                                    },
+                                                ),
                                             ),
-                                            args: [],
-                                        },
-                                    ),
-                                    body: Ident(
-                                        Ident {
-                                            span: 41..42,
-                                            name: "x",
+                                            type_ann: None,
+                                            init: Expr {
+                                                span: 26..39,
+                                                kind: App(
+                                                    App {
+                                                        lam: Expr {
+                                                            span: 26..37,
+                                                            kind: Member(
+                                                                Member {
+                                                                    obj: Expr {
+                                                                        span: 26..30,
+                                                                        kind: Ident(
+                                                                            Ident {
+                                                                                span: 26..30,
+                                                                                name: "Math",
+                                                                            },
+                                                                        ),
+                                                                    },
+                                                                    prop: Ident(
+                                                                        Ident {
+                                                                            span: 31..37,
+                                                                            name: "random",
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        },
+                                                        args: [],
+                                                    },
+                                                ),
+                                            },
+                                            body: Expr {
+                                                span: 41..42,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 41..42,
+                                                        name: "x",
+                                                    },
+                                                ),
+                                            },
                                         },
                                     ),
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-2.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..8,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 0..7,
-                            value: "hello",
-                        },
+                expr: Expr {
+                    span: 0..7,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 0..7,
+                                value: "hello",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-3.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..25,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 0..24,
-                            value: "line 1\nline 2\nline 3",
-                        },
+                expr: Expr {
+                    span: 0..24,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 0..24,
+                                value: "line 1\nline 2\nline 3",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-4.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..13,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 0..12,
-                            value: "a − b",
-                        },
+                expr: Expr {
+                    span: 0..12,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 0..12,
+                                value: "a − b",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings-5.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..20,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 0..19,
-                            value: "hello, \"world\"!",
-                        },
+                expr: Expr {
+                    span: 0..19,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 0..19,
+                                value: "hello, \"world\"!",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__strings.snap
@@ -7,14 +7,17 @@ Ok(
         body: [
             Expr {
                 span: 0..3,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 0..2,
-                            value: "",
-                        },
+                expr: Expr {
+                    span: 0..2,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 0..2,
+                                value: "",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__tagged_template_literals.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__tagged_template_literals.snap
@@ -7,79 +7,86 @@ Ok(
         body: [
             Expr {
                 span: 0..44,
-                expr: TaggedTemplateLiteral(
-                    TaggedTemplateLiteral {
-                        span: 0..44,
-                        tag: Ident {
-                            span: 0..3,
-                            name: "sql",
-                        },
-                        template: TemplateLiteral {
-                            span: 3..44,
-                            exprs: [
-                                Ident(
-                                    Ident {
+                expr: Expr {
+                    span: 0..44,
+                    kind: TaggedTemplateLiteral(
+                        TaggedTemplateLiteral {
+                            tag: Ident {
+                                span: 0..3,
+                                name: "sql",
+                            },
+                            template: TemplateLiteral {
+                                exprs: [
+                                    Expr {
                                         span: 20..25,
-                                        name: "table",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 20..25,
+                                                name: "table",
+                                            },
+                                        ),
                                     },
-                                ),
-                                Ident(
-                                    Ident {
+                                    Expr {
                                         span: 40..42,
-                                        name: "id",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 40..42,
+                                                name: "id",
+                                            },
+                                        ),
                                     },
-                                ),
-                            ],
-                            quasis: [
-                                TemplateElem {
-                                    span: 4..18,
-                                    raw: Str(
-                                        Str {
-                                            span: 4..18,
-                                            value: "SELECT * FROM ",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            span: 4..18,
-                                            value: "SELECT * FROM ",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    span: 26..38,
-                                    raw: Str(
-                                        Str {
-                                            span: 26..38,
-                                            value: " WHERE id = ",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            span: 26..38,
-                                            value: " WHERE id = ",
-                                        },
-                                    ),
-                                },
-                                TemplateElem {
-                                    span: 43..43,
-                                    raw: Str(
-                                        Str {
-                                            span: 43..43,
-                                            value: "",
-                                        },
-                                    ),
-                                    cooked: Str(
-                                        Str {
-                                            span: 43..43,
-                                            value: "",
-                                        },
-                                    ),
-                                },
-                            ],
+                                ],
+                                quasis: [
+                                    TemplateElem {
+                                        span: 4..18,
+                                        raw: Str(
+                                            Str {
+                                                span: 4..18,
+                                                value: "SELECT * FROM ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                span: 4..18,
+                                                value: "SELECT * FROM ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        span: 26..38,
+                                        raw: Str(
+                                            Str {
+                                                span: 26..38,
+                                                value: " WHERE id = ",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                span: 26..38,
+                                                value: " WHERE id = ",
+                                            },
+                                        ),
+                                    },
+                                    TemplateElem {
+                                        span: 43..43,
+                                        raw: Str(
+                                            Str {
+                                                span: 43..43,
+                                                value: "",
+                                            },
+                                        ),
+                                        cooked: Str(
+                                            Str {
+                                                span: 43..43,
+                                                value: "",
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
                         },
-                    },
-                ),
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-2.snap
@@ -7,51 +7,56 @@ Ok(
         body: [
             Expr {
                 span: 0..16,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..16,
-                        exprs: [
-                            Ident(
-                                Ident {
+                expr: Expr {
+                    span: 0..16,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [
+                                Expr {
                                     span: 10..14,
-                                    name: "name",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 10..14,
+                                            name: "name",
+                                        },
+                                    ),
                                 },
-                            ),
-                        ],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..8,
-                                raw: Str(
-                                    Str {
-                                        span: 1..8,
-                                        value: "Hello, ",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..8,
-                                        value: "Hello, ",
-                                    },
-                                ),
-                            },
-                            TemplateElem {
-                                span: 15..15,
-                                raw: Str(
-                                    Str {
-                                        span: 15..15,
-                                        value: "",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 15..15,
-                                        value: "",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                            ],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..8,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..8,
+                                            value: "Hello, ",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..8,
+                                            value: "Hello, ",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 15..15,
+                                    raw: Str(
+                                        Str {
+                                            span: 15..15,
+                                            value: "",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 15..15,
+                                            value: "",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-3.snap
@@ -7,72 +7,80 @@ Ok(
         body: [
             Expr {
                 span: 0..14,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..14,
-                        exprs: [
-                            Ident(
-                                Ident {
+                expr: Expr {
+                    span: 0..14,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [
+                                Expr {
                                     span: 4..5,
-                                    name: "x",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 4..5,
+                                            name: "x",
+                                        },
+                                    ),
                                 },
-                            ),
-                            Ident(
-                                Ident {
+                                Expr {
                                     span: 10..11,
-                                    name: "y",
+                                    kind: Ident(
+                                        Ident {
+                                            span: 10..11,
+                                            name: "y",
+                                        },
+                                    ),
                                 },
-                            ),
-                        ],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..2,
-                                raw: Str(
-                                    Str {
-                                        span: 1..2,
-                                        value: "(",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..2,
-                                        value: "(",
-                                    },
-                                ),
-                            },
-                            TemplateElem {
-                                span: 6..8,
-                                raw: Str(
-                                    Str {
-                                        span: 6..8,
-                                        value: ", ",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 6..8,
-                                        value: ", ",
-                                    },
-                                ),
-                            },
-                            TemplateElem {
-                                span: 12..13,
-                                raw: Str(
-                                    Str {
-                                        span: 12..13,
-                                        value: ")",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 12..13,
-                                        value: ")",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                            ],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..2,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..2,
+                                            value: "(",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..2,
+                                            value: "(",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 6..8,
+                                    raw: Str(
+                                        Str {
+                                            span: 6..8,
+                                            value: ", ",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 6..8,
+                                            value: ", ",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 12..13,
+                                    raw: Str(
+                                        Str {
+                                            span: 12..13,
+                                            value: ")",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 12..13,
+                                            value: ")",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-4.snap
@@ -7,29 +7,31 @@ Ok(
         body: [
             Expr {
                 span: 0..16,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..16,
-                        exprs: [],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..15,
-                                raw: Str(
-                                    Str {
-                                        span: 1..15,
-                                        value: "Hello, \"world\"",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..15,
-                                        value: "Hello, \"world\"",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..16,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..15,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..15,
+                                            value: "Hello, \"world\"",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..15,
+                                            value: "Hello, \"world\"",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-5.snap
@@ -7,90 +7,97 @@ Ok(
         body: [
             Expr {
                 span: 0..21,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..21,
-                        exprs: [
-                            TemplateLiteral(
-                                TemplateLiteral {
+                expr: Expr {
+                    span: 0..21,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [
+                                Expr {
                                     span: 7..19,
-                                    exprs: [
-                                        Ident(
-                                            Ident {
-                                                span: 14..17,
-                                                name: "baz",
-                                            },
-                                        ),
-                                    ],
-                                    quasis: [
-                                        TemplateElem {
-                                            span: 8..12,
-                                            raw: Str(
-                                                Str {
+                                    kind: TemplateLiteral(
+                                        TemplateLiteral {
+                                            exprs: [
+                                                Expr {
+                                                    span: 14..17,
+                                                    kind: Ident(
+                                                        Ident {
+                                                            span: 14..17,
+                                                            name: "baz",
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                            quasis: [
+                                                TemplateElem {
                                                     span: 8..12,
-                                                    value: "bar ",
+                                                    raw: Str(
+                                                        Str {
+                                                            span: 8..12,
+                                                            value: "bar ",
+                                                        },
+                                                    ),
+                                                    cooked: Str(
+                                                        Str {
+                                                            span: 8..12,
+                                                            value: "bar ",
+                                                        },
+                                                    ),
                                                 },
-                                            ),
-                                            cooked: Str(
-                                                Str {
-                                                    span: 8..12,
-                                                    value: "bar ",
-                                                },
-                                            ),
-                                        },
-                                        TemplateElem {
-                                            span: 18..18,
-                                            raw: Str(
-                                                Str {
+                                                TemplateElem {
                                                     span: 18..18,
-                                                    value: "",
+                                                    raw: Str(
+                                                        Str {
+                                                            span: 18..18,
+                                                            value: "",
+                                                        },
+                                                    ),
+                                                    cooked: Str(
+                                                        Str {
+                                                            span: 18..18,
+                                                            value: "",
+                                                        },
+                                                    ),
                                                 },
-                                            ),
-                                            cooked: Str(
-                                                Str {
-                                                    span: 18..18,
-                                                    value: "",
-                                                },
-                                            ),
+                                            ],
                                         },
-                                    ],
+                                    ),
                                 },
-                            ),
-                        ],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..5,
-                                raw: Str(
-                                    Str {
-                                        span: 1..5,
-                                        value: "foo ",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..5,
-                                        value: "foo ",
-                                    },
-                                ),
-                            },
-                            TemplateElem {
-                                span: 20..20,
-                                raw: Str(
-                                    Str {
-                                        span: 20..20,
-                                        value: "",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 20..20,
-                                        value: "",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                            ],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..5,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..5,
+                                            value: "foo ",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..5,
+                                            value: "foo ",
+                                        },
+                                    ),
+                                },
+                                TemplateElem {
+                                    span: 20..20,
+                                    raw: Str(
+                                        Str {
+                                            span: 20..20,
+                                            value: "",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 20..20,
+                                            value: "",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-6.snap
@@ -7,29 +7,31 @@ Ok(
         body: [
             Expr {
                 span: 0..24,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..24,
-                        exprs: [],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..23,
-                                raw: Str(
-                                    Str {
-                                        span: 1..23,
-                                        value: "line 1\\nline 2\\nline 3",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..23,
-                                        value: "line 1\nline 2\nline 3",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..24,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..23,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..23,
+                                            value: "line 1\\nline 2\\nline 3",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..23,
+                                            value: "line 1\nline 2\nline 3",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals-7.snap
@@ -7,29 +7,31 @@ Ok(
         body: [
             Expr {
                 span: 0..12,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..12,
-                        exprs: [],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..11,
-                                raw: Str(
-                                    Str {
-                                        span: 1..11,
-                                        value: "a \\u2212 b",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..11,
-                                        value: "a − b",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..12,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..11,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..11,
+                                            value: "a \\u2212 b",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..11,
+                                            value: "a − b",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__template_literals.snap
@@ -7,29 +7,31 @@ Ok(
         body: [
             Expr {
                 span: 0..14,
-                expr: TemplateLiteral(
-                    TemplateLiteral {
-                        span: 0..14,
-                        exprs: [],
-                        quasis: [
-                            TemplateElem {
-                                span: 1..13,
-                                raw: Str(
-                                    Str {
-                                        span: 1..13,
-                                        value: "Hello, world",
-                                    },
-                                ),
-                                cooked: Str(
-                                    Str {
-                                        span: 1..13,
-                                        value: "Hello, world",
-                                    },
-                                ),
-                            },
-                        ],
-                    },
-                ),
+                expr: Expr {
+                    span: 0..14,
+                    kind: TemplateLiteral(
+                        TemplateLiteral {
+                            exprs: [],
+                            quasis: [
+                                TemplateElem {
+                                    span: 1..13,
+                                    raw: Str(
+                                        Str {
+                                            span: 1..13,
+                                            value: "Hello, world",
+                                        },
+                                    ),
+                                    cooked: Str(
+                                        Str {
+                                            span: 1..13,
+                                            value: "Hello, world",
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_expressions-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_expressions-2.snap
@@ -7,25 +7,31 @@ Ok(
         body: [
             Expr {
                 span: 0..4,
-                expr: Lit(
-                    Num(
-                        Num {
-                            span: 0..3,
-                            value: "123",
-                        },
+                expr: Expr {
+                    span: 0..3,
+                    kind: Lit(
+                        Num(
+                            Num {
+                                span: 0..3,
+                                value: "123",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
             Expr {
                 span: 5..13,
-                expr: Lit(
-                    Str(
-                        Str {
-                            span: 5..12,
-                            value: "hello",
-                        },
+                expr: Expr {
+                    span: 5..12,
+                    kind: Lit(
+                        Str(
+                            Str {
+                                span: 5..12,
+                                value: "hello",
+                            },
+                        ),
                     ),
-                ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_expressions.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_expressions.snap
@@ -7,24 +7,32 @@ Ok(
         body: [
             Expr {
                 span: 0..6,
-                expr: BinaryExpr(
-                    BinaryExpr {
-                        span: 0..5,
-                        op: Add,
-                        left: Ident(
-                            Ident {
+                expr: Expr {
+                    span: 0..5,
+                    kind: BinaryExpr(
+                        BinaryExpr {
+                            op: Add,
+                            left: Expr {
                                 span: 0..1,
-                                name: "a",
+                                kind: Ident(
+                                    Ident {
+                                        span: 0..1,
+                                        name: "a",
+                                    },
+                                ),
                             },
-                        ),
-                        right: Ident(
-                            Ident {
+                            right: Expr {
                                 span: 4..5,
-                                name: "b",
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..5,
+                                        name: "b",
+                                    },
+                                ),
                             },
-                        ),
-                    },
-                ),
+                        },
+                    ),
+                },
             },
         ],
     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-2.snap
@@ -18,46 +18,57 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 8..17,
-                            elems: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 9..10,
-                                                value: "1",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 12..13,
-                                                value: "2",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 15..16,
-                                                value: "3",
-                                            },
-                                        ),
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                    Expr {
+                        span: 8..17,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 9..10,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 9..10,
+                                                        value: "1",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 12..13,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 12..13,
+                                                        value: "2",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 15..16,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 15..16,
+                                                        value: "3",
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-3.snap
@@ -18,52 +18,65 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 8..19,
-                            elems: [
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Lit(
-                                        Num(
-                                            Num {
-                                                span: 9..10,
-                                                value: "1",
-                                            },
-                                        ),
-                                    ),
-                                },
-                                ExprOrSpread {
-                                    spread: None,
-                                    expr: Tuple(
-                                        Tuple {
-                                            span: 12..18,
-                                            elems: [
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Ident(
-                                                        Ident {
-                                                            span: 13..14,
-                                                            name: "a",
-                                                        },
-                                                    ),
-                                                },
-                                                ExprOrSpread {
-                                                    spread: None,
-                                                    expr: Ident(
-                                                        Ident {
-                                                            span: 16..17,
-                                                            name: "b",
-                                                        },
-                                                    ),
-                                                },
-                                            ],
+                    Expr {
+                        span: 8..19,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 9..10,
+                                            kind: Lit(
+                                                Num(
+                                                    Num {
+                                                        span: 9..10,
+                                                        value: "1",
+                                                    },
+                                                ),
+                                            ),
                                         },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                                    },
+                                    ExprOrSpread {
+                                        spread: None,
+                                        expr: Expr {
+                                            span: 12..18,
+                                            kind: Tuple(
+                                                Tuple {
+                                                    elems: [
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                span: 13..14,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 13..14,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                        ExprOrSpread {
+                                                            spread: None,
+                                                            expr: Expr {
+                                                                span: 16..17,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 16..17,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    },
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples-4.snap
@@ -18,40 +18,50 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..22,
-                            params: [],
-                            body: Tuple(
-                                Tuple {
+                    Expr {
+                        span: 10..22,
+                        kind: Lambda(
+                            Lambda {
+                                params: [],
+                                body: Expr {
                                     span: 16..22,
-                                    elems: [
-                                        ExprOrSpread {
-                                            spread: None,
-                                            expr: Ident(
-                                                Ident {
-                                                    span: 17..18,
-                                                    name: "a",
+                                    kind: Tuple(
+                                        Tuple {
+                                            elems: [
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Expr {
+                                                        span: 17..18,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 17..18,
+                                                                name: "a",
+                                                            },
+                                                        ),
+                                                    },
                                                 },
-                                            ),
-                                        },
-                                        ExprOrSpread {
-                                            spread: None,
-                                            expr: Ident(
-                                                Ident {
-                                                    span: 20..21,
-                                                    name: "b",
+                                                ExprOrSpread {
+                                                    spread: None,
+                                                    expr: Expr {
+                                                        span: 20..21,
+                                                        kind: Ident(
+                                                            Ident {
+                                                                span: 20..21,
+                                                                name: "b",
+                                                            },
+                                                        ),
+                                                    },
                                                 },
-                                            ),
+                                            ],
                                         },
-                                    ],
+                                    ),
                                 },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: None,
-                        },
-                    ),
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__tuples.snap
@@ -18,12 +18,14 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 8..10,
-                            elems: [],
-                        },
-                    ),
+                    Expr {
+                        span: 8..10,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-2.snap
@@ -25,14 +25,17 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Lit(
-                        Str(
-                            Str {
-                                span: 18..25,
-                                value: "hello",
-                            },
+                    Expr {
+                        span: 18..25,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    span: 18..25,
+                                    value: "hello",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-3.snap
@@ -18,83 +18,93 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 10..49,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 11..12,
-                                            id: Ident {
+                    Expr {
+                        span: 10..49,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 11..12,
-                                                name: "a",
-                                            },
-                                        },
-                                    ),
-                                    type_ann: Some(
-                                        Prim(
-                                            PrimType {
-                                                span: 14..20,
-                                                prim: Num,
+                                                id: Ident {
+                                                    span: 11..12,
+                                                    name: "a",
+                                                },
                                             },
                                         ),
-                                    ),
-                                    optional: false,
-                                    mutable: false,
-                                },
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 22..23,
-                                            id: Ident {
-                                                span: 22..23,
-                                                name: "b",
-                                            },
-                                        },
-                                    ),
-                                    type_ann: Some(
-                                        Prim(
-                                            PrimType {
-                                                span: 25..31,
-                                                prim: Num,
-                                            },
+                                        type_ann: Some(
+                                            Prim(
+                                                PrimType {
+                                                    span: 14..20,
+                                                    prim: Num,
+                                                },
+                                            ),
                                         ),
-                                    ),
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: BinaryExpr(
-                                BinaryExpr {
-                                    span: 44..49,
-                                    op: Add,
-                                    left: Ident(
-                                        Ident {
-                                            span: 44..45,
-                                            name: "a",
-                                        },
-                                    ),
-                                    right: Ident(
-                                        Ident {
-                                            span: 48..49,
-                                            name: "b",
-                                        },
-                                    ),
-                                },
-                            ),
-                            is_async: false,
-                            return_type: Some(
-                                Prim(
-                                    PrimType {
-                                        span: 34..40,
-                                        prim: Num,
+                                        optional: false,
+                                        mutable: false,
                                     },
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
+                                                span: 22..23,
+                                                id: Ident {
+                                                    span: 22..23,
+                                                    name: "b",
+                                                },
+                                            },
+                                        ),
+                                        type_ann: Some(
+                                            Prim(
+                                                PrimType {
+                                                    span: 25..31,
+                                                    prim: Num,
+                                                },
+                                            ),
+                                        ),
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 44..49,
+                                    kind: BinaryExpr(
+                                        BinaryExpr {
+                                            op: Add,
+                                            left: Expr {
+                                                span: 44..45,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 44..45,
+                                                        name: "a",
+                                                    },
+                                                ),
+                                            },
+                                            right: Expr {
+                                                span: 48..49,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 48..49,
+                                                        name: "b",
+                                                    },
+                                                ),
+                                            },
+                                        },
+                                    ),
+                                },
+                                is_async: false,
+                                return_type: Some(
+                                    Prim(
+                                        PrimType {
+                                            span: 34..40,
+                                            prim: Num,
+                                        },
+                                    ),
                                 ),
-                            ),
-                            type_params: None,
-                        },
-                    ),
+                                type_params: None,
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-4.snap
@@ -26,45 +26,51 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Obj(
-                        Obj {
-                            span: 15..28,
-                            props: [
-                                Prop(
-                                    KeyValue(
-                                        KeyValueProp {
-                                            span: 16..20,
-                                            name: "x",
-                                            value: Lit(
-                                                Num(
-                                                    Num {
-                                                        span: 19..20,
-                                                        value: "5",
-                                                    },
-                                                ),
-                                            ),
-                                        },
+                    Expr {
+                        span: 15..28,
+                        kind: Obj(
+                            Obj {
+                                props: [
+                                    Prop(
+                                        KeyValue(
+                                            KeyValueProp {
+                                                name: "x",
+                                                value: Expr {
+                                                    span: 19..20,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 19..20,
+                                                                value: "5",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
                                     ),
-                                ),
-                                Prop(
-                                    KeyValue(
-                                        KeyValueProp {
-                                            span: 22..27,
-                                            name: "y",
-                                            value: Lit(
-                                                Num(
-                                                    Num {
-                                                        span: 25..27,
-                                                        value: "10",
-                                                    },
-                                                ),
-                                            ),
-                                        },
+                                    Prop(
+                                        KeyValue(
+                                            KeyValueProp {
+                                                name: "y",
+                                                value: Expr {
+                                                    span: 25..27,
+                                                    kind: Lit(
+                                                        Num(
+                                                            Num {
+                                                                span: 25..27,
+                                                                value: "10",
+                                                            },
+                                                        ),
+                                                    ),
+                                                },
+                                            },
+                                        ),
                                     ),
-                                ),
-                            ],
-                        },
-                    ),
+                                ],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations-5.snap
@@ -27,14 +27,17 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Lit(
-                        Str(
-                            Str {
-                                span: 17..22,
-                                value: "foo",
-                            },
+                    Expr {
+                        span: 17..22,
+                        kind: Lit(
+                            Str(
+                                Str {
+                                    span: 17..22,
+                                    value: "foo",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_annotations.snap
@@ -25,14 +25,17 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Lit(
-                        Num(
-                            Num {
-                                span: 16..17,
-                                value: "5",
-                            },
+                    Expr {
+                        span: 16..17,
+                        kind: Lit(
+                            Num(
+                                Num {
+                                    span: 16..17,
+                                    value: "5",
+                                },
+                            ),
                         ),
-                    ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-8.snap
@@ -15,12 +15,15 @@ Ok(
                 type_ann: Query(
                     QueryType {
                         span: 11..21,
-                        expr: Ident(
-                            Ident {
-                                span: 18..21,
-                                name: "foo",
-                            },
-                        ),
+                        expr: Expr {
+                            span: 18..21,
+                            kind: Ident(
+                                Ident {
+                                    span: 18..21,
+                                    name: "foo",
+                                },
+                            ),
+                        },
                     },
                 ),
                 type_params: None,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-9.snap
@@ -15,23 +15,28 @@ Ok(
                 type_ann: Query(
                     QueryType {
                         span: 14..28,
-                        expr: Member(
-                            Member {
-                                span: 21..28,
-                                obj: Ident(
-                                    Ident {
+                        expr: Expr {
+                            span: 21..28,
+                            kind: Member(
+                                Member {
+                                    obj: Expr {
                                         span: 21..24,
-                                        name: "foo",
+                                        kind: Ident(
+                                            Ident {
+                                                span: 21..24,
+                                                name: "foo",
+                                            },
+                                        ),
                                     },
-                                ),
-                                prop: Ident(
-                                    Ident {
-                                        span: 25..28,
-                                        name: "bar",
-                                    },
-                                ),
-                            },
-                        ),
+                                    prop: Ident(
+                                        Ident {
+                                            span: 25..28,
+                                            name: "bar",
+                                        },
+                                    ),
+                                },
+                            ),
+                        },
                     },
                 ),
                 type_params: None,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-3.snap
@@ -30,12 +30,14 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 24..26,
-                            elems: [],
-                        },
-                    ),
+                    Expr {
+                        span: 24..26,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-4.snap
@@ -37,12 +37,14 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 37..39,
-                            elems: [],
-                        },
-                    ),
+                    Expr {
+                        span: 37..39,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-5.snap
@@ -48,12 +48,14 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 31..33,
-                            elems: [],
-                        },
-                    ),
+                    Expr {
+                        span: 31..33,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-7.snap
@@ -35,12 +35,14 @@ Ok(
                     ),
                 ),
                 init: Some(
-                    Tuple(
-                        Tuple {
-                            span: 29..31,
-                            elems: [],
-                        },
-                    ),
+                    Expr {
+                        span: 29..31,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types.snap
@@ -18,77 +18,84 @@ Ok(
                 ),
                 type_ann: None,
                 init: Some(
-                    Lambda(
-                        Lambda {
-                            span: 14..41,
-                            params: [
-                                EFnParam {
-                                    pat: Ident(
-                                        EFnParamBindingIdent {
-                                            span: 18..21,
-                                            id: Ident {
+                    Expr {
+                        span: 14..41,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Ident(
+                                            EFnParamBindingIdent {
                                                 span: 18..21,
-                                                name: "foo",
-                                            },
-                                        },
-                                    ),
-                                    type_ann: Some(
-                                        TypeRef(
-                                            TypeRef {
-                                                span: 23..29,
-                                                name: "Foo",
-                                                type_args: Some(
-                                                    [
-                                                        TypeRef(
-                                                            TypeRef {
-                                                                span: 27..28,
-                                                                name: "T",
-                                                                type_args: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                ),
+                                                id: Ident {
+                                                    span: 18..21,
+                                                    name: "foo",
+                                                },
                                             },
                                         ),
-                                    ),
-                                    optional: false,
-                                    mutable: false,
-                                },
-                            ],
-                            body: Member(
-                                Member {
-                                    span: 34..41,
-                                    obj: Ident(
-                                        Ident {
-                                            span: 34..37,
-                                            name: "foo",
-                                        },
-                                    ),
-                                    prop: Ident(
-                                        Ident {
-                                            span: 38..41,
-                                            name: "bar",
-                                        },
-                                    ),
-                                },
-                            ),
-                            is_async: false,
-                            return_type: None,
-                            type_params: Some(
-                                [
-                                    TypeParam {
-                                        span: 15..16,
-                                        name: Ident {
-                                            span: 15..16,
-                                            name: "T",
-                                        },
-                                        constraint: None,
-                                        default: None,
+                                        type_ann: Some(
+                                            TypeRef(
+                                                TypeRef {
+                                                    span: 23..29,
+                                                    name: "Foo",
+                                                    type_args: Some(
+                                                        [
+                                                            TypeRef(
+                                                                TypeRef {
+                                                                    span: 27..28,
+                                                                    name: "T",
+                                                                    type_args: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                    ),
+                                                },
+                                            ),
+                                        ),
+                                        optional: false,
+                                        mutable: false,
                                     },
                                 ],
-                            ),
-                        },
-                    ),
+                                body: Expr {
+                                    span: 34..41,
+                                    kind: Member(
+                                        Member {
+                                            obj: Expr {
+                                                span: 34..37,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 34..37,
+                                                        name: "foo",
+                                                    },
+                                                ),
+                                            },
+                                            prop: Ident(
+                                                Ident {
+                                                    span: 38..41,
+                                                    name: "bar",
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: Some(
+                                    [
+                                        TypeParam {
+                                            span: 15..16,
+                                            name: Ident {
+                                                span: 15..16,
+                                                name: "T",
+                                            },
+                                            constraint: None,
+                                            default: None,
+                                        },
+                                    ],
+                                ),
+                            },
+                        ),
+                    },
                 ),
                 declare: false,
             },


### PR DESCRIPTION
I'd like to add an `inferred_type` prop on all expressions that gets filled in as the types get inferred.  Making `Expr` a struct will make this much easier in the future.