### PR TITLE
Replace `type_params` on Type::Lam and Type::Object with Type::Qualified wrapper

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -400,8 +400,9 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
 pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
     match t {
         Type::Qualified(TQualified { t, .. }) => {
-            // TODO: combine this `type_params` with the one passed in to `build_type`
-            let type_params = build_type_params(t);
+            // TODO: combine the return value from the `build_type_params()` call
+            // with the `type_params` passed into this function.
+            let _ = build_type_params(t);
             build_type(t, type_params)
         }
         Type::Var(id) => {

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -8,7 +8,7 @@ use swc_ecma_codegen::*;
 
 use crochet_ast as ast;
 use crochet_infer::{get_type_params, Context};
-use crochet_types::{self as types, TFnParam, TPat, Type};
+use crochet_types::{self as types, TFnParam, TPat, TQualified, Type};
 
 pub fn codegen_d_ts(program: &ast::Program, ctx: &Context) -> String {
     print_d_ts(&build_d_ts(program, ctx))
@@ -399,6 +399,11 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
 /// from if it exists.
 pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
     match t {
+        Type::Qualified(TQualified { t, .. }) => {
+            // TODO: combine this `type_params` with the one passed in to `build_type`
+            let type_params = build_type_params(t);
+            build_type(t, type_params)
+        }
         Type::Var(id) => {
             let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 .chars()
@@ -519,9 +524,7 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             })
         }
         Type::Ref(types::TRef {
-            name,
-            type_args: type_params,
-            ..
+            name, type_args, ..
         }) => TsType::TsTypeRef(TsTypeRef {
             span: DUMMY_SP,
             type_name: TsEntityName::from(Ident {
@@ -529,7 +532,8 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
                 sym: JsWord::from(name.to_owned()),
                 optional: false,
             }),
-            type_params: type_params.clone().map(|params| TsTypeParamInstantiation {
+            // swc's AST calls these type params when really they're type args
+            type_params: type_args.clone().map(|params| TsTypeParamInstantiation {
                 span: DUMMY_SP,
                 params: params
                     .iter()

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -322,10 +322,7 @@ fn infer_interface_decl(decl: &TsInterfaceDecl, ctx: &Context) -> Result<Type, S
         })
         .collect();
 
-    let t = Type::Object(TObject {
-        elems,
-        type_params: vec![],
-    });
+    let t = Type::Object(TObject { elems });
 
     let t = match &decl.type_params {
         Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx),

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use swc_ecma_ast::*;
 
 use crochet_infer::{get_type_params, set_type_params, Context, Subst, Substitutable};
-use crochet_types::{self as types, TFnParam, TIndexAccess, TLam, TObjElem, TObject, Type};
+use crochet_types::{
+    self as types, TFnParam, TIndexAccess, TLam, TObjElem, TObject, TQualified, Type,
+};
 
 pub fn replace_aliases(t: &Type, type_param_decl: &TsTypeParamDecl, ctx: &Context) -> Type {
     let mut type_params: Vec<i32> = vec![];
@@ -23,6 +25,10 @@ pub fn replace_aliases(t: &Type, type_param_decl: &TsTypeParamDecl, ctx: &Contex
 
 fn replace_aliases_rec(t: &Type, map: &HashMap<String, i32>) -> Type {
     match t {
+        Type::Qualified(TQualified { t, type_params: _ }) => {
+            // TODO: create a new `map` that adds in `type_params`
+            replace_aliases_rec(t, map)
+        }
         Type::Var(_) => t.to_owned(),
         Type::App(types::TApp { args, ret }) => Type::App(types::TApp {
             args: args.iter().map(|t| replace_aliases_rec(t, map)).collect(),

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -177,13 +177,24 @@ impl Context {
     }
 
     pub fn instantiate(&self, t: &Type) -> Type {
-        let type_params = get_type_params(t);
+        match t {
+            Type::Qualified(TQualified { t, type_params }) => {
+                let ids = type_params.iter().map(|id| id.to_owned());
+                let fresh_quals = type_params.iter().map(|_| self.fresh_var());
+                let subs: Subst = ids.zip(fresh_quals).collect();
 
-        let ids = type_params.iter().map(|id| id.to_owned());
-        let fresh_quals = type_params.iter().map(|_| self.fresh_var());
-        let subs: Subst = ids.zip(fresh_quals).collect();
+                t.apply(&subs)
+            }
+            _ => {
+                let type_params = get_type_params(t);
 
-        t.apply(&subs)
+                let ids = type_params.iter().map(|id| id.to_owned());
+                let fresh_quals = type_params.iter().map(|_| self.fresh_var());
+                let subs: Subst = ids.zip(fresh_quals).collect();
+
+                t.apply(&subs)
+            }
+        }
     }
 
     pub fn fresh_id(&self) -> i32 {

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -20,10 +20,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
         mutable: false,
         t: Type::from(Lit::str(String::from("Promise"), 0..0)),
     })];
-    let promise_type = Type::Object(TObject {
-        elems,
-        type_params: vec![],
-    });
+    let promise_type = Type::Object(TObject { elems });
     ctx.insert_type(String::from("Promise"), promise_type);
     // TODO: replace with Class type once it exists
     // We use {_name: "JSXElement"} to differentiate it from other
@@ -34,10 +31,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
         mutable: false,
         t: Type::from(Lit::str(String::from("JSXElement"), 0..0)),
     })];
-    let jsx_element_type = Type::Object(TObject {
-        elems,
-        type_params: vec![],
-    });
+    let jsx_element_type = Type::Object(TObject { elems });
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 
     // We push a scope here so that it's easy to differentiate globals from

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -67,7 +67,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                 &Type::Lam(types::TLam {
                     params: vec![param],
                     ret: Box::from(tv),
-                    type_params: vec![],
                 }),
                 &t,
                 ctx,
@@ -285,7 +284,6 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
             let t = Type::Lam(types::TLam {
                 params: t_params,
                 ret: Box::from(rt_1),
-                type_params: vec![],
             });
 
             let s = compose_many_subs(&ss);

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crochet_ast::*;
-use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, Type};
+use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, TQualified, Type};
 use types::TObjElem;
 
 use super::context::Context;
@@ -198,10 +198,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         });
 
                         let call_type = Type::App(types::TApp {
-                            args: vec![Type::Object(TObject {
-                                elems,
-                                type_params: vec![],
-                            })],
+                            args: vec![Type::Object(TObject { elems })],
                             ret: Box::from(ret_type.clone()),
                         });
 
@@ -396,16 +393,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
 
             let s = compose_many_subs(&ss);
             let t = if spread_types.is_empty() {
-                Type::Object(TObject {
-                    elems,
-                    type_params: vec![],
-                })
+                Type::Object(TObject { elems })
             } else {
                 let mut all_types = spread_types;
-                all_types.push(Type::Object(TObject {
-                    elems,
-                    type_params: vec![],
-                }));
+                all_types.push(Type::Object(TObject { elems }));
                 simplify_intersection(&all_types)
             };
             expr.inferred_type = Some(t.clone());
@@ -567,6 +558,7 @@ fn infer_property_type(
     ctx: &mut Context,
 ) -> Result<(Subst, Type), String> {
     match &obj_t {
+        Type::Qualified(TQualified { t, type_params: _ }) => infer_property_type(t, prop, ctx),
         Type::Object(obj) => get_prop_value(obj, prop, ctx),
         Type::Ref(alias) => {
             let t = ctx.lookup_ref_and_instantiate(alias)?;

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -180,6 +180,7 @@ fn infer_param_pattern_rec(
 
             Ok(Type::Tuple(elems?))
         }
+        // TODO: infer type_params
         EFnParamPat::Object(EFnParamObjectPat { props, .. }) => {
             let mut rest_opt_ty: Option<Type> = None;
             let elems: Vec<types::TObjElem> = props
@@ -236,11 +237,7 @@ fn infer_param_pattern_rec(
                 })
                 .collect();
 
-            let obj_type = Type::Object(TObject {
-                elems,
-                // TODO: infer type_params
-                type_params: vec![],
-            });
+            let obj_type = Type::Object(TObject { elems });
 
             match rest_opt_ty {
                 Some(rest_ty) => Ok(Type::Intersection(vec![obj_type, rest_ty])),

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -116,6 +116,7 @@ fn infer_pattern_rec(
 
             Ok(Type::Tuple(elems?))
         }
+        // TODO: infer type_params
         PatternKind::Object(ObjectPat { props, .. }) => {
             let mut rest_opt_ty: Option<Type> = None;
             let elems: Vec<types::TObjElem> = props
@@ -167,11 +168,7 @@ fn infer_pattern_rec(
                 })
                 .collect();
 
-            let obj_type = Type::Object(TObject {
-                elems,
-                // TODO: infer type_params
-                type_params: vec![],
-            });
+            let obj_type = Type::Object(TObject { elems });
 
             match rest_opt_ty {
                 // TODO: Replace this with a proper Rest/Spread type

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::iter::Iterator;
 
 use crochet_ast::*;
-use crochet_types::{self as types, TFnParam, TIndex, TKeyword, TLam, TObject, TProp, Type};
+use crochet_types::{self as types, TFnParam, TIndex, TKeyword, TObject, TProp, Type};
 use types::TObjElem;
 
+use crate::set_type_params;
 use crate::util::compose_many_subs;
 use crate::Subst;
 use crate::Substitutable;
@@ -59,11 +60,12 @@ pub fn infer_qualified_type_ann(
         .collect();
 
     // set type_params
-    let t = match type_ann_t {
-        Type::Lam(lam) => Type::Lam(TLam { type_params, ..lam }),
-        Type::Object(obj) => Type::Object(TObject { type_params, ..obj }),
-        _ => type_ann_t,
-    };
+    let t = set_type_params(&type_ann_t, &type_params);
+    // let t = match type_ann_t {
+    //     Type::Lam(lam) => Type::Lam(TLam { type_params, ..lam }),
+    //     Type::Object(obj) => Type::Object(TObject { type_params, ..obj }),
+    //     _ => type_ann_t,
+    // };
     Ok((type_ann_s, t))
 }
 
@@ -162,10 +164,7 @@ fn infer_type_ann_rec(
             }
 
             let s = compose_many_subs(&ss);
-            let t = Type::Object(TObject {
-                elems,
-                type_params: vec![],
-            });
+            let t = Type::Object(TObject { elems });
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
         }
@@ -293,10 +292,7 @@ fn infer_property_type(
     ctx: &mut Context,
 ) -> Result<(Subst, Type), String> {
     match &obj_t {
-        Type::Object(TObject {
-            elems,
-            type_params: _,
-        }) => match index_t {
+        Type::Object(TObject { elems }) => match index_t {
             Type::Ref(alias) => {
                 let t = ctx.lookup_ref_and_instantiate(alias)?;
                 infer_property_type(obj_t, &t, ctx)

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -60,13 +60,9 @@ pub fn infer_qualified_type_ann(
         .collect();
 
     // set type_params
+    let s = type_ann_s;
     let t = set_type_params(&type_ann_t, &type_params);
-    // let t = match type_ann_t {
-    //     Type::Lam(lam) => Type::Lam(TLam { type_params, ..lam }),
-    //     Type::Object(obj) => Type::Object(TObject { type_params, ..obj }),
-    //     _ => type_ann_t,
-    // };
-    Ok((type_ann_s, t))
+    Ok((s, t))
 }
 
 pub fn infer_type_ann_with_params(
@@ -103,11 +99,7 @@ fn infer_type_ann_rec(
             ss.push(ret_s);
 
             let s = compose_many_subs(&ss);
-            let t = Type::Lam(types::TLam {
-                params,
-                ret,
-                type_params: vec![],
-            });
+            let t = Type::Lam(types::TLam { params, ret });
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
         }

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -5,7 +5,7 @@ use crochet_types::{TKeyword, TLit, TObjElem, TObject, TQualified, Type};
 // TODO: try to dedupe with infer_property_type()
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
     match t {
-        Type::Qualified(TQualified { t, type_params: _ }) => key_of(&t, ctx),
+        Type::Qualified(TQualified { t, type_params: _ }) => key_of(t, ctx),
         Type::Var(_) => Err(String::from(
             "There isn't a way to infer a type from its keys",
         )),
@@ -13,10 +13,7 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
             let t = ctx.lookup_ref_and_instantiate(alias)?;
             key_of(&t, ctx)
         }
-        Type::Object(TObject {
-            elems,
-            type_params: _,
-        }) => {
+        Type::Object(TObject { elems }) => {
             let elems: Vec<_> = elems
                 .iter()
                 .filter_map(|elem| match elem {

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -1,10 +1,11 @@
 use super::context::Context;
 use super::util::union_many_types;
-use crochet_types::{TKeyword, TLit, TObjElem, TObject, Type};
+use crochet_types::{TKeyword, TLit, TObjElem, TObject, TQualified, Type};
 
 // TODO: try to dedupe with infer_property_type()
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
     match t {
+        Type::Qualified(TQualified { t, type_params: _ }) => key_of(&t, ctx),
         Type::Var(_) => Err(String::from(
             "There isn't a way to infer a type from its keys",
         )),

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -132,7 +132,6 @@ Program {
                                 ret: Keyword(
                                     Number,
                                 ),
-                                type_params: [],
                             },
                         ),
                     ),

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -13,6 +13,20 @@ pub trait Substitutable {
 impl Substitutable for Type {
     fn apply(&self, sub: &Subst) -> Type {
         let result = match self {
+            Type::Qualified(TQualified { t, type_params }) => {
+                // QUESTION: Do we really need to be filtering out type_params from
+                // substitutions?
+                let type_params = type_params
+                    .iter()
+                    .filter(|tp| !sub.contains_key(tp))
+                    .cloned()
+                    .collect();
+
+                Type::Qualified(TQualified {
+                    t: Box::from(t.as_ref().apply(sub)),
+                    type_params,
+                })
+            }
             Type::Var(id) => match sub.get(id) {
                 Some(replacement) => replacement.to_owned(),
                 None => self.to_owned(),
@@ -60,6 +74,10 @@ impl Substitutable for Type {
     }
     fn ftv(&self) -> HashSet<i32> {
         match self {
+            Type::Qualified(TQualified { t, type_params }) => {
+                let qualifiers: HashSet<_> = type_params.iter().map(|id| id.to_owned()).collect();
+                t.ftv().difference(&qualifiers).cloned().collect()
+            }
             Type::Var(id) => HashSet::from([id.to_owned()]),
             Type::App(TApp { args, ret }) => {
                 let mut result: HashSet<_> = args.ftv();

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -123,6 +123,20 @@ impl Substitutable for TObjElem {
 
 impl Substitutable for TLam {
     fn apply(&self, sub: &Subst) -> Self {
+        Self {
+            params: self.params.iter().map(|param| param.apply(sub)).collect(),
+            ret: Box::from(self.ret.apply(sub)),
+        }
+    }
+    fn ftv(&self) -> HashSet<i32> {
+        let mut result: HashSet<_> = self.params.ftv();
+        result.extend(self.ret.ftv());
+        result
+    }
+}
+
+impl Substitutable for TCallable {
+    fn apply(&self, sub: &Subst) -> Self {
         // QUESTION: Do we really need to be filtering out type_params from
         // substitutions?
         let type_params = self
@@ -132,7 +146,7 @@ impl Substitutable for TLam {
             .cloned()
             .collect();
 
-        TLam {
+        Self {
             params: self.params.iter().map(|param| param.apply(sub)).collect(),
             ret: Box::from(self.ret.apply(sub)),
             type_params,
@@ -160,7 +174,7 @@ impl Substitutable for TIndex {
 }
 
 impl Substitutable for TProp {
-    fn apply(&self, sub: &Subst) -> TProp {
+    fn apply(&self, sub: &Subst) -> Self {
         TProp {
             t: self.t.apply(sub),
             ..self.to_owned()
@@ -172,7 +186,7 @@ impl Substitutable for TProp {
 }
 
 impl Substitutable for TFnParam {
-    fn apply(&self, sub: &Subst) -> TFnParam {
+    fn apply(&self, sub: &Subst) -> Self {
         TFnParam {
             t: self.t.apply(sub),
             ..self.to_owned()

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -11,6 +11,7 @@ use super::util::*;
 
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
 pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
+    println!("attempting to unify {t1:#?} with {t2:#?}");
     let result = match (&t1, &t2) {
         // All binding must be done first
         (Type::Var(id), _) => bind(id, t2),
@@ -387,24 +388,10 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                             })
                         });
 
-                    let s1 = unify(
-                        &Type::Object(TObject {
-                            elems: obj_elems,
-                            type_params: vec![],
-                        }),
-                        &obj_type,
-                        ctx,
-                    )?;
+                    let s1 = unify(&Type::Object(TObject { elems: obj_elems }), &obj_type, ctx)?;
 
                     let rest_type = rest_types.get(0).unwrap();
-                    let s2 = unify(
-                        &Type::Object(TObject {
-                            elems: rest_elems,
-                            type_params: vec![],
-                        }),
-                        rest_type,
-                        ctx,
-                    )?;
+                    let s2 = unify(&Type::Object(TObject { elems: rest_elems }), rest_type, ctx)?;
 
                     let s = compose_subs(&s2, &s1);
                     Ok(s)
@@ -446,24 +433,11 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                             })
                         });
 
-                    let s_obj = unify(
-                        &obj_type,
-                        &Type::Object(TObject {
-                            elems: obj_elems,
-                            type_params: vec![],
-                        }),
-                        ctx,
-                    )?;
+                    let s_obj = unify(&obj_type, &Type::Object(TObject { elems: obj_elems }), ctx)?;
 
                     let rest_type = rest_types.get(0).unwrap();
-                    let s_rest = unify(
-                        rest_type,
-                        &Type::Object(TObject {
-                            elems: rest_elems,
-                            type_params: vec![],
-                        }),
-                        ctx,
-                    )?;
+                    let s_rest =
+                        unify(rest_type, &Type::Object(TObject { elems: rest_elems }), ctx)?;
 
                     let s = compose_subs(&s_rest, &s_obj);
                     Ok(s)
@@ -644,10 +618,7 @@ mod tests {
                 t: Type::Keyword(TKeyword::String),
             }),
         ];
-        let t1 = Type::Object(TObject {
-            elems,
-            type_params: vec![],
-        });
+        let t1 = Type::Object(TObject { elems });
 
         let elems = vec![
             types::TObjElem::Prop(types::TProp {
@@ -671,10 +642,7 @@ mod tests {
                 t: Type::Keyword(TKeyword::String),
             }),
         ];
-        let t2 = Type::Object(TObject {
-            elems,
-            type_params: vec![],
-        });
+        let t2 = Type::Object(TObject { elems });
 
         let result = unify(&t1, &t2, &ctx);
         assert_eq!(result, Ok(Subst::default()));

--- a/crates/crochet_types/src/lam.rs
+++ b/crates/crochet_types/src/lam.rs
@@ -10,7 +10,6 @@ use crate::r#type::Type;
 pub struct TLam {
     pub params: Vec<TFnParam>,
     pub ret: Box<Type>,
-    pub type_params: Vec<i32>,
 }
 
 impl PartialEq for TLam {
@@ -28,23 +27,8 @@ impl Hash for TLam {
 
 impl fmt::Display for TLam {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Self {
-            params,
-            ret,
-            type_params,
-        } = self;
-        if type_params.is_empty() {
-            write!(f, "({}) => {}", join(params, ", "), ret)
-        } else {
-            let type_params = type_params.iter().map(|tp| format!("t{tp}"));
-            write!(
-                f,
-                "<{}>({}) => {}",
-                join(type_params, ", "),
-                join(params, ", "),
-                ret
-            )
-        }
+        let Self { params, ret } = self;
+        write!(f, "({}) => {}", join(params, ", "), ret)
     }
 }
 

--- a/crates/crochet_types/src/obj.rs
+++ b/crates/crochet_types/src/obj.rs
@@ -1,13 +1,42 @@
+use itertools::join;
 use std::fmt;
 
-use crate::lam::TLam;
 use crate::r#type::Type;
 use crate::TFnParam;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TCallable {
+    pub params: Vec<TFnParam>,
+    pub ret: Box<Type>,
+    pub type_params: Vec<i32>,
+}
+
+impl fmt::Display for TCallable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let Self {
+            params,
+            ret,
+            type_params,
+        } = self;
+        if type_params.is_empty() {
+            write!(f, "({}) => {}", join(params, ", "), ret)
+        } else {
+            let type_params = type_params.iter().map(|tp| format!("t{tp}"));
+            write!(
+                f,
+                "<{}>({}) => {}",
+                join(type_params, ", "),
+                join(params, ", "),
+                ret
+            )
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum TObjElem {
-    Call(TLam),
-    Constructor(TLam),
+    Call(TCallable),
+    Constructor(TCallable),
     Index(TIndex),
     Prop(TProp),
     // Getter

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -47,6 +47,12 @@ pub struct TIndexAccess {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TQualified {
+    pub t: Box<Type>,
+    pub type_params: Vec<i32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type {
     Var(i32), // i32 is the if of the type variable
     App(TApp),
@@ -64,6 +70,7 @@ pub enum Type {
     This,
     KeyOf(Box<Type>),
     IndexAccess(TIndexAccess),
+    Qualified(TQualified),
 }
 
 impl From<TLit> for Type {
@@ -75,7 +82,10 @@ impl From<TLit> for Type {
 impl fmt::Display for Type {
     // TODO: add in parentheses where necessary to get the precedence right
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self {
+        match self {
+            Type::Qualified(TQualified { t, type_params }) => {
+                write!(f, "<{}>{{{}}}", join(type_params, ", "), t)
+            }
             Type::Var(id) => write!(f, "t{id}"),
             Type::App(TApp { args, ret }) => {
                 write!(f, "({}) => {}", join(args, ", "), ret)

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -37,7 +37,6 @@ impl Hash for TRef {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TObject {
     pub elems: Vec<TObjElem>,
-    pub type_params: Vec<i32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -84,7 +83,15 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Type::Qualified(TQualified { t, type_params }) => {
-                write!(f, "<{}>{{{}}}", join(type_params, ", "), t)
+                if type_params.is_empty() {
+                    write!(f, "{t}")
+                } else {
+                    let params: Vec<_> = type_params
+                        .iter()
+                        .map(|param| format!("t{param}"))
+                        .collect();
+                    write!(f, "<{}>{t}", join(params, ", "))
+                }
             }
             Type::Var(id) => write!(f, "t{id}"),
             Type::App(TApp { args, ret }) => {
@@ -101,15 +108,8 @@ impl fmt::Display for Type {
                 let strings: Vec<_> = types.iter().map(|t| format!("{t}")).sorted().collect();
                 write!(f, "{}", join(strings, " & "))
             }
-            Type::Object(TObject {
-                elems, type_params, ..
-            }) => {
-                if type_params.is_empty() {
-                    write!(f, "{{{}}}", join(elems, ", "))
-                } else {
-                    let params = type_params.iter().map(|p| format!("t{p}"));
-                    write!(f, "<{}>{{{}}}", join(params, ", "), join(elems, ", "))
-                }
+            Type::Object(TObject { elems, .. }) => {
+                write!(f, "{{{}}}", join(elems, ", "))
             }
             Type::Ref(TRef {
                 name,


### PR DESCRIPTION
Really any type can contain type variables and thus could become qualified as a result of generalization (if it appears at the top-level).  This is basically a reformulation of the `Scheme` type that we had before.  The main difference is that qualified types are types and as such can appear within a `Type` data structure whereas `Scheme`s could only appear at the top.  The reason we couldn't use `Scheme` is that TypeScript interfaces can be qualified, but also contain other types which themselves are qualified, e.g. a method that is generic.  In these situations, we don't want to hoist type params from every generic method up to live on the interface itself.  `Type::Qualified` addresses this situation by allowing type params to be specified at different levels with in a type.