### PR TITLE
Constrained Generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "array_tool"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
+
+[[package]]
 name = "ast_node"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,7 @@ dependencies = [
 name = "crochet_infer"
 version = "0.1.0"
 dependencies = [
+ "array_tool",
  "crochet_ast",
  "crochet_parser",
  "crochet_types",

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -370,8 +370,8 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
             span: DUMMY_SP,
             params: type_params
                 .iter()
-                .map(|id| {
-                    let id = chars.get(id.to_owned() as usize).unwrap();
+                .map(|tv| {
+                    let id = chars.get(tv.id.to_owned() as usize).unwrap();
 
                     TsTypeParam {
                         span: DUMMY_SP,

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -405,7 +405,7 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             let _ = build_type_params(t);
             build_type(t, type_params)
         }
-        Type::Var(TVar { id, quals: _ }) => {
+        Type::Var(TVar { id, constraint: _ }) => {
             let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 .chars()
                 .collect();

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -405,7 +405,7 @@ pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
             let _ = build_type_params(t);
             build_type(t, type_params)
         }
-        Type::Var(TVar { id }) => {
+        Type::Var(TVar { id, quals: _ }) => {
             let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 .chars()
                 .collect();

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -8,7 +8,7 @@ use swc_ecma_codegen::*;
 
 use crochet_ast as ast;
 use crochet_infer::{get_type_params, Context};
-use crochet_types::{self as types, TFnParam, TPat, TQualified, Type};
+use crochet_types::{self as types, TFnParam, TGeneric, TPat, TVar, Type};
 
 pub fn codegen_d_ts(program: &ast::Program, ctx: &Context) -> String {
     print_d_ts(&build_d_ts(program, ctx))
@@ -399,13 +399,13 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
 /// from if it exists.
 pub fn build_type(t: &Type, type_params: Option<TsTypeParamDecl>) -> TsType {
     match t {
-        Type::Qualified(TQualified { t, .. }) => {
+        Type::Generic(TGeneric { t, .. }) => {
             // TODO: combine the return value from the `build_type_params()` call
             // with the `type_params` passed into this function.
             let _ = build_type_params(t);
             build_type(t, type_params)
         }
-        Type::Var(id) => {
+        Type::Var(TVar { id }) => {
             let chars: Vec<_> = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
                 .chars()
                 .collect();

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -482,6 +482,43 @@ fn function_with_optional_param_and_rest_param() {
 }
 
 #[test]
+fn generic_function() {
+    let src = r#"
+    let fst = <T>(a: T, b: T) => a;
+    "#;
+
+    insta::assert_snapshot!(compile(src), @"export const fst = (a, b)=>a;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut ctx = Context::default();
+    infer_prog(&mut program, &mut ctx).unwrap();
+    let result = codegen_d_ts(&program, &ctx);
+
+    insta::assert_snapshot!(result, @"export declare const fst: <A>(a: A, b: A) => A;
+");
+}
+
+#[test]
+#[ignore] // TODO: fix this test case
+fn constrained_generic_function() {
+    let src = r#"
+    let fst = <T extends number | string>(a: T, b: T) => a;
+    "#;
+
+    insta::assert_snapshot!(compile(src), @"export const fst = (a, b)=>a;
+");
+
+    let mut program = parse(src).unwrap();
+    let mut ctx = Context::default();
+    infer_prog(&mut program, &mut ctx).unwrap();
+    let result = codegen_d_ts(&program, &ctx);
+
+    insta::assert_snapshot!(result, @"export declare const fst: (a: number | string, b: number | string) => number | string;
+");
+}
+
+#[test]
 fn variable_declaration_with_destructuring() {
     let src = r#"
     let [x, y] = [5, 10];

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use types::{TCallable, TIndex, TObjElem, TObject};
 
@@ -223,7 +223,7 @@ fn infer_ts_type_element(elem: &TsTypeElement, ctx: &Context) -> Result<TObjElem
             Some(type_ann) => {
                 let params = infer_fn_params(&decl.params, ctx)?;
                 let ret = infer_ts_type_ann(&type_ann.type_ann, ctx)?;
-                let mut qualifiers: HashSet<_> = params.ftv();
+                let mut qualifiers = params.ftv();
                 qualifiers.extend(ret.ftv());
 
                 Ok(TObjElem::Call(TCallable {
@@ -238,7 +238,7 @@ fn infer_ts_type_element(elem: &TsTypeElement, ctx: &Context) -> Result<TObjElem
             Some(type_ann) => {
                 let params = infer_fn_params(&decl.params, ctx)?;
                 let ret = infer_ts_type_ann(&type_ann.type_ann, ctx)?;
-                let mut qualifiers: HashSet<_> = params.ftv();
+                let mut qualifiers = params.ftv();
                 qualifiers.extend(ret.ftv());
 
                 Ok(TObjElem::Constructor(TCallable {

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -21,7 +21,7 @@ pub struct InterfaceCollector {
     pub namespace: Vec<String>,
 }
 
-fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
+pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
     match type_ann {
         TsType::TsKeywordType(keyword) => match &keyword.kind {
             TsKeywordTypeKind::TsAnyKeyword => Ok(ctx.fresh_var()),
@@ -53,7 +53,7 @@ fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, String> {
                 });
 
                 match &fn_type.type_params {
-                    Some(type_param_decl) => Ok(util::replace_aliases(&t, type_param_decl, ctx)),
+                    Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx),
                     None => Ok(t),
                 }
             }
@@ -201,7 +201,7 @@ fn infer_method_sig(sig: &TsMethodSignature, ctx: &Context) -> Result<Type, Stri
     });
 
     let t = match &sig.type_params {
-        Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx),
+        Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx)?,
         None => t,
     };
 
@@ -321,10 +321,11 @@ fn infer_interface_decl(decl: &TsInterfaceDecl, ctx: &Context) -> Result<Type, S
         })
         .collect();
 
+    // TODO: make this generic if the decl has any type params
     let t = Type::Object(TObject { elems });
 
     let t = match &decl.type_params {
-        Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx),
+        Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx)?,
         None => t,
     };
 

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -163,6 +163,7 @@ pub fn merge_types(t1: &Type, t2: &Type) -> Type {
     // Creates a mapping from type params in t2 to those in t1
     let subs: Subst = tp2
         .into_iter()
+        .map(|tv| tv.id.to_owned())
         .zip(tp1.iter().map(|tv| Type::Var(tv.to_owned())))
         .collect();
 

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -7,6 +7,7 @@ use crochet_types::{
     self as types, TCallable, TFnParam, TGeneric, TIndexAccess, TObjElem, TObject, TVar, Type,
 };
 
+// TODO: rename this replace_refs
 pub fn replace_aliases(t: &Type, type_param_decl: &TsTypeParamDecl, ctx: &Context) -> Type {
     let mut type_params: Vec<i32> = vec![];
     let type_param_map: HashMap<String, i32> = type_param_decl
@@ -23,6 +24,7 @@ pub fn replace_aliases(t: &Type, type_param_decl: &TsTypeParamDecl, ctx: &Contex
     replace_aliases_rec(&t, &type_param_map)
 }
 
+// TODO: rename this replace_refs_rec
 fn replace_aliases_rec(t: &Type, map: &HashMap<String, i32>) -> Type {
     match t {
         Type::Generic(TGeneric { t, type_params }) => {
@@ -115,7 +117,10 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, i32>) -> Type {
             Type::Object(TObject { elems })
         }
         Type::Ref(alias) => match map.get(&alias.name) {
-            Some(id) => Type::Var(TVar { id: id.to_owned() }),
+            Some(id) => Type::Var(TVar {
+                id: id.to_owned(),
+                quals: None,
+            }),
             None => t.to_owned(),
         },
         Type::Tuple(types) => {
@@ -143,7 +148,12 @@ pub fn merge_types(t1: &Type, t2: &Type) -> Type {
     // Creates a mapping from type params in t2 to those in t1
     let subs: Subst = tp2
         .into_iter()
-        .zip(tp1.iter().map(|id| Type::Var(TVar { id: id.to_owned() })))
+        .zip(tp1.iter().map(|id| {
+            Type::Var(TVar {
+                id: id.to_owned(),
+                quals: None,
+            })
+        }))
         .collect();
 
     // Unwrap qualified types since we return a qualified

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -22,16 +22,16 @@ pub fn replace_aliases(
         .map(|tp| {
             // NOTE: We can't use .map() here because infer_ts_type_ann
             // returns a Result.
-            let quals = match &tp.constraint {
+            let constraint = match &tp.constraint {
                 Some(constraint) => {
                     let t = infer_ts_type_ann(constraint, ctx)?;
-                    Some(vec![t])
+                    Some(Box::from(t))
                 }
                 None => None,
             };
             let tv = TVar {
                 id: ctx.fresh_id(),
-                quals,
+                constraint,
             };
             type_params.push(tv.clone());
             Ok((tp.name.sym.to_string(), tv))

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -45,7 +45,7 @@ fn infer_method_on_readonly_array() {
     let result = format!("{}", ctx.lookup_value("map").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: string, index: number) => t1, thisArg?: t0) => t1[]"
+        "<t0, t1>(callbackfn: (value: string, index: number) => t0, thisArg?: t1) => t0[]"
     );
 }
 
@@ -73,12 +73,12 @@ fn infer_method_on_readonly_arrays_of_different_things() {
     let result = format!("{}", ctx.lookup_value("map1").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: string, index: number) => t1, thisArg?: t0) => t1[]"
+        "<t0, t1>(callbackfn: (value: string, index: number) => t0, thisArg?: t1) => t0[]"
     );
     let result = format!("{}", ctx.lookup_value("map2").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: number, index: number) => t1, thisArg?: t0) => t1[]"
+        "<t0, t1>(callbackfn: (value: number, index: number) => t0, thisArg?: t1) => t0[]"
     );
 }
 
@@ -92,7 +92,7 @@ fn infer_array_method_on_tuple() {
     let result = format!("{}", ctx.lookup_value("map").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: \"hello\" | 5 | true, index: number) => t1, thisArg?: t0) => t1[]"
+        "<t0, t1>(callbackfn: (value: \"hello\" | 5 | true, index: number) => t0, thisArg?: t1) => t0[]"
     );
 }
 

--- a/crates/crochet_infer/Cargo.toml
+++ b/crates/crochet_infer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 crochet_types = { version = "0.1.0", path = "../crochet_types" }
+array_tool = "1.0.3"
 defaultmap = "0.5.0"
 itertools = "0.10.3"
 

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -208,7 +208,7 @@ impl Context {
     pub fn fresh_var(&self) -> Type {
         Type::Var(TVar {
             id: self.fresh_id(),
-            quals: None,
+            constraint: None,
         })
     }
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -180,7 +180,7 @@ impl Context {
 
     pub fn instantiate(&self, t: &Type) -> Type {
         match t {
-            Type::Qualified(TQualified { t, type_params }) => {
+            Type::Generic(TGeneric { t, type_params }) => {
                 let ids = type_params.iter().map(|id| id.to_owned());
                 let fresh_quals = type_params.iter().map(|_| self.fresh_var());
                 let subs: Subst = ids.zip(fresh_quals).collect();
@@ -206,6 +206,8 @@ impl Context {
     }
 
     pub fn fresh_var(&self) -> Type {
-        Type::Var(self.fresh_id())
+        Type::Var(TVar {
+            id: self.fresh_id(),
+        })
     }
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -208,6 +208,7 @@ impl Context {
     pub fn fresh_var(&self) -> Type {
         Type::Var(TVar {
             id: self.fresh_id(),
+            quals: None,
         })
     }
 }

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crochet_ast::*;
-use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, TQualified, Type};
+use crochet_types::{self as types, TFnParam, TGeneric, TKeyword, TObject, TPat, Type};
 use types::TObjElem;
 
 use crate::context::Context;
@@ -556,7 +556,7 @@ fn infer_property_type(
     ctx: &mut Context,
 ) -> Result<(Subst, Type), String> {
     match &obj_t {
-        Type::Qualified(TQualified { t, type_params: _ }) => infer_property_type(t, prop, ctx),
+        Type::Generic(TGeneric { t, type_params: _ }) => infer_property_type(t, prop, ctx),
         Type::Object(obj) => get_prop_value(obj, prop, ctx),
         Type::Ref(alias) => {
             let t = ctx.lookup_ref_and_instantiate(alias)?;

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -621,7 +621,7 @@ fn infer_property_type(
             // TODO: Instead of instantiating the whole interface for one method, do
             // the lookup call first and then instantiate the method.
             let s: Subst =
-                Subst::from([(type_params[0].to_owned(), type_param.as_ref().to_owned())]);
+                Subst::from([(type_params[0].id.to_owned(), type_param.as_ref().to_owned())]);
             let t = t.apply(&s);
             infer_property_type(&t, prop, ctx)
         }
@@ -638,7 +638,7 @@ fn infer_property_type(
                     let type_param = Type::Union(elem_types.to_owned());
                     let type_params = get_type_params(&t); // ReadonlyArray type params
 
-                    let s: Subst = Subst::from([(type_params[0].to_owned(), type_param)]);
+                    let s: Subst = Subst::from([(type_params[0].id.to_owned(), type_param)]);
                     let t = t.apply(&s);
                     infer_property_type(&t, prop, ctx)
                 }

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -237,10 +237,10 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         let tv = match &mut param.constraint {
                             Some(type_ann) => {
                                 // TODO: push `s` on to `ss`
-                                let (_s, t) = infer_type_ann(type_ann, ctx, &None)?;
+                                let (_s, t) = infer_type_ann(type_ann, ctx, &mut None)?;
                                 Type::Var(TVar {
                                     id: ctx.fresh_id(),
-                                    quals: Some(vec![t]),
+                                    constraint: Some(Box::from(t)),
                                 })
                             }
                             None => ctx.fresh_var(),

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -603,7 +603,8 @@ fn infer_property_type(
             let type_params = get_type_params(&t);
             // TODO: Instead of instantiating the whole interface for one method, do
             // the lookup call first and then instantiate the method.
-            let s: Subst = Subst::from([(type_params[0], type_param.as_ref().to_owned())]);
+            let s: Subst =
+                Subst::from([(type_params[0].to_owned(), type_param.as_ref().to_owned())]);
             let t = t.apply(&s);
             infer_property_type(&t, prop, ctx)
         }
@@ -620,7 +621,7 @@ fn infer_property_type(
                     let type_param = Type::Union(elem_types.to_owned());
                     let type_params = get_type_params(&t); // ReadonlyArray type params
 
-                    let s: Subst = Subst::from([(type_params[0], type_param)]);
+                    let s: Subst = Subst::from([(type_params[0].to_owned(), type_param)]);
                     let t = t.apply(&s);
                     infer_property_type(&t, prop, ctx)
                 }

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -245,6 +245,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                             }
                             None => ctx.fresh_var(),
                         };
+                        ctx.insert_type(param.name.name.clone(), tv.clone());
                         Ok((param.name.name.to_owned(), tv))
                     })
                     .collect::<Result<Assump, String>>()?,

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crochet_ast::*;
 use crochet_types::{self as types, TFnParam, TKeyword, TObject, TPat, Type};
 
@@ -15,10 +13,10 @@ use crate::util::compose_subs;
 pub fn infer_fn_param(
     param: &mut EFnParam,
     ctx: &mut Context,
-    type_param_map: &HashMap<String, Type>,
+    type_param_map: &Assump,
 ) -> Result<(Subst, Assump, TFnParam), String> {
     // Keeps track of all of the variables the need to be introduced by this pattern.
-    let mut new_vars: HashMap<String, Type> = HashMap::new();
+    let mut new_vars: Assump = Assump::default();
 
     let pat_type = infer_param_pattern_rec(&param.pat, ctx, &mut new_vars)?;
     let pat = e_pat_to_t_pat(&param.pat);

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -363,7 +363,7 @@ fn infer_property_type(
             // TODO: Instead of instantiating the whole interface for one method, do
             // the lookup call first and then instantiate the method.
             let s: Subst =
-                Subst::from([(type_params[0].to_owned(), type_param.as_ref().to_owned())]);
+                Subst::from([(type_params[0].id.to_owned(), type_param.as_ref().to_owned())]);
             let t = t.apply(&s);
             infer_property_type(&t, index_t, ctx)
         }
@@ -377,7 +377,7 @@ fn infer_property_type(
             let type_param = Type::Union(elem_types.to_owned());
             let type_params = get_type_params(&t); // ReadonlyArray type params
 
-            let s: Subst = Subst::from([(type_params[0].to_owned(), type_param)]);
+            let s: Subst = Subst::from([(type_params[0].id.to_owned(), type_param)]);
             let t = t.apply(&s);
             infer_property_type(&t, index_t, ctx)
         }

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -348,7 +348,8 @@ fn infer_property_type(
             let type_params = get_type_params(&t);
             // TODO: Instead of instantiating the whole interface for one method, do
             // the lookup call first and then instantiate the method.
-            let s: Subst = Subst::from([(type_params[0], type_param.as_ref().to_owned())]);
+            let s: Subst =
+                Subst::from([(type_params[0].to_owned(), type_param.as_ref().to_owned())]);
             let t = t.apply(&s);
             infer_property_type(&t, index_t, ctx)
         }
@@ -362,7 +363,7 @@ fn infer_property_type(
             let type_param = Type::Union(elem_types.to_owned());
             let type_params = get_type_params(&t); // ReadonlyArray type params
 
-            let s: Subst = Subst::from([(type_params[0], type_param)]);
+            let s: Subst = Subst::from([(type_params[0].to_owned(), type_param)]);
             let t = t.apply(&s);
             infer_property_type(&t, index_t, ctx)
         }

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -1,4 +1,4 @@
-use crochet_types::{TKeyword, TLit, TObjElem, TObject, TQualified, Type};
+use crochet_types::{TGeneric, TKeyword, TLit, TObjElem, TObject, Type};
 
 use crate::context::Context;
 use crate::util::union_many_types;
@@ -6,7 +6,7 @@ use crate::util::union_many_types;
 // TODO: try to dedupe with infer_property_type()
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
     match t {
-        Type::Qualified(TQualified { t, type_params: _ }) => key_of(t, ctx),
+        Type::Generic(TGeneric { t, type_params: _ }) => key_of(t, ctx),
         Type::Var(_) => Err(String::from(
             "There isn't a way to infer a type from its keys",
         )),

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2358,4 +2358,36 @@ mod tests {
 
         insta::assert_debug_snapshot!(prog);
     }
+
+    #[test]
+    fn test_constrained_generic_function() {
+        let src = r#"
+        declare let add: <T extends number | string>(a: T, b: T) => T;
+        let a: number = 5;
+        let b: number = 10;
+        let num_sum = add(a, b);
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
+        assert_eq!(get_value_type("num_sum", &ctx), "number");
+    }
+
+    // TODO: This should fail but it doesn't.  The reason it should fail is that
+    // the arguments are numbers which aren't subtypes of string.
+    #[test]
+    fn test_constrained_generic_function_failed_constraint() {
+        let src = r#"
+        declare let add: <T extends string>(a: T, b: T) => T;
+        let a: number = 5;
+        let b: number = 10;
+        let num_sum = add(a, b);
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
+        assert_eq!(get_value_type("num_sum", &ctx), "number");
+    }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2370,11 +2370,11 @@ mod tests {
 
         let ctx = infer_prog(src);
 
-        // TODO: include constraint when printing type params
-        println!("add = {:#?}", ctx.lookup_value("add"));
-
-        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
-        // assert_eq!(get_value_type("num_sum", &ctx), "number");
+        assert_eq!(
+            get_value_type("add", &ctx),
+            "<t0 extends number | string>(a: t0, b: t0) => t0"
+        );
+        assert_eq!(get_value_type("num_sum", &ctx), "number");
     }
 
     #[test]

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2370,24 +2370,44 @@ mod tests {
 
         let ctx = infer_prog(src);
 
+        // TODO: include constraint when printing type params
+        println!("add = {:#?}", ctx.lookup_value("add"));
+
         assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
-        assert_eq!(get_value_type("num_sum", &ctx), "number");
+        // assert_eq!(get_value_type("num_sum", &ctx), "number");
     }
 
-    // TODO: This should fail but it doesn't.  The reason it should fail is that
-    // the arguments are numbers which aren't subtypes of string.
     #[test]
+    #[should_panic = "Can't unify string with number"]
     fn test_constrained_generic_function_failed_constraint() {
         let src = r#"
-        declare let add: <T extends string>(a: T, b: T) => T;
-        let a: number = 5;
-        let b: number = 10;
-        let num_sum = add(a, b);
+        let add = <T extends number>(a: T, b: T): T => a + b;
+        let a: string = "hello, ";
+        let b: string = "world";
+        let string_sum = add(a, b);
         "#;
 
         let ctx = infer_prog(src);
 
+        // TODO: include constraint when printing type params
         assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
-        assert_eq!(get_value_type("num_sum", &ctx), "number");
+        assert_eq!(get_value_type("string_sum", &ctx), "string");
+    }
+
+    #[test]
+    #[should_panic = "Can't unify number with string"]
+    fn test_constrained_generic_function_failed_constraint_external_decl() {
+        let src = r#"
+        declare let add: <T extends string>(a: T, b: T) => T;
+        let a: number = 5;
+        let b: number = 10;
+        let number_sum = add(a, b);
+        "#;
+
+        let ctx = infer_prog(src);
+
+        // TODO: include constraint when printing type params
+        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
+        assert_eq!(get_value_type("number_sum", &ctx), "number");
     }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2360,12 +2360,17 @@ mod tests {
     }
 
     #[test]
-    fn test_constrained_generic_function() {
+    fn test_constrained_generic_declared_function() {
         let src = r#"
         declare let add: <T extends number | string>(a: T, b: T) => T;
+
         let a: number = 5;
         let b: number = 10;
         let num_sum = add(a, b);
+
+        let c: string = "hello";
+        let d: string = "world";
+        let str_sum = add(c, d);
         "#;
 
         let ctx = infer_prog(src);
@@ -2375,6 +2380,43 @@ mod tests {
             "<t0 extends number | string>(a: t0, b: t0) => t0"
         );
         assert_eq!(get_value_type("num_sum", &ctx), "number");
+        assert_eq!(get_value_type("str_sum", &ctx), "string");
+    }
+
+    #[test]
+    #[ignore] // TODO: Fix this test
+    fn test_constrained_generic_function() {
+        let src = r#"
+        let fst = <T extends number | string>(a: T, b: T): T => a;
+
+        let a: number = 5;
+        let b: number = 10;
+        let fst_num = fst(a, b);
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(
+            get_value_type("fst", &ctx),
+            "<t0 extends number | string>(a: t0, b: t0) => t0"
+        );
+        assert_eq!(get_value_type("fst_num", &ctx), "number");
+    }
+
+    #[test]
+    fn test_unconstrained_generic_function() {
+        let src = r#"
+        let fst = <T>(a: T, b: T): T => a;
+
+        let a: number = 5;
+        let b: number = 10;
+        let fst_num = fst(a, b);
+        "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("fst", &ctx), "<t0>(a: t0, b: t0) => t0");
+        assert_eq!(get_value_type("fst_num", &ctx), "number");
     }
 
     #[test]
@@ -2387,11 +2429,7 @@ mod tests {
         let string_sum = add(a, b);
         "#;
 
-        let ctx = infer_prog(src);
-
-        // TODO: include constraint when printing type params
-        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
-        assert_eq!(get_value_type("string_sum", &ctx), "string");
+        infer_prog(src);
     }
 
     #[test]
@@ -2404,10 +2442,6 @@ mod tests {
         let number_sum = add(a, b);
         "#;
 
-        let ctx = infer_prog(src);
-
-        // TODO: include constraint when printing type params
-        assert_eq!(get_value_type("add", &ctx), "<t0>(a: t0, b: t0) => t0");
-        assert_eq!(get_value_type("number_sum", &ctx), "number");
+        infer_prog(src);
     }
 }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use crochet_types::*;
 
-pub type Subst = HashMap<TVar, Type>;
+pub type Subst = HashMap<i32, Type>;
 
 pub trait Substitutable {
     fn apply(&self, subs: &Subst) -> Self;
@@ -19,7 +19,7 @@ impl Substitutable for Type {
                 // substitutions?
                 let type_params: Vec<_> = type_params
                     .iter()
-                    .filter(|tp| !sub.contains_key(tp))
+                    .filter(|tp| !sub.contains_key(&tp.id))
                     .cloned()
                     .collect();
 
@@ -35,7 +35,7 @@ impl Substitutable for Type {
                 }
             }
 
-            Type::Var(tv) => match sub.get(tv) {
+            Type::Var(tv) => match sub.get(&tv.id) {
                 Some(replacement) => {
                     // TODO: apply the constraint and then check if the replacement
                     // is a subtype of it.
@@ -168,7 +168,7 @@ impl Substitutable for TCallable {
         let type_params = self
             .type_params
             .iter()
-            .filter(|tp| !sub.contains_key(tp))
+            .filter(|tp| !sub.contains_key(&tp.id))
             .cloned()
             .collect();
 

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -13,8 +13,8 @@ use crate::util::*;
 pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
     let result = match (&t1, &t2) {
         // All binding must be done first
-        (Type::Var(TVar { id }), _) => bind(id, t2),
-        (_, Type::Var(TVar { id })) => bind(id, t1),
+        (Type::Var(TVar { id, quals: _ }), _) => bind(id, t2),
+        (_, Type::Var(TVar { id, quals: _ })) => bind(id, t1),
 
         (Type::Lit(lit), Type::Keyword(keyword)) => {
             let b = matches!(
@@ -514,6 +514,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
     result
 }
 
+// TODO: update bind to accept a TVar instead of an i32
 fn bind(id: &i32, t: &Type) -> Result<Subst, String> {
     // | t == TVar a     = return nullSubst
     // | occursCheck a t = throwError $ InfiniteType a t

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -553,7 +553,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &Context) -> Result<Subst, Stri
                             Type::Union(types)
                         };
 
-                        return Ok(Subst::from([(tv.to_owned(), t)]));
+                        return Ok(Subst::from([(tv.id.to_owned(), t)]));
                     }
                 }
 
@@ -565,10 +565,10 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &Context) -> Result<Subst, Stri
                             Relation::SubType => unify(c, t, ctx)?,
                             Relation::SuperType => unify(t, c, ctx)?,
                         };
-                        s.insert(tv.to_owned(), t.to_owned());
+                        s.insert(tv.id.to_owned(), t.to_owned());
                         Ok(s)
                     }
-                    None => Ok(Subst::from([(tv.to_owned(), t.to_owned())])),
+                    None => Ok(Subst::from([(tv.id.to_owned(), t.to_owned())])),
                 }
             }
         }

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -3,41 +3,7 @@ use crochet_types::Type;
 
 use crate::substitutable::{Subst, Substitutable};
 
-pub fn update_program(prog: &mut Program, s: &Subst) {
-    for stmt in prog.body.iter_mut() {
-        match stmt {
-            Statement::VarDecl {
-                span: _,
-                pattern,
-                type_ann,
-                init,
-                declare: _,
-            } => {
-                update_pattern(pattern, s);
-                if let Some(type_ann) = type_ann {
-                    update_type_ann(type_ann, s);
-                }
-                if let Some(init) = init.as_mut() {
-                    update_expr(init, s);
-                }
-            }
-            Statement::TypeDecl {
-                span: _,
-                declare: _,
-                id: _,
-                type_ann,
-                type_params: _,
-            } => {
-                update_type_ann(type_ann, s);
-            }
-            Statement::Expr { span: _, expr } => {
-                update_expr(expr, s);
-            }
-        }
-    }
-}
-
-fn update_pattern(pattern: &mut Pattern, s: &Subst) {
+pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &pattern.inferred_type {
@@ -87,7 +53,7 @@ fn update_pattern(pattern: &mut Pattern, s: &Subst) {
     }
 }
 
-fn update_expr(expr: &mut Expr, s: &Subst) {
+pub fn update_expr(expr: &mut Expr, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &expr.inferred_type {
@@ -263,7 +229,7 @@ fn update_fn_param_pat(pat: &mut EFnParamPat, s: &Subst) {
     }
 }
 
-fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
+pub fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &type_ann.inferred_type {

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -16,7 +16,15 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
     let mut mapping: HashMap<i32, Type> = keys
         .iter()
         .enumerate()
-        .map(|(index, key)| (key.to_owned(), Type::Var(TVar { id: index as i32 })))
+        .map(|(index, key)| {
+            (
+                key.to_owned(),
+                Type::Var(TVar {
+                    id: index as i32,
+                    quals: None,
+                }),
+            )
+        })
         .collect();
 
     let type_params = get_type_params(t);
@@ -26,6 +34,7 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
             tp.to_owned(),
             Type::Var(TVar {
                 id: (offset + index) as i32,
+                quals: None,
             }),
         );
     }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -1,3 +1,4 @@
+use array_tool::vec::*;
 use defaultmap::*;
 use std::collections::{HashMap, HashSet};
 use std::iter::Iterator;
@@ -8,12 +9,8 @@ use crate::context::{Context, Env};
 use crate::substitutable::{Subst, Substitutable};
 
 fn get_mapping(t: &Type) -> HashMap<TVar, Type> {
-    let body = t;
-    let keys = body.ftv();
-    let mut keys: Vec<_> = keys.iter().cloned().collect();
-    // keys.sort_unstable();
-
-    let mut mapping: HashMap<TVar, Type> = keys
+    let mut mapping: HashMap<TVar, Type> = t
+        .ftv()
         .iter()
         .enumerate()
         .map(|(index, key)| {
@@ -199,19 +196,15 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
 }
 
 pub fn generalize(env: &Env, t: &Type) -> Type {
-    // ftv() returns a Set which is not ordered
-    // TODO: switch to an ordered set
     let mut type_params = get_type_params(t);
 
     // We do this to account for type params from the environment.
     // QUESTION: Why is it okay to ignore the keys of env?
-    type_params.extend(t.ftv().difference(&env.ftv()).cloned());
+    type_params.extend(t.ftv().uniq(env.ftv()));
 
     if type_params.is_empty() {
         return t.to_owned();
     }
-
-    // type_params.sort_unstable();
 
     set_type_params(t, &type_params)
 }

--- a/crates/crochet_types/src/obj.rs
+++ b/crates/crochet_types/src/obj.rs
@@ -21,7 +21,13 @@ impl fmt::Display for TCallable {
         if type_params.is_empty() {
             write!(f, "({}) => {}", join(params, ", "), ret)
         } else {
-            let type_params = type_params.iter().map(|tp| format!("t{tp}"));
+            let type_params = type_params.iter().map(|tp| {
+                let TVar { id, constraint } = tp;
+                match constraint {
+                    Some(constraint) => format!("t{id} extends {constraint}"),
+                    None => format!("t{id}"),
+                }
+            });
             write!(
                 f,
                 "<{}>({}) => {}",

--- a/crates/crochet_types/src/obj.rs
+++ b/crates/crochet_types/src/obj.rs
@@ -1,14 +1,14 @@
 use itertools::join;
 use std::fmt;
 
-use crate::r#type::Type;
+use crate::r#type::{TVar, Type};
 use crate::TFnParam;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TCallable {
     pub params: Vec<TFnParam>,
     pub ret: Box<Type>,
-    pub type_params: Vec<i32>,
+    pub type_params: Vec<TVar>,
 }
 
 impl fmt::Display for TCallable {

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -58,13 +58,23 @@ pub struct TIndexAccess {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TGeneric {
     pub t: Box<Type>,
-    pub type_params: Vec<i32>,
+    pub type_params: Vec<TVar>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TVar {
     pub id: i32,
     pub quals: Option<Vec<TRef>>,
+}
+
+impl fmt::Display for TVar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let TVar { id, quals } = self;
+        match quals {
+            Some(params) => write!(f, "t{id}<{}>", join(params, ", ")),
+            None => write!(f, "t{id}"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -102,17 +112,10 @@ impl fmt::Display for Type {
                 if type_params.is_empty() {
                     write!(f, "{t}")
                 } else {
-                    let params: Vec<_> = type_params
-                        .iter()
-                        .map(|param| format!("t{param}"))
-                        .collect();
-                    write!(f, "<{}>{t}", join(params, ", "))
+                    write!(f, "<{}>{t}", join(type_params, ", "))
                 }
             }
-            Type::Var(TVar { id, quals }) => match quals {
-                Some(quals) => write!(f, "t{id} extends {}", join(quals, ", ")),
-                None => write!(f, "t{id}"),
-            },
+            Type::Var(tv) => write!(f, "{tv}"),
             Type::App(TApp { args, ret }) => {
                 write!(f, "({}) => {}", join(args, ", "), ret)
             }

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -46,14 +46,19 @@ pub struct TIndexAccess {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TQualified {
+pub struct TGeneric {
     pub t: Box<Type>,
     pub type_params: Vec<i32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TVar {
+    pub id: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type {
-    Var(i32), // i32 is the if of the type variable
+    Var(TVar),
     App(TApp),
     Lam(TLam),
     // Query, // use for typed holes
@@ -69,7 +74,7 @@ pub enum Type {
     This,
     KeyOf(Box<Type>),
     IndexAccess(TIndexAccess),
-    Qualified(TQualified),
+    Generic(TGeneric),
 }
 
 impl From<TLit> for Type {
@@ -82,7 +87,7 @@ impl fmt::Display for Type {
     // TODO: add in parentheses where necessary to get the precedence right
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Type::Qualified(TQualified { t, type_params }) => {
+            Type::Generic(TGeneric { t, type_params }) => {
                 if type_params.is_empty() {
                     write!(f, "{t}")
                 } else {
@@ -93,7 +98,7 @@ impl fmt::Display for Type {
                     write!(f, "<{}>{t}", join(params, ", "))
                 }
             }
-            Type::Var(id) => write!(f, "t{id}"),
+            Type::Var(TVar { id }) => write!(f, "t{id}"),
             Type::App(TApp { args, ret }) => {
                 write!(f, "({}) => {}", join(args, ", "), ret)
             }

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -64,7 +64,7 @@ pub struct TGeneric {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TVar {
     pub id: i32,
-    pub quals: Option<Vec<TRef>>,
+    pub quals: Option<Vec<Type>>,
 }
 
 impl fmt::Display for TVar {


### PR DESCRIPTION
- [x] introduce `TVar`
- [x] rename (T)Qualified to (T)Generic
- [x] add `quals` vector to `TVar`
- [x] update parser to handle constraints (`extends`) in type params from tree-sitter (this was already done)
- [x] update infer_expr.rs to set `quals` when there are constraints on type params
- [x] update unify.rs to check `quals` when unifying type variables
- [x] update code generation to output qualified type variables