### PR TITLE
Parser error handling

### DIFF
--- a/crates/crochet/src/lib.rs
+++ b/crates/crochet/src/lib.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn deallocate(ptr: *mut c_void, length: usize) {
 }
 
 fn _compile(input: &str, lib: &str) -> Result<(String, String), String> {
-    let mut program = crochet_parser::parse(input).unwrap();
+    let mut program = crochet_parser::parse(input)?;
 
     let js = crochet_codegen::js::codegen_js(&program);
 

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_parse_error.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__top_level_parse_error.snap
@@ -1,0 +1,7 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(r#\"\n            let obj = {foo: \"hello\"};\n            let foo = obj.\"#)"
+---
+Err(
+    "failed to parse: 'let foo = obj.'",
+)

--- a/demo/wasm.ts
+++ b/demo/wasm.ts
@@ -56,7 +56,14 @@ export const loadWasm = async (
   const wasm = await WebAssembly.compile(buffer);
 
   const imports = wasi.getImports(wasm);
-  const instance = await WebAssembly.instantiate(wasm, imports);
+  const instance = await WebAssembly.instantiate(wasm, {
+    ...imports,
+    my_custom_module: {
+      _log: (value: any) => {
+        console.log(decodeString(memory, value));
+      },
+    },
+  });
   wasi.start(instance);
 
   const memory = instance.exports.memory as WebAssembly.Memory;


### PR DESCRIPTION
- [x] update functions in crochet_parser to use `Result<>` types
- [x] add `log` function to crochet_parser with `wasm` binding
- [x] don't call `.unwrap()` on `parse()` result in `_compile()` in crochet