### PR TITLE
Indexed access should always return T | undefined

### DIFF
--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -173,7 +173,7 @@ fn infer_index_value_on_interface() {
     let ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
     let result = format!("{}", ctx.lookup_value("num").unwrap());
-    assert_eq!(result, "number");
+    assert_eq!(result, "number | undefined");
     let result = format!("{}", ctx.lookup_value("bool").unwrap());
     assert_eq!(result, "boolean");
 }
@@ -203,7 +203,10 @@ fn infer_generic_index_value_on_interface() {
     let ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
     let result = format!("{}", ctx.lookup_value("id").unwrap());
-    assert_eq!(result, "<t0>(arg: t0) => t0");
+    // This test currently fails.  The result it returns is `(arg: t0) => t0 | undefined`,
+    // but this is wrong b/c the qualifiers have been removed.  This is because union types
+    // don't support qualifiers.  Also, the type should be printed as `(<t0>(arg: t0) => t0) | undefined`
+    assert_eq!(result, "<t0>(arg: t0) => t0 | undefined");
 }
 
 #[test]

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -203,10 +203,9 @@ fn infer_generic_index_value_on_interface() {
     let ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
     let result = format!("{}", ctx.lookup_value("id").unwrap());
-    // This test currently fails.  The result it returns is `(arg: t0) => t0 | undefined`,
-    // but this is wrong b/c the qualifiers have been removed.  This is because union types
-    // don't support qualifiers.  Also, the type should be printed as `(<t0>(arg: t0) => t0) | undefined`
-    assert_eq!(result, "<t0>(arg: t0) => t0 | undefined");
+    // NOTE: The type variables aren't normalized.  See comment inside
+    // norm_type() in crochet_infer/src/util.rs.
+    assert_eq!(result, "<t1>(arg: t1) => t1 | undefined");
 }
 
 #[test]

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -763,8 +763,6 @@ fn get_prop_value(
             match result {
                 Ok((s, t)) => Ok((s, t)),
                 Err(err) => {
-                    // TODO:
-                    // - look for indexers
                     let indexers: Vec<_> = elems
                         .iter()
                         .filter_map(|elem| match elem {
@@ -782,7 +780,11 @@ fn get_prop_value(
                                 let key_s = result?;
                                 let s = compose_subs(&key_s, &prop_s_clone);
                                 // TODO: handle generic indexers
-                                return Ok((s, indexer.t.to_owned()));
+                                // NOTE: Since access any indexer could result in an `undefined`
+                                // we include `| undefined` in the return type here.
+                                let undefined = Type::Keyword(TKeyword::Undefined);
+                                let t = union_types(&indexer.t, &undefined);
+                                return Ok((s, t));
                             }
                         }
                         Err(format!("{prop_t_clone} is an invalid key for object types"))

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1615,6 +1615,21 @@ mod tests {
     }
 
     #[test]
+    fn infer_elem_access_on_array() {
+        let src = r#"
+        type ReadonlyArray<T> = {
+            [key: number]: T;
+        }
+        let array: number[] = [1, 2, 3];
+        let fst = array[0];
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("fst", &ctx), "number | undefined");
+    }
+
+    #[test]
     fn destructure_obj_with_rest() {
         let src = r#"
         declare let point: {x: number, y: number, z?: number};


### PR DESCRIPTION
This a work-in-progress.  Before this can be completed we need to support type qualifiers on all types not just function and object types.  I'll do that work in a separate PR and then rebase this one.