### PR TITLE
Ensure that the .init field of Expr::Let is being inferred

### DIFF
--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -1298,6 +1298,7 @@ fn codegen_if_let_with_rename() {
 }
 
 #[test]
+#[should_panic = "Unification failure"]
 fn infer_if_let_with_type_error() {
     let src = r#"
     let p = {x: "hello", y: "world"};

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -29,9 +29,7 @@ pub fn infer_fn_param(
             let (type_ann_s, type_ann_t) =
                 infer_type_ann_with_params(type_ann, ctx, type_param_map)?;
 
-            // Allowing type_ann_ty to be a subtype of pat_type because
-            // only non-refutable patterns can have type annotations.
-            let s = unify(&type_ann_t, &pat_type, ctx)?;
+            let s = unify(&pat_type, &type_ann_t, ctx)?;
             let s = compose_subs(&s, &type_ann_s);
 
             // Substs are applied to any new variables introduced.  This handles

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -21,6 +21,9 @@ pub fn infer_fn_param(
     let pat_type = infer_param_pattern_rec(&param.pat, ctx, &mut new_vars)?;
     let pat = e_pat_to_t_pat(&param.pat);
 
+    // TODO: convert EFnParamPat to Pattern perhaps we can just get rid of EFnParamPat
+    // Use infer_let as a model for this
+
     // If the pattern had a type annotation associated with it, we infer type of the
     // type annotation and add a constraint between the types of the pattern and its
     // type annotation.
@@ -29,6 +32,8 @@ pub fn infer_fn_param(
             let (type_ann_s, type_ann_t) =
                 infer_type_ann_with_params(type_ann, ctx, type_param_map)?;
 
+            // We probably shouldn't have reversed this.  We did it so that the
+            // substitutions would come out in the correct direction.
             let s = unify(&pat_type, &type_ann_t, ctx)?;
             let s = compose_subs(&s, &type_ann_s);
 

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -13,7 +13,7 @@ use crate::util::*;
 
 // NOTE: The caller is responsible for inserting any new variables introduced
 // into the appropriate context.
-fn infer_pattern(
+pub fn infer_pattern(
     pat: &mut Pattern,
     type_ann: &mut Option<TypeAnn>,
     ctx: &mut Context,

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -361,6 +361,28 @@ mod tests {
     }
 
     #[test]
+    fn partial_object_destructuring() {
+        let src = r#"
+        declare let point: {x: number, y: number, z?: number};
+        let {x} = point;
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("x", &ctx), "number");
+    }
+
+    #[test]
+    fn partial_object_destructuring_with_type_annotation() {
+        let src = r#"
+        declare let point: {x: number, y: number, z?: number};
+        let {x}: {x: number, y: number} = point;
+        "#;
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("x", &ctx), "number");
+    }
+
+    #[test]
     fn destructure_obj_with_renaming() {
         let src = "let {x: a, y: b} = {x: 5, y: 10};";
         let ctx = infer_prog(src);

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -37,6 +37,7 @@ impl Substitutable for Type {
 
             Type::Var(tv) => match sub.get(&tv.id) {
                 Some(replacement) => {
+                    println!("replacing {tv:#?} with {replacement}");
                     // TODO: apply the constraint and then check if the replacement
                     // is a subtype of it.
                     replacement.to_owned()
@@ -83,8 +84,8 @@ impl Substitutable for Type {
                 .uniq_via(type_params.to_owned(), |a, b| a.id == b.id),
             Type::Var(tv) => {
                 let mut result = vec![tv.to_owned()];
-                if let Some(quals) = &tv.constraint {
-                    result.extend(quals.ftv());
+                if let Some(constraint) = &tv.constraint {
+                    result.extend(constraint.ftv());
                 }
                 result.unique_via(|a, b| a.id == b.id)
             }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -37,7 +37,6 @@ impl Substitutable for Type {
 
             Type::Var(tv) => match sub.get(&tv.id) {
                 Some(replacement) => {
-                    println!("replacing {tv:#?} with {replacement}");
                     // TODO: apply the constraint and then check if the replacement
                     // is a subtype of it.
                     replacement.to_owned()

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -11,6 +11,7 @@ use crate::util::*;
 
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
 pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
+    println!("attempting to unify {t1} and {t2}");
     let result = match (&t1, &t2) {
         // All binding must be done first
         (Type::Var(tv), _) => bind(tv, t2, Relation::SubType, ctx),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -11,7 +11,6 @@ use crate::util::*;
 
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
 pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
-    println!("attempting to unify {t1} and {t2}");
     let result = match (&t1, &t2) {
         // All binding must be done first
         (Type::Var(tv), _) => bind(tv, t2, Relation::SubType, ctx),


### PR DESCRIPTION
This fixes #298.  This PR also makes the following changes:
- fixes an issue with inferring rest patterns (we were using the wrong identifier)
- object patterns as type params must destructure all properties