### PR TITLE
Parse and codegen `mut`/`readonly`

### DIFF
--- a/crates/crochet_ast/src/type_ann.rs
+++ b/crates/crochet_ast/src/type_ann.rs
@@ -118,6 +118,12 @@ pub struct IndexedAccessType {
     pub index_type: Box<TypeAnn>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MutableType {
+    pub span: Span,
+    pub type_ann: Box<TypeAnn>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnnKind {
     Lam(LamType),
@@ -132,6 +138,7 @@ pub enum TypeAnnKind {
     KeyOf(KeyOfType), // keyof
     Query(QueryType), // typeof
     IndexedAccess(IndexedAccessType),
+    Mutable(MutableType),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -1616,6 +1616,6 @@ fn codegen_array() {
     "###);
 
     let result = codegen_d_ts(&program, &ctx);
-    insta::assert_snapshot!(result, @"export declare const arr: string[];
+    insta::assert_snapshot!(result, @"export declare const arr: readonly string[];
 ");
 }

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -441,7 +441,7 @@ fn function_with_rest_param() {
     infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
-    insta::assert_snapshot!(result, @"export declare const foo: (x: number, ...y: number[]) => number;
+    insta::assert_snapshot!(result, @"export declare const foo: (x: number, ...y: readonly number[]) => number;
 ");
 }
 
@@ -477,7 +477,7 @@ fn function_with_optional_param_and_rest_param() {
     infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
-    insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: number[]) => number | undefined;
+    insta::assert_snapshot!(result, @"export declare const foo: (x?: number, ...y: readonly number[]) => number | undefined;
 ");
 }
 

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -118,7 +118,25 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
         TsType::TsConditionalType(_) => Err(String::from("can't parse conditional type yet")),
         TsType::TsInferType(_) => Err(String::from("can't parse infer type yet")),
         TsType::TsParenthesizedType(_) => Err(String::from("can't parse parenthesized yet")),
-        TsType::TsTypeOperator(_) => Err(String::from("can't parse type operator yet")),
+        TsType::TsTypeOperator(TsTypeOperator {
+            op,
+            type_ann,
+            span: _,
+        }) => {
+            // TODO: If type_ann is a Type::Mutable(_) then we have to unwrap it here
+            // let type_ann = ;
+            match op {
+                TsTypeOperatorOp::KeyOf => {
+                    let type_ann = infer_ts_type_ann(type_ann, ctx)?;
+                    Ok(Type::KeyOf(Box::from(type_ann)))
+                }
+                TsTypeOperatorOp::Unique => todo!(),
+                TsTypeOperatorOp::ReadOnly => {
+                    let type_ann = infer_ts_type_ann(type_ann, ctx)?;
+                    Ok(type_ann)
+                }
+            }
+        }
         TsType::TsIndexedAccessType(_) => Err(String::from("can't parse indexed type yet")),
         TsType::TsMappedType(_) => Err(String::from("can't parse mapped type yet")),
         TsType::TsLitType(lit) => match &lit.lit {

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -149,6 +149,7 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
             object: Box::from(replace_aliases_rec(object, map)),
             index: Box::from(replace_aliases_rec(index, map)),
         }),
+        Type::Mutable(t) => Type::Mutable(Box::from(replace_aliases_rec(t, map))),
     }
 }
 

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -45,7 +45,7 @@ fn infer_method_on_readonly_array() {
     let result = format!("{}", ctx.lookup_value("map").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: string, index: number) => t0, thisArg?: t1) => t0[]"
+        "<t0, t1>(callbackfn: (value: string, index: number, array: string[]) => t0, thisArg?: t1) => t0[]"
     );
 }
 
@@ -73,12 +73,12 @@ fn infer_method_on_readonly_arrays_of_different_things() {
     let result = format!("{}", ctx.lookup_value("map1").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: string, index: number) => t0, thisArg?: t1) => t0[]"
+        "<t0, t1>(callbackfn: (value: string, index: number, array: string[]) => t0, thisArg?: t1) => t0[]"
     );
     let result = format!("{}", ctx.lookup_value("map2").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: number, index: number) => t0, thisArg?: t1) => t0[]"
+        "<t0, t1>(callbackfn: (value: number, index: number, array: number[]) => t0, thisArg?: t1) => t0[]"
     );
 }
 
@@ -92,7 +92,8 @@ fn infer_array_method_on_tuple() {
     let result = format!("{}", ctx.lookup_value("map").unwrap());
     assert_eq!(
         result,
-        "<t0, t1>(callbackfn: (value: \"hello\" | 5 | true, index: number) => t0, thisArg?: t1) => t0[]"
+        // TODO: add parens around a union when it's the child of an arry
+        "<t0, t1>(callbackfn: (value: \"hello\" | 5 | true, index: number, array: \"hello\" | 5 | true[]) => t0, thisArg?: t1) => t0[]"
     );
 }
 

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -250,6 +250,12 @@ fn infer_type_ann_rec(
             Ok((s, t))
         }
         TypeAnnKind::Query(QueryType { expr, .. }) => infer_expr(ctx, expr),
+        TypeAnnKind::Mutable(MutableType { type_ann, .. }) => {
+            let (s, t) = infer_type_ann_rec(type_ann, ctx, type_param_map)?;
+            let t = Type::Mutable(Box::from(t));
+            type_ann.inferred_type = Some(t.clone());
+            Ok((s, t))
+        }
         TypeAnnKind::IndexedAccess(IndexedAccessType {
             obj_type,
             index_type,

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -73,6 +73,7 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
             todo!() // Depends on what this is referencing
         }
         Type::KeyOf(t) => key_of(&key_of(t, ctx)?, ctx),
+        Type::Mutable(t) => key_of(t, ctx),
         Type::IndexAccess(_) => {
             todo!() // We have to evaluate the IndexAccess first
         }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -68,6 +68,7 @@ impl Substitutable for Type {
             Type::Rest(arg) => Type::Rest(Box::from(arg.apply(sub))),
             Type::This => Type::This,
             Type::KeyOf(t) => Type::KeyOf(Box::from(t.apply(sub))),
+            Type::Mutable(t) => Type::Mutable(Box::from(t.apply(sub))),
             Type::IndexAccess(TIndexAccess { object, index }) => Type::IndexAccess(TIndexAccess {
                 object: Box::from(object.apply(sub)),
                 index: Box::from(index.apply(sub)),
@@ -104,6 +105,7 @@ impl Substitutable for Type {
             Type::Rest(arg) => arg.ftv(),
             Type::This => vec![],
             Type::KeyOf(t) => t.ftv(),
+            Type::Mutable(t) => t.ftv(),
             Type::IndexAccess(TIndexAccess { object, index }) => {
                 let mut result = object.ftv();
                 result.extend(index.ftv());

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -500,6 +500,8 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
             (TKeyword::Never, TKeyword::Null) => Ok(Subst::new()),
             _ => Err(format!("Can't unify {t1} with {t2}")),
         },
+        (_, Type::Mutable(t)) => unify(t1, t, ctx),
+        (Type::Mutable(t), _) => unify(t, t2, ctx),
         (v1, v2) => {
             if v1 == v2 {
                 Ok(Subst::new())

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -292,6 +292,9 @@ pub fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
         TypeAnnKind::Query(QueryType { span: _, expr }) => {
             update_expr(expr, s);
         }
+        TypeAnnKind::Mutable(MutableType { span: _, type_ann }) => {
+            update_type_ann(type_ann, s);
+        }
         TypeAnnKind::IndexedAccess(IndexedAccessType {
             span: _,
             obj_type,

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -193,6 +193,7 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                 object: Box::from(norm_type(object, mapping, ctx)),
                 index: Box::from(norm_type(index, mapping, ctx)),
             }),
+            Type::Mutable(t) => Type::Mutable(Box::from(norm_type(t, mapping, ctx))),
         }
     }
 

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1368,7 +1368,14 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> TypeAnn {
                 type_params,
             })
         }
-        "readonly_type" => todo!(),
+        "mutable_type" => {
+            let type_ann = node.named_child(0).unwrap();
+
+            TypeAnnKind::Mutable(MutableType {
+                span: node.byte_range(),
+                type_ann: Box::from(parse_type_ann(&type_ann, src)),
+            })
+        }
         "constructor_type" => todo!(),
         "infer_type" => todo!(),
 

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -96,6 +96,7 @@ pub enum Type {
     Rest(Box<Type>), // TODO: rename this to Spread
     This,
     KeyOf(Box<Type>),
+    Mutable(Box<Type>),
     IndexAccess(TIndexAccess),
     Generic(TGeneric),
 }
@@ -149,6 +150,7 @@ impl fmt::Display for Type {
             Type::Rest(arg) => write!(f, "...{arg}"),
             Type::This => write!(f, "this"),
             Type::KeyOf(t) => write!(f, "keyof {t}"),
+            Type::Mutable(t) => write!(f, "mut {t}"),
             Type::IndexAccess(TIndexAccess { object, index }) => write!(f, "{object}[{index}]"),
         }
     }

--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -1104,7 +1104,6 @@ a ?. b;
   (expression_statement
     (member_expression
       (identifier)
-      (optional_chain)
       (property_identifier))))
 
 ================================================================================
@@ -1124,7 +1123,6 @@ a ?. [b];
   (expression_statement
     (subscript_expression
       (identifier)
-      (optional_chain)
       (identifier))))
 
 ================================================================================
@@ -1321,10 +1319,10 @@ i + j * 3 - j % 5;
         (number))))
   (expression_statement
     (binary_expression
-      (number)
       (binary_expression
-        (identifier)
-        (number))))
+        (number)
+        (identifier))
+      (number)))
   (expression_statement
     (unary_expression
       (identifier)))

--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -1104,6 +1104,7 @@ a ?. b;
   (expression_statement
     (member_expression
       (identifier)
+      (optional_chain)
       (property_identifier))))
 
 ================================================================================
@@ -1123,6 +1124,7 @@ a ?. [b];
   (expression_statement
     (subscript_expression
       (identifier)
+      (optional_chain)
       (identifier))))
 
 ================================================================================
@@ -1319,10 +1321,10 @@ i + j * 3 - j % 5;
         (number))))
   (expression_statement
     (binary_expression
+      (number)
       (binary_expression
-        (number)
-        (identifier))
-      (number)))
+        (identifier)
+        (number))))
   (expression_statement
     (unary_expression
       (identifier)))

--- a/crates/tree_sitter_crochet/corpus/tsx/types.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/types.txt
@@ -54,9 +54,9 @@ Object types
 
 let person: {name: string, age: number};
 let thing: { [type: string]: string };
-type T = { [K in keyof T]-?: any }
-type T = { [K in keyof T]?: any }
-type T = { -readonly [K in keyof T]: any }
+type T = { [K in keyof T]-?: any };
+type T = { [K in keyof T]?: any };
+type T = { -readonly [K in keyof T]: any };
 
 --------------------------------------------------------------------------------
 
@@ -93,8 +93,7 @@ type T = { -readonly [K in keyof T]: any }
           (index_type_query
             (type_identifier)))
         (omitting_type_annotation
-          (predefined_type))))
-    (MISSING ";"))
+          (predefined_type)))))
   (type_alias_declaration
     (type_identifier)
     (object_type
@@ -104,8 +103,7 @@ type T = { -readonly [K in keyof T]: any }
           (index_type_query
             (type_identifier)))
         (opting_type_annotation
-          (predefined_type))))
-    (MISSING ";"))
+          (predefined_type)))))
   (type_alias_declaration
     (type_identifier)
     (object_type
@@ -115,8 +113,7 @@ type T = { -readonly [K in keyof T]: any }
           (index_type_query
             (type_identifier)))
         (type_annotation
-          (predefined_type))))
-    (MISSING ";")))
+          (predefined_type))))))
 
 ================================================================================
 Object types with call signatures
@@ -1274,14 +1271,14 @@ function isFish(object: Fish): object is Fish {
     (statement_block)))
 
 ================================================================================
-Read-only arrays
+Mutable arrays
 ================================================================================
 
 type t = a[];
-type t = readonly a[];
-type t = readonly a[][];
-type t = (readonly a[])[];
-type t = readonly (readonly a[]) [];
+type t = mut a[];
+type t = mut a[][];
+type t = (mut a[])[];
+type t = mut (mut a[]) [];
 
 --------------------------------------------------------------------------------
 
@@ -1292,12 +1289,12 @@ type t = readonly (readonly a[]) [];
       (type_identifier)))
   (type_alias_declaration
     (type_identifier)
-    (readonly_type
+    (mutable_type
       (array_type
         (type_identifier))))
   (type_alias_declaration
     (type_identifier)
-    (readonly_type
+    (mutable_type
       (array_type
         (array_type
           (type_identifier)))))
@@ -1305,15 +1302,15 @@ type t = readonly (readonly a[]) [];
     (type_identifier)
     (array_type
       (parenthesized_type
-        (readonly_type
+        (mutable_type
           (array_type
             (type_identifier))))))
   (type_alias_declaration
     (type_identifier)
-    (readonly_type
+    (mutable_type
       (array_type
         (parenthesized_type
-          (readonly_type
+          (mutable_type
             (array_type
               (type_identifier))))))))
 
@@ -1324,13 +1321,13 @@ Tuple types
 type t = [];
 type t = [A,];
 type t = [A|B, C];
-type t = readonly [A[], B.C];
+type t = mut [A[], B.C];
 
 // special optional and rest type syntax
-type t = [string?, ...B]
+type t = [string?, ...B];
 
 // labeled elements
-type t = [a: A, b?: B, ...c: C[]]
+type t = [a: A, b?: B, ...c: C[]];
 
 --------------------------------------------------------------------------------
 
@@ -1351,7 +1348,7 @@ type t = [a: A, b?: B, ...c: C[]]
       (type_identifier)))
   (type_alias_declaration
     (type_identifier)
-    (readonly_type
+    (mutable_type
       (tuple_type
         (array_type
           (type_identifier))
@@ -1365,9 +1362,8 @@ type t = [a: A, b?: B, ...c: C[]]
       (optional_type
         (predefined_type))
       (rest_type
-        (type_identifier)))
-    (comment)
-    (MISSING ";"))
+        (type_identifier))))
+  (comment)
   (type_alias_declaration
     (type_identifier)
     (tuple_type
@@ -1384,8 +1380,7 @@ type t = [a: A, b?: B, ...c: C[]]
           (identifier))
         (type_annotation
           (array_type
-            (type_identifier)))))
-    (MISSING ";")))
+            (type_identifier)))))))
 
 ================================================================================
 Conditional types

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -29,6 +29,17 @@ module.exports = grammar(tsx, {
     // Removes automatic semicolon insertion
     _semicolon: ($, prev) => ";",
 
+    // Replaces 'readonly' with 'mut'
+    _type: ($) =>
+      choice(
+        $._primary_type,
+        $.function_type,
+        alias($.readonly_type, $.mutable_type),
+        $.constructor_type,
+        $.infer_type
+      ),
+    readonly_type: ($, prev) => seq("mut", $._type),
+
     expression: ($, prev) => {
       // Removes ternary expression
       const choices = prev.members.filter(

--- a/crates/tree_sitter_crochet/yarn.lock
+++ b/crates/tree_sitter_crochet/yarn.lock
@@ -443,7 +443,12 @@ ms@^2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.12.1, nan@^2.14.0, nan@^2.16.0:
+nan@^2.12.1:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
+  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
+
+nan@^2.14.0, nan@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==


### PR DESCRIPTION
- [x] Add Type::Mutable(t)
- [x] Update codegen of .d.ts to add `readonly` for non mutable types
- [x] Update codegen of .d.ts to omit `readonly` for mutable types 
- [x] update tree-sitter parser
- [x] update `crochet_parser` and `crochet_ast` to handle `mut` modifiers
- [x] update `crochet_infer` to wrap types marked as `mut` with `Type::Mutable(t)`

Updates to the unification algorithm will happen in a separate PR.