### PR TITLE
Simplify crochet infer

### DIFF
--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -867,8 +867,8 @@ fn infer_fn_param_with_type_alias_with_param_2() {
     let (_, ctx) = infer_prog(src);
 
     let result = format!("{}", ctx.lookup_value("get_bar").unwrap());
-    // TODO: normalize the scheme before inserting it into the context
-    insta::assert_snapshot!(result, @"<t2>(foo: Foo<t2>) => t2");
+    // TODO: normalize the type before inserting it into the context
+    insta::assert_snapshot!(result, @"<t0>(foo: Foo<t0>) => t0");
 }
 
 #[test]
@@ -898,6 +898,24 @@ fn infer_fn_param_with_type_alias_with_param_4() {
 
     let result = format!("{}", ctx.lookup_value("bar").unwrap());
     assert_eq!(result, "\"hello\"");
+}
+
+#[test]
+fn infer_generic_type_aliases() {
+    // What's the difference between these two?
+    let src = r#"
+    type Identity1<T> = <T>(foo: T) => T;
+    type Identity2 = <T>(foo: T) => T;
+    "#;
+    let (_, ctx) = infer_prog(src);
+
+    let result = format!("{}", ctx.lookup_type("Identity1").unwrap());
+    // TODO: normalize the type before inserting it into the context
+    insta::assert_snapshot!(result, @"<t0>(foo: t0) => t0");
+
+    let result = format!("{}", ctx.lookup_type("Identity2").unwrap());
+    // TODO: normalize the type before inserting it into the context
+    insta::assert_snapshot!(result, @"<t0>(foo: t0) => t0");
 }
 
 #[test]

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -489,32 +489,29 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             let members: Vec<TsTypeElement> = obj
                 .elems
                 .iter()
-                .map(|elem| {
-                    match elem {
-                        types::TObjElem::Call(_) => todo!(),
-                        types::TObjElem::Constructor(_) => todo!(),
-                        types::TObjElem::Index(_) => todo!(),
-                        types::TObjElem::Prop(prop) => {
-                            TsTypeElement::TsPropertySignature(TsPropertySignature {
+                .map(|elem| match elem {
+                    types::TObjElem::Call(_) => todo!(),
+                    types::TObjElem::Constructor(_) => todo!(),
+                    types::TObjElem::Index(_) => todo!(),
+                    types::TObjElem::Prop(prop) => {
+                        TsTypeElement::TsPropertySignature(TsPropertySignature {
+                            span: DUMMY_SP,
+                            readonly: !prop.mutable,
+                            key: Box::from(Expr::from(Ident {
                                 span: DUMMY_SP,
-                                readonly: !prop.mutable,
-                                key: Box::from(Expr::from(Ident {
-                                    span: DUMMY_SP,
-                                    sym: JsWord::from(prop.name.to_owned()),
-                                    optional: false,
-                                })),
-                                computed: false,
-                                optional: prop.optional,
-                                init: None,
-                                params: vec![],
-                                type_ann: Some(TsTypeAnn {
-                                    span: DUMMY_SP,
-                                    // TODO: add build_type_from_scheme() helper that handles type params
-                                    type_ann: Box::from(build_type(&prop.t, None)),
-                                }),
-                                type_params: None,
-                            })
-                        }
+                                sym: JsWord::from(prop.name.to_owned()),
+                                optional: false,
+                            })),
+                            computed: false,
+                            optional: prop.optional,
+                            init: None,
+                            params: vec![],
+                            type_ann: Some(TsTypeAnn {
+                                span: DUMMY_SP,
+                                type_ann: Box::from(build_type(&prop.t, None)),
+                            }),
+                            type_params: None,
+                        })
                     }
                 })
                 .collect();

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -9,7 +9,7 @@ use swc_ecma_visit::*;
 
 // TODO: have crochet_infer re-export Lit
 use crochet_ast::Lit;
-use crochet_infer::{close_over, generalize_type, normalize, Context, Env, Subst, Substitutable};
+use crochet_infer::{close_over, generalize, normalize, Context, Env, Subst, Substitutable};
 use crochet_types::{self as types, RestPat, TFnParam, TKeyword, TPat, TProp, Type};
 
 use crate::util;
@@ -206,7 +206,7 @@ fn infer_method_sig(sig: &TsMethodSignature, ctx: &Context) -> Result<Type, Stri
     };
 
     // TODO: maintain param names
-    Ok(generalize_type(&HashMap::default(), &t))
+    Ok(generalize(&HashMap::default(), &t))
 }
 
 fn get_key_name(key: &Expr) -> Result<String, String> {
@@ -254,7 +254,7 @@ fn infer_ts_type_element(elem: &TsTypeElement, ctx: &Context) -> Result<TObjElem
                 Some(type_ann) => {
                     // TODO: do a better job of handling this
                     let t = infer_ts_type_ann(&type_ann.type_ann, ctx)?;
-                    let gen_t = generalize_type(&HashMap::default(), &t);
+                    let gen_t = generalize(&HashMap::default(), &t);
                     let name = get_key_name(sig.key.as_ref())?;
                     Ok(TObjElem::Prop(TProp {
                         name,
@@ -276,7 +276,7 @@ fn infer_ts_type_element(elem: &TsTypeElement, ctx: &Context) -> Result<TObjElem
         }
         TsTypeElement::TsMethodSignature(sig) => {
             let t = infer_method_sig(sig, ctx)?;
-            let gen_t = generalize_type(&HashMap::default(), &t);
+            let gen_t = generalize(&HashMap::default(), &t);
             // println!("t = {t}, gen_t = {gen_t}");
             let name = get_key_name(sig.key.as_ref())?;
             Ok(TObjElem::Prop(TProp {
@@ -377,7 +377,7 @@ impl Visit for InterfaceCollector {
                         Some(type_ann) => {
                             // TODO: capture errors and store them in self.errors
                             let t = infer_ts_type_ann(&type_ann.type_ann, &self.ctx).unwrap();
-                            let t = generalize_type(&Env::new(), &t);
+                            let t = generalize(&Env::new(), &t);
                             let name = bi.id.sym.to_string();
                             self.ctx.insert_value(name, t)
                         }

--- a/crates/crochet_infer/src/assump.rs
+++ b/crates/crochet_infer/src/assump.rs
@@ -1,0 +1,6 @@
+use std::collections::HashMap;
+
+use crochet_types::Type;
+
+// NOTE: This is the same as the Env type in context.rs
+pub type Assump = HashMap<String, Type>;

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -4,13 +4,13 @@ use crochet_ast::*;
 use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, TQualified, Type};
 use types::TObjElem;
 
-use super::context::Context;
-use super::infer_fn_param::infer_fn_param;
-use super::infer_pattern::*;
-use super::infer_type_ann::*;
-use super::substitutable::{Subst, Substitutable};
-use super::unify::unify;
-use super::util::*;
+use crate::context::Context;
+use crate::infer_fn_param::infer_fn_param;
+use crate::infer_pattern::*;
+use crate::infer_type_ann::*;
+use crate::substitutable::{Subst, Substitutable};
+use crate::unify::unify;
+use crate::util::*;
 
 pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), String> {
     let result = match &mut expr.kind {
@@ -246,8 +246,8 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
 
                     // Inserts any new variables introduced by infer_fn_param() into
                     // the current context.
-                    for (name, scheme) in pa {
-                        ctx.insert_value(name, scheme);
+                    for (name, t) in pa {
+                        ctx.insert_value(name, t);
                     }
 
                     Ok((ps, t_param))
@@ -532,8 +532,8 @@ fn infer_let(
     // Inserts the new variables from infer_pattern_and_init() into the
     // current context.
     // TODO: have infer_pattern_and_init do this
-    for (name, scheme) in pa {
-        ctx.insert_value(name.to_owned(), scheme.to_owned());
+    for (name, t) in pa {
+        ctx.insert_value(name.to_owned(), t.to_owned());
     }
 
     let (s2, t2) = infer_expr(ctx, body)?;

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -3,14 +3,12 @@ use std::collections::HashMap;
 use crochet_ast::*;
 use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, Type};
 
+use crate::assump::Assump;
+use crate::context::Context;
+use crate::infer_type_ann::*;
+use crate::substitutable::{Subst, Substitutable};
+use crate::unify::unify;
 use crate::util::compose_subs;
-
-use super::context::Context;
-use super::infer_type_ann::*;
-use super::substitutable::{Subst, Substitutable};
-use super::unify::unify;
-
-pub type Assump = HashMap<String, Type>;
 
 // NOTE: The caller is responsible for inserting any new variables introduced
 // into the appropriate context.
@@ -43,7 +41,6 @@ pub fn infer_fn_param(
             // parameters.
             let mut a = new_vars.apply(&s);
 
-            // TODO: handle schemes with type params
             if param.optional {
                 match a.iter().find(|(_, value)| type_ann_t == **value) {
                     Some((name, t)) => {
@@ -65,7 +62,6 @@ pub fn infer_fn_param(
             Ok((s, a, param))
         }
         None => {
-            // TODO: handle schemes with type params
             if param.optional {
                 match new_vars.iter().find(|(_, value)| pat_type == **value) {
                     Some((name, t)) => {

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -3,14 +3,13 @@ use std::collections::HashMap;
 use crochet_ast::*;
 use crochet_types::{self as types, TObject, Type};
 
-use super::context::Context;
-use super::infer_expr::infer_expr;
-use super::infer_type_ann::*;
-use super::substitutable::{Subst, Substitutable};
-use super::unify::unify;
-use super::util::*;
-
-pub type Assump = HashMap<String, Type>;
+use crate::assump::Assump;
+use crate::context::Context;
+use crate::infer_expr::infer_expr;
+use crate::infer_type_ann::*;
+use crate::substitutable::{Subst, Substitutable};
+use crate::unify::unify;
+use crate::util::*;
 
 // NOTE: The caller is responsible for inserting any new variables introduced
 // into the appropriate context.
@@ -84,7 +83,7 @@ fn infer_pattern_rec(
             // TODO: we need a method on Context to get all types that currently in
             // scope so that we can pass them to generalize()
             let all_types = ctx.get_all_types();
-            let t = generalize_type(&all_types, &t);
+            let t = generalize(&all_types, &t);
             if assump.insert(id.name.to_owned(), t.clone()).is_some() {
                 return Err(String::from("Duplicate identifier in pattern"));
             }

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -1,6 +1,7 @@
-use super::context::Context;
-use super::util::union_many_types;
 use crochet_types::{TKeyword, TLit, TObjElem, TObject, TQualified, Type};
+
+use crate::context::Context;
+use crate::util::union_many_types;
 
 // TODO: try to dedupe with infer_property_type()
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1,3 +1,4 @@
+mod assump;
 mod context;
 mod infer_expr;
 mod infer_fn_param;
@@ -14,7 +15,7 @@ pub mod infer;
 pub use context::*;
 pub use infer::*;
 pub use substitutable::{Subst, Substitutable};
-pub use util::{generalize_type, get_type_params, normalize, set_type_params};
+pub use util::{close_over, generalize, get_type_params, normalize, set_type_params};
 
 #[cfg(test)]
 mod tests {
@@ -2061,7 +2062,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "Can't find value type: Bar"]
+    #[should_panic = "Can't find value: Bar"]
     fn jsx_custom_element_not_found() {
         let src = r#"
         let Foo = () => <div>Hello, world!</div>;

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -4,10 +4,10 @@ use std::collections::HashSet;
 use crochet_types::{self as types, TLam, TObjElem, TObject, TQualified, Type};
 use types::TKeyword;
 
-use super::context::Context;
-use super::key_of::key_of;
-use super::substitutable::{Subst, Substitutable};
-use super::util::*;
+use crate::context::Context;
+use crate::key_of::key_of;
+use crate::substitutable::{Subst, Substitutable};
+use crate::util::*;
 
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
 pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -1,7 +1,7 @@
 use crochet_ast::*;
 use crochet_types::Type;
 
-use super::substitutable::{Subst, Substitutable};
+use crate::substitutable::{Subst, Substitutable};
 
 pub fn update_program(prog: &mut Program, s: &Subst) {
     for stmt in prog.body.iter_mut() {

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -4,8 +4,8 @@ use std::iter::Iterator;
 
 use crochet_types::*;
 
-use super::context::{Context, Env};
-use super::substitutable::{Subst, Substitutable};
+use crate::context::{Context, Env};
+use crate::substitutable::{Subst, Substitutable};
 
 fn get_mapping(t: &Type) -> HashMap<i32, Type> {
     let body = t;
@@ -26,6 +26,11 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
     }
 
     mapping
+}
+
+pub fn close_over(s: &Subst, t: &Type, ctx: &Context) -> Type {
+    let empty_env = Env::default();
+    normalize(&generalize(&empty_env, &t.to_owned().apply(s)), ctx)
 }
 
 pub fn normalize(t: &Type, ctx: &Context) -> Type {
@@ -174,7 +179,7 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
     set_type_params(&t, &type_params)
 }
 
-pub fn generalize_type(env: &Env, t: &Type) -> Type {
+pub fn generalize(env: &Env, t: &Type) -> Type {
     // ftv() returns a Set which is not ordered
     // TODO: switch to an ordered set
     let mut type_params = get_type_params(t);


### PR DESCRIPTION
- rename `scheme` to `t` or `type`
- update `infer_prog` to call `close_over()` on the result from `infer_type_ann`
- merge some of the functions in infer_type_ann.rs
- replace `super::` with `crate::`
- other small tweaks