### PR TITLE
Fix miscellaneous generics bugs

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -382,7 +382,10 @@ pub fn build_type_params(t: &Type) -> Option<TsTypeParamDecl> {
                         },
                         is_in: false,
                         is_out: false,
-                        constraint: None,
+                        constraint: tv
+                            .constraint
+                            .as_ref()
+                            .map(|t| Box::from(build_type(t, None))),
                         default: None,
                     }
                 })

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -500,7 +500,6 @@ fn generic_function() {
 }
 
 #[test]
-#[ignore] // TODO: fix this test case
 fn constrained_generic_function() {
     let src = r#"
     let fst = <T extends number | string>(a: T, b: T) => a;
@@ -514,7 +513,7 @@ fn constrained_generic_function() {
     infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
-    insta::assert_snapshot!(result, @"export declare const fst: (a: number | string, b: number | string) => number | string;
+    insta::assert_snapshot!(result, @"export declare const fst: <A extends number | string>(a: A, b: A) => A;
 ");
 }
 

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2384,7 +2384,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Fix this test
     fn test_constrained_generic_function() {
         let src = r#"
         let fst = <T extends number | string>(a: T, b: T): T => a;


### PR DESCRIPTION
- [x] include type constraint in codegen that was missing in a some situations
- [x] copy over constraint when binding a type variable that has a constraint to one that doesn't