### PR TITLE
Rename current Type enum to TypeKind and introduce Type struct

### DIFF
--- a/crates/crochet_ast/src/keyword.rs
+++ b/crates/crochet_ast/src/keyword.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crochet_types::{TKeyword, Type};
+use crochet_types::{TKeyword, Type, TypeKind};
 
 use crate::span::Span;
 
@@ -44,13 +44,15 @@ impl fmt::Display for Keyword {
 
 impl From<Keyword> for Type {
     fn from(keyword: Keyword) -> Self {
-        Type::Keyword(match keyword {
-            Keyword::Number => TKeyword::Number,
-            Keyword::String => TKeyword::String,
-            Keyword::Boolean => TKeyword::Boolean,
-            Keyword::Null => TKeyword::Null,
-            Keyword::Symbol => TKeyword::Symbol,
-            Keyword::Undefined => TKeyword::Undefined,
-        })
+        Type {
+            kind: TypeKind::Keyword(match keyword {
+                Keyword::Number => TKeyword::Number,
+                Keyword::String => TKeyword::String,
+                Keyword::Boolean => TKeyword::Boolean,
+                Keyword::Null => TKeyword::Null,
+                Keyword::Symbol => TKeyword::Symbol,
+                Keyword::Undefined => TKeyword::Undefined,
+            }),
+        }
     }
 }

--- a/crates/crochet_ast/src/lit.rs
+++ b/crates/crochet_ast/src/lit.rs
@@ -3,7 +3,7 @@ use swc_atoms::{Atom, JsWord};
 use swc_common::source_map::DUMMY_SP;
 use swc_ecma_ast;
 
-use crochet_types::{TLit, Type};
+use crochet_types::{TLit, Type, TypeKind};
 
 use crate::span::Span;
 
@@ -103,11 +103,13 @@ impl From<&Lit> for swc_ecma_ast::Expr {
 
 impl From<Lit> for Type {
     fn from(lit: Lit) -> Self {
-        Type::Lit(match lit {
-            Lit::Num(n) => TLit::Num(n.value),
-            Lit::Bool(b) => TLit::Bool(b.value),
-            Lit::Str(s) => TLit::Str(s.value),
-        })
+        Type {
+            kind: TypeKind::Lit(match lit {
+                Lit::Num(n) => TLit::Num(n.value),
+                Lit::Bool(b) => TLit::Bool(b.value),
+                Lit::Str(s) => TLit::Str(s.value),
+            }),
+        }
     }
 }
 

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -165,11 +165,11 @@ impl Context {
                                     "mismatch between the number of qualifiers and type params",
                                 ));
                             }
-                            ids.zip(type_params.iter().map(|tp| {
-                                Type::Var(TVar {
+                            ids.zip(type_params.iter().map(|tp| Type {
+                                kind: TypeKind::Var(TVar {
                                     id: self.fresh_id(),
                                     constraint: tp.constraint.to_owned(),
-                                })
+                                }),
                             }))
                             .collect()
                         }
@@ -184,14 +184,14 @@ impl Context {
     }
 
     pub fn instantiate(&self, t: &Type) -> Type {
-        match t {
-            Type::Generic(TGeneric { t, type_params }) => {
+        match &t.kind {
+            TypeKind::Generic(TGeneric { t, type_params }) => {
                 let ids = type_params.iter().map(|tv| tv.id.to_owned());
-                let fresh_params = type_params.iter().map(|tp| {
-                    Type::Var(TVar {
+                let fresh_params = type_params.iter().map(|tp| Type {
+                    kind: TypeKind::Var(TVar {
                         id: self.fresh_id(),
                         constraint: tp.constraint.to_owned(),
-                    })
+                    }),
                 });
                 let subs: Subst = ids.zip(fresh_params).collect();
 
@@ -216,9 +216,11 @@ impl Context {
     }
 
     pub fn fresh_var(&self) -> Type {
-        Type::Var(TVar {
-            id: self.fresh_id(),
-            constraint: None,
-        })
+        Type {
+            kind: TypeKind::Var(TVar {
+                id: self.fresh_id(),
+                constraint: None,
+            }),
+        }
     }
 }

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -1,5 +1,5 @@
 use crochet_ast::*;
-use crochet_types::{TObjElem, TObject, TProp, Type};
+use crochet_types::{TObjElem, TObject, TProp, Type, TypeKind};
 
 use crate::context::Context;
 use crate::infer_expr::infer_expr as infer_expr_rec;
@@ -18,7 +18,9 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
         mutable: false,
         t: Type::from(Lit::str(String::from("Promise"), 0..0)),
     })];
-    let promise_type = Type::Object(TObject { elems });
+    let promise_type = Type {
+        kind: TypeKind::Object(TObject { elems }),
+    };
     ctx.insert_type(String::from("Promise"), promise_type);
     // TODO: replace with Class type once it exists
     // We use {_name: "JSXElement"} to differentiate it from other
@@ -29,7 +31,9 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
         mutable: false,
         t: Type::from(Lit::str(String::from("JSXElement"), 0..0)),
     })];
-    let jsx_element_type = Type::Object(TObject { elems });
+    let jsx_element_type = Type {
+        kind: TypeKind::Object(TObject { elems }),
+    };
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 
     // We push a scope here so that it's easy to differentiate globals from

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -1,5 +1,5 @@
 use crochet_ast::*;
-use crochet_types::{self as types, TFnParam, TKeyword, TPat, Type};
+use crochet_types::{self as types, TFnParam, TKeyword, TPat, Type, TypeKind};
 
 use crate::assump::Assump;
 use crate::context::Context;
@@ -20,15 +20,24 @@ pub fn infer_fn_param(
 
     // TypeScript annotates rest params using an array type so we do the
     // same thing by converting top-level rest types to array types.
-    let pt = if let Type::Rest(arg) = pt {
-        Type::Array(arg)
+    let pt = if let TypeKind::Rest(arg) = &pt.kind {
+        Type {
+            kind: TypeKind::Array(arg.to_owned()),
+        }
     } else {
         pt
     };
 
     if param.optional {
         if let Some((name, t)) = pa.iter().find(|(_, value)| pt == **value) {
-            let t = Type::Union(vec![t.to_owned(), Type::Keyword(TKeyword::Undefined)]);
+            let t = Type {
+                kind: TypeKind::Union(vec![
+                    t.to_owned(),
+                    Type {
+                        kind: TypeKind::Keyword(TKeyword::Undefined),
+                    },
+                ]),
+            };
             pa.insert(name.to_owned(), t);
         };
     }

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -1,41 +1,45 @@
-use crochet_types::{TGeneric, TKeyword, TLit, TObjElem, TObject, Type};
+use crochet_types::{TGeneric, TKeyword, TLit, TObjElem, TObject, Type, TypeKind};
 
 use crate::context::Context;
 use crate::util::union_many_types;
 
 // TODO: try to dedupe with infer_property_type()
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
-    match t {
-        Type::Generic(TGeneric { t, type_params: _ }) => key_of(t, ctx),
-        Type::Var(_) => Err(String::from(
+    match &t.kind {
+        TypeKind::Generic(TGeneric { t, type_params: _ }) => key_of(t, ctx),
+        TypeKind::Var(_) => Err(String::from(
             "There isn't a way to infer a type from its keys",
         )),
-        Type::Ref(alias) => {
+        TypeKind::Ref(alias) => {
             let t = ctx.lookup_ref_and_instantiate(alias)?;
             key_of(&t, ctx)
         }
-        Type::Object(TObject { elems }) => {
+        TypeKind::Object(TObject { elems }) => {
             let elems: Vec<_> = elems
                 .iter()
                 .filter_map(|elem| match elem {
                     TObjElem::Call(_) => None,
                     TObjElem::Constructor(_) => None,
                     TObjElem::Index(_) => todo!(),
-                    TObjElem::Prop(prop) => Some(Type::Lit(TLit::Str(prop.name.to_owned()))),
+                    TObjElem::Prop(prop) => Some(Type {
+                        kind: TypeKind::Lit(TLit::Str(prop.name.to_owned())),
+                    }),
                 })
                 .collect();
 
             Ok(union_many_types(&elems))
         }
-        Type::Lit(lit) => match lit {
+        TypeKind::Lit(lit) => match lit {
             TLit::Num(_) => key_of(&ctx.lookup_type_and_instantiate("Number")?, ctx),
             TLit::Bool(_) => key_of(&ctx.lookup_type_and_instantiate("Boolean")?, ctx),
             TLit::Str(_) => key_of(&ctx.lookup_type_and_instantiate("String")?, ctx),
         },
-        Type::Tuple(tuple) => {
+        TypeKind::Tuple(tuple) => {
             let mut elems: Vec<Type> = vec![];
             for i in 0..tuple.len() {
-                elems.push(Type::Lit(TLit::Num(i.to_string())))
+                elems.push(Type {
+                    kind: TypeKind::Lit(TLit::Num(i.to_string())),
+                })
             }
             elems.push(key_of(
                 &ctx.lookup_type_and_instantiate("ReadonlyArray")?,
@@ -43,38 +47,46 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
             )?);
             Ok(union_many_types(&elems))
         }
-        Type::Array(_) => Ok(union_many_types(&[
-            Type::Keyword(TKeyword::Number),
+        TypeKind::Array(_) => Ok(union_many_types(&[
+            Type {
+                kind: TypeKind::Keyword(TKeyword::Number),
+            },
             key_of(&ctx.lookup_type_and_instantiate("ReadonlyArray")?, ctx)?,
         ])),
-        Type::Lam(_) => key_of(&ctx.lookup_type_and_instantiate("Function")?, ctx),
-        Type::App(_) => {
+        TypeKind::Lam(_) => key_of(&ctx.lookup_type_and_instantiate("Function")?, ctx),
+        TypeKind::App(_) => {
             todo!() // What does this even mean?
         }
-        Type::Keyword(keyword) => match keyword {
+        TypeKind::Keyword(keyword) => match keyword {
             TKeyword::Number => key_of(&ctx.lookup_type_and_instantiate("Number")?, ctx),
             TKeyword::Boolean => key_of(&ctx.lookup_type_and_instantiate("Boolean")?, ctx),
             TKeyword::String => key_of(&ctx.lookup_type_and_instantiate("String")?, ctx),
             TKeyword::Symbol => key_of(&ctx.lookup_type_and_instantiate("Symbol")?, ctx),
-            TKeyword::Null => Ok(Type::Keyword(TKeyword::Never)),
-            TKeyword::Undefined => Ok(Type::Keyword(TKeyword::Never)),
-            TKeyword::Never => Ok(Type::Keyword(TKeyword::Never)),
+            TKeyword::Null => Ok(Type {
+                kind: TypeKind::Keyword(TKeyword::Never),
+            }),
+            TKeyword::Undefined => Ok(Type {
+                kind: TypeKind::Keyword(TKeyword::Never),
+            }),
+            TKeyword::Never => Ok(Type {
+                kind: TypeKind::Keyword(TKeyword::Never),
+            }),
         },
-        Type::Union(_) => todo!(),
-        Type::Intersection(elems) => {
+        TypeKind::Union(_) => todo!(),
+        TypeKind::Intersection(elems) => {
             let elems: Result<Vec<_>, String> =
                 elems.iter().map(|elem| key_of(elem, ctx)).collect();
             Ok(union_many_types(&elems?))
         }
-        Type::Rest(_) => {
+        TypeKind::Rest(_) => {
             todo!() // What does this even mean?
         }
-        Type::This => {
+        TypeKind::This => {
             todo!() // Depends on what this is referencing
         }
-        Type::KeyOf(t) => key_of(&key_of(t, ctx)?, ctx),
-        Type::Mutable(t) => key_of(t, ctx),
-        Type::IndexAccess(_) => {
+        TypeKind::KeyOf(t) => key_of(&key_of(t, ctx)?, ctx),
+        TypeKind::Mutable(t) => key_of(t, ctx),
+        TypeKind::IndexAccess(_) => {
             todo!() // We have to evaluate the IndexAccess first
         }
     }

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -74,9 +74,11 @@ Program {
                                                 },
                                             ),
                                             inferred_type: Some(
-                                                Keyword(
-                                                    Number,
-                                                ),
+                                                Type {
+                                                    kind: Keyword(
+                                                        Number,
+                                                    ),
+                                                },
                                             ),
                                         },
                                         right: Expr {
@@ -88,17 +90,21 @@ Program {
                                                 },
                                             ),
                                             inferred_type: Some(
-                                                Keyword(
-                                                    Number,
-                                                ),
+                                                Type {
+                                                    kind: Keyword(
+                                                        Number,
+                                                    ),
+                                                },
                                             ),
                                         },
                                     },
                                 ),
                                 inferred_type: Some(
-                                    Keyword(
-                                        Number,
-                                    ),
+                                    Type {
+                                        kind: Keyword(
+                                            Number,
+                                        ),
+                                    },
                                 ),
                             },
                             is_async: false,
@@ -107,39 +113,47 @@ Program {
                         },
                     ),
                     inferred_type: Some(
-                        Lam(
-                            TLam {
-                                params: [
-                                    TFnParam {
-                                        pat: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
+                        Type {
+                            kind: Lam(
+                                TLam {
+                                    params: [
+                                        TFnParam {
+                                            pat: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                },
+                                            ),
+                                            t: Type {
+                                                kind: Keyword(
+                                                    Number,
+                                                ),
                                             },
-                                        ),
-                                        t: Keyword(
+                                            optional: false,
+                                        },
+                                        TFnParam {
+                                            pat: Ident(
+                                                BindingIdent {
+                                                    name: "b",
+                                                    mutable: false,
+                                                },
+                                            ),
+                                            t: Type {
+                                                kind: Keyword(
+                                                    Number,
+                                                ),
+                                            },
+                                            optional: false,
+                                        },
+                                    ],
+                                    ret: Type {
+                                        kind: Keyword(
                                             Number,
                                         ),
-                                        optional: false,
                                     },
-                                    TFnParam {
-                                        pat: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                            },
-                                        ),
-                                        t: Keyword(
-                                            Number,
-                                        ),
-                                        optional: false,
-                                    },
-                                ],
-                                ret: Keyword(
-                                    Number,
-                                ),
-                            },
-                        ),
+                                },
+                            ),
+                        },
                     ),
                 },
             ),

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -1,5 +1,5 @@
 use crochet_ast::*;
-use crochet_types::Type;
+use crochet_types::TypeKind;
 
 use crate::substitutable::{Subst, Substitutable};
 
@@ -7,7 +7,7 @@ pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &pattern.inferred_type {
-        if let Type::Var(_) = t {
+        if let TypeKind::Var(_) = &t.kind {
             pattern.inferred_type = Some(t.apply(s));
         }
     }
@@ -57,7 +57,7 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &expr.inferred_type {
-        if let Type::Var(_) = t {
+        if let TypeKind::Var(_) = &t.kind {
             expr.inferred_type = Some(t.apply(s));
         }
     }
@@ -238,7 +238,7 @@ pub fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
     if let Some(t) = &type_ann.inferred_type {
-        if let Type::Var(_) = t {
+        if let TypeKind::Var(_) = &t.kind {
             type_ann.inferred_type = Some(t.apply(s));
         }
     }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -16,10 +16,12 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
         .map(|(index, key)| {
             (
                 key.id,
-                Type::Var(TVar {
-                    id: index as i32,
-                    constraint: key.constraint.clone(),
-                }),
+                Type {
+                    kind: TypeKind::Var(TVar {
+                        id: index as i32,
+                        constraint: key.constraint.clone(),
+                    }),
+                },
             )
         })
         .collect();
@@ -29,10 +31,12 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
     for (index, tp) in type_params.iter().enumerate() {
         mapping.insert(
             tp.id,
-            Type::Var(TVar {
-                id: (offset + index) as i32,
-                constraint: tp.constraint.clone(),
-            }),
+            Type {
+                kind: TypeKind::Var(TVar {
+                    id: (offset + index) as i32,
+                    constraint: tp.constraint.clone(),
+                }),
+            },
         );
     }
 
@@ -51,8 +55,8 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
     // We should also add it to TObjElem (and structs used by its enums.  This will help us filter out
     // type variables that are bound to the object element as opposed to the encompassing object type.
     fn norm_type(t: &Type, mapping: &HashMap<i32, Type>, ctx: &Context) -> Type {
-        match t {
-            Type::Generic(TGeneric {
+        match &t.kind {
+            TypeKind::Generic(TGeneric {
                 t: inner_t,
                 type_params,
             }) => {
@@ -60,13 +64,13 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                 // mappings from higher up may cause type variables to be reassigned
                 // to the incorrect type.  In order to fix this, we'd have to run
                 // `normalize` itself on each qualified type in the tree.
-                Type::Generic(TGeneric {
+                Type { kind: TypeKind::Generic(TGeneric {
                     t: Box::from(norm_type(inner_t, mapping, ctx)),
                     type_params: type_params
                         .iter()
                         .map(|tp| match mapping.get(&tp.id) {
                             Some(t) => {
-                                if let Type::Var(tv) = t {
+                                if let TypeKind::Var(tv) = &t.kind {
                                     tv.to_owned()
                                 } else {
                                     panic!("Expected a type variable in mapping when update type_params");
@@ -75,24 +79,26 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                             None => tp.to_owned(),
                         })
                         .collect(),
-                })
+                })}
             }
-            Type::Var(tv) => match mapping.get(&tv.id) {
+            TypeKind::Var(tv) => match mapping.get(&tv.id) {
                 Some(t) => t.to_owned(),
                 // If `id` doesn't exist in `mapping` we return the original type variable.
                 // In this situation, it should appear in some other list of qualifiers.
                 None => t.to_owned(),
             },
-            Type::App(app) => {
+            TypeKind::App(app) => {
                 let args: Vec<_> = app
                     .args
                     .iter()
                     .map(|arg| norm_type(arg, mapping, ctx))
                     .collect();
                 let ret = Box::from(norm_type(&app.ret, mapping, ctx));
-                Type::App(TApp { args, ret })
+                Type {
+                    kind: TypeKind::App(TApp { args, ret }),
+                }
             }
-            Type::Lam(lam) => {
+            TypeKind::Lam(lam) => {
                 let params: Vec<_> = lam
                     .params
                     .iter()
@@ -102,23 +108,27 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                     })
                     .collect();
                 let ret = Box::from(norm_type(&lam.ret, mapping, ctx));
-                Type::Lam(TLam { params, ret })
+                Type {
+                    kind: TypeKind::Lam(TLam { params, ret }),
+                }
             }
-            Type::Lit(_) => t.to_owned(),
-            Type::Keyword(_) => t.to_owned(),
-            Type::Union(types) => {
+            TypeKind::Lit(_) => t.to_owned(),
+            TypeKind::Keyword(_) => t.to_owned(),
+            TypeKind::Union(types) => {
                 // TODO: update union_types from constraint_solver.rs to handle
                 // any number of types instead of just two and then call it here.
                 let types = types.iter().map(|t| norm_type(t, mapping, ctx)).collect();
-                Type::Union(types)
+                Type {
+                    kind: TypeKind::Union(types),
+                }
             }
-            Type::Intersection(types) => {
+            TypeKind::Intersection(types) => {
                 // TODO: update intersection_types from constraint_solver.rs to handle
                 // any number of types instead of just two and then call it here.
                 let types: Vec<_> = types.iter().map(|t| norm_type(t, mapping, ctx)).collect();
                 simplify_intersection(&types)
             }
-            Type::Object(obj) => {
+            TypeKind::Object(obj) => {
                 let elems = obj
                     .elems
                     .iter()
@@ -170,30 +180,48 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                         }),
                     })
                     .collect();
-                Type::Object(TObject { elems })
+                Type {
+                    kind: TypeKind::Object(TObject { elems }),
+                }
             }
-            Type::Ref(TRef { name, type_args }) => {
+            TypeKind::Ref(TRef { name, type_args }) => {
                 let type_args = type_args
                     .clone()
                     .map(|params| params.iter().map(|t| norm_type(t, mapping, ctx)).collect());
-                Type::Ref(TRef {
-                    name: name.to_owned(),
-                    type_args,
-                })
+                Type {
+                    kind: TypeKind::Ref(TRef {
+                        name: name.to_owned(),
+                        type_args,
+                    }),
+                }
             }
-            Type::Tuple(types) => {
+            TypeKind::Tuple(types) => {
                 let types = types.iter().map(|t| norm_type(t, mapping, ctx)).collect();
-                Type::Tuple(types)
+                Type {
+                    kind: TypeKind::Tuple(types),
+                }
             }
-            Type::Array(t) => Type::Array(Box::from(norm_type(t, mapping, ctx))),
-            Type::Rest(arg) => Type::Rest(Box::from(norm_type(arg, mapping, ctx))),
-            Type::This => Type::This,
-            Type::KeyOf(t) => Type::KeyOf(Box::from(norm_type(t, mapping, ctx))),
-            Type::IndexAccess(TIndexAccess { object, index }) => Type::IndexAccess(TIndexAccess {
-                object: Box::from(norm_type(object, mapping, ctx)),
-                index: Box::from(norm_type(index, mapping, ctx)),
-            }),
-            Type::Mutable(t) => Type::Mutable(Box::from(norm_type(t, mapping, ctx))),
+            TypeKind::Array(t) => Type {
+                kind: TypeKind::Array(Box::from(norm_type(t, mapping, ctx))),
+            },
+            TypeKind::Rest(arg) => Type {
+                kind: TypeKind::Rest(Box::from(norm_type(arg, mapping, ctx))),
+            },
+            TypeKind::This => Type {
+                kind: TypeKind::This,
+            },
+            TypeKind::KeyOf(t) => Type {
+                kind: TypeKind::KeyOf(Box::from(norm_type(t, mapping, ctx))),
+            },
+            TypeKind::IndexAccess(TIndexAccess { object, index }) => Type {
+                kind: TypeKind::IndexAccess(TIndexAccess {
+                    object: Box::from(norm_type(object, mapping, ctx)),
+                    index: Box::from(norm_type(index, mapping, ctx)),
+                }),
+            },
+            TypeKind::Mutable(t) => Type {
+                kind: TypeKind::Mutable(Box::from(norm_type(t, mapping, ctx))),
+            },
         }
     }
 
@@ -223,8 +251,8 @@ pub fn generalize(env: &Env, t: &Type) -> Type {
 pub fn simplify_intersection(in_types: &[Type]) -> Type {
     let obj_types: Vec<_> = in_types
         .iter()
-        .filter_map(|t| match &t {
-            Type::Object(elems) => Some(elems),
+        .filter_map(|t| match &t.kind {
+            TypeKind::Object(elems) => Some(elems),
             _ => None,
         })
         .collect();
@@ -252,7 +280,9 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
             let t: Type = if types.len() == 1 {
                 types[0].clone()
             } else {
-                Type::Intersection(types)
+                Type {
+                    kind: TypeKind::Intersection(types),
+                }
             };
             TObjElem::Prop(TProp {
                 name: name.to_owned(),
@@ -275,14 +305,16 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
 
     let mut not_obj_types: Vec<_> = in_types
         .iter()
-        .filter(|t| !matches!(t, Type::Object(_)))
+        .filter(|t| !matches!(&t.kind, TypeKind::Object(_)))
         .cloned()
         .collect();
 
     let mut out_types = vec![];
     out_types.append(&mut not_obj_types);
     if !elems.is_empty() {
-        out_types.push(Type::Object(TObject { elems }));
+        out_types.push(Type {
+            kind: TypeKind::Object(TObject { elems }),
+        });
     }
     // TODO: figure out a consistent way to sort types
     // out_types.sort_by_key(|t| t.id); // ensure a stable order
@@ -290,13 +322,15 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
     if out_types.len() == 1 {
         out_types[0].clone()
     } else {
-        Type::Intersection(out_types)
+        Type {
+            kind: TypeKind::Intersection(out_types),
+        }
     }
 }
 
 fn flatten_types(t: &Type) -> Vec<Type> {
-    match &t {
-        Type::Union(types) => types.iter().flat_map(flatten_types).collect(),
+    match &t.kind {
+        TypeKind::Union(types) => types.iter().flat_map(flatten_types).collect(),
         _ => vec![t.to_owned()],
     }
 }
@@ -313,18 +347,24 @@ pub fn union_many_types(ts: &[Type]) -> Type {
     let keyword_types: HashSet<_> = types_set
         .iter()
         .cloned()
-        .filter(|t| matches!(t, Type::Keyword(_)))
+        .filter(|t| matches!(&t.kind, TypeKind::Keyword(_)))
         .collect();
 
     let lit_types: HashSet<_> = types_set
         .iter()
         .cloned()
-        .filter(|t| match &t {
+        .filter(|t| match &t.kind {
             // Primitive types subsume corresponding literal types
-            Type::Lit(lit) => match lit {
-                TLit::Num(_) => !keyword_types.contains(&Type::Keyword(TKeyword::Number)),
-                TLit::Bool(_) => !keyword_types.contains(&Type::Keyword(TKeyword::Boolean)),
-                TLit::Str(_) => !keyword_types.contains(&Type::Keyword(TKeyword::String)),
+            TypeKind::Lit(lit) => match lit {
+                TLit::Num(_) => !keyword_types.contains(&Type {
+                    kind: TypeKind::Keyword(TKeyword::Number),
+                }),
+                TLit::Bool(_) => !keyword_types.contains(&Type {
+                    kind: TypeKind::Keyword(TKeyword::Boolean),
+                }),
+                TLit::Str(_) => !keyword_types.contains(&Type {
+                    kind: TypeKind::Keyword(TKeyword::String),
+                }),
             },
             _ => false,
         })
@@ -333,7 +373,7 @@ pub fn union_many_types(ts: &[Type]) -> Type {
     let other_types: HashSet<_> = types_set
         .iter()
         .cloned()
-        .filter(|t| !matches!(t, Type::Lit(_) | Type::Keyword(_)))
+        .filter(|t| !matches!(&t.kind, TypeKind::Lit(_) | TypeKind::Keyword(_)))
         .collect();
 
     let types: Vec<_> = keyword_types
@@ -344,7 +384,9 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         .collect();
 
     if types.len() > 1 {
-        Type::Union(types)
+        Type {
+            kind: TypeKind::Union(types),
+        }
     } else {
         types[0].clone()
     }
@@ -394,14 +436,21 @@ pub fn compose_many_subs_with_context(subs: &[Subst]) -> Subst {
 pub fn get_property_type(prop: &TProp) -> Type {
     let t = prop.t.to_owned();
     match prop.optional {
-        true => Type::Union(vec![t, Type::Keyword(TKeyword::Undefined)]),
+        true => Type {
+            kind: TypeKind::Union(vec![
+                t,
+                Type {
+                    kind: TypeKind::Keyword(TKeyword::Undefined),
+                },
+            ]),
+        },
         false => t,
     }
 }
 
 pub fn get_type_params(t: &Type) -> Vec<TVar> {
-    match t {
-        Type::Generic(gen) => gen.type_params.to_owned(),
+    match &t.kind {
+        TypeKind::Generic(gen) => gen.type_params.to_owned(),
         _ => vec![],
     }
 }
@@ -413,20 +462,24 @@ pub fn set_type_params(t: &Type, type_params: &[TVar]) -> Type {
         return t.to_owned();
     }
 
-    match t {
-        Type::Var(_) => t.to_owned(),
-        Type::Generic(TGeneric {
+    match &t.kind {
+        TypeKind::Var(_) => t.to_owned(),
+        TypeKind::Generic(TGeneric {
             t,
             // NOTE: `generalize_type` is responsible for merge type params so
             // it's safe to ignore `type_params` here.
             type_params: _,
-        }) => Type::Generic(TGeneric {
-            t: t.to_owned(),
-            type_params: type_params.to_owned(),
-        }),
-        _ => Type::Generic(TGeneric {
-            t: Box::from(t.to_owned()),
-            type_params: type_params.to_owned(),
-        }),
+        }) => Type {
+            kind: TypeKind::Generic(TGeneric {
+                t: t.to_owned(),
+                type_params: type_params.to_owned(),
+            }),
+        },
+        _ => Type {
+            kind: TypeKind::Generic(TGeneric {
+                t: Box::from(t.to_owned()),
+                type_params: type_params.to_owned(),
+            }),
+        },
     }
 }

--- a/crates/crochet_types/src/lam.rs
+++ b/crates/crochet_types/src/lam.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use crate::keyword::TKeyword;
 use crate::pat::TPat;
-use crate::r#type::Type;
+use crate::r#type::{Type, TypeKind};
 
 #[derive(Clone, Debug, Eq)]
 pub struct TLam {
@@ -42,7 +42,14 @@ pub struct TFnParam {
 impl TFnParam {
     pub fn get_type(&self) -> Type {
         match self.optional {
-            true => Type::Union(vec![self.t.to_owned(), Type::Keyword(TKeyword::Undefined)]),
+            true => {
+                let undefined = Type {
+                    kind: TypeKind::Keyword(TKeyword::Undefined),
+                };
+                Type {
+                    kind: TypeKind::Union(vec![self.t.to_owned(), undefined]),
+                }
+            }
             false => self.t.to_owned(),
         }
     }

--- a/crates/crochet_types/src/type.rs
+++ b/crates/crochet_types/src/type.rs
@@ -80,7 +80,7 @@ pub struct TVar {
 // }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Type {
+pub enum TypeKind {
     Var(TVar),
     App(TApp),
     Lam(TLam),
@@ -101,17 +101,24 @@ pub enum Type {
     Generic(TGeneric),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Type {
+    pub kind: TypeKind,
+}
+
 impl From<TLit> for Type {
     fn from(lit: TLit) -> Self {
-        Type::Lit(lit)
+        Type {
+            kind: TypeKind::Lit(lit),
+        }
     }
 }
 
 impl fmt::Display for Type {
     // TODO: add in parentheses where necessary to get the precedence right
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Type::Generic(TGeneric { t, type_params }) => {
+        match &self.kind {
+            TypeKind::Generic(TGeneric { t, type_params }) => {
                 if type_params.is_empty() {
                     write!(f, "{t}")
                 } else {
@@ -126,32 +133,32 @@ impl fmt::Display for Type {
                     write!(f, "<{}>{t}", join(type_params, ", "))
                 }
             }
-            Type::Var(tv) => write!(f, "t{}", tv.id),
-            Type::App(TApp { args, ret }) => {
+            TypeKind::Var(tv) => write!(f, "t{}", tv.id),
+            TypeKind::App(TApp { args, ret }) => {
                 write!(f, "({}) => {}", join(args, ", "), ret)
             }
-            Type::Lam(lam) => write!(f, "{lam}"),
-            Type::Lit(lit) => write!(f, "{}", lit),
-            Type::Keyword(keyword) => write!(f, "{}", keyword),
-            Type::Union(types) => {
+            TypeKind::Lam(lam) => write!(f, "{lam}"),
+            TypeKind::Lit(lit) => write!(f, "{}", lit),
+            TypeKind::Keyword(keyword) => write!(f, "{}", keyword),
+            TypeKind::Union(types) => {
                 let strings: Vec<_> = types.iter().map(|t| format!("{t}")).sorted().collect();
                 write!(f, "{}", join(strings, " | "))
             }
-            Type::Intersection(types) => {
+            TypeKind::Intersection(types) => {
                 let strings: Vec<_> = types.iter().map(|t| format!("{t}")).sorted().collect();
                 write!(f, "{}", join(strings, " & "))
             }
-            Type::Object(TObject { elems, .. }) => {
+            TypeKind::Object(TObject { elems, .. }) => {
                 write!(f, "{{{}}}", join(elems, ", "))
             }
-            Type::Ref(tr) => write!(f, "{tr}"),
-            Type::Tuple(types) => write!(f, "[{}]", join(types, ", ")),
-            Type::Array(t) => write!(f, "{t}[]"),
-            Type::Rest(arg) => write!(f, "...{arg}"),
-            Type::This => write!(f, "this"),
-            Type::KeyOf(t) => write!(f, "keyof {t}"),
-            Type::Mutable(t) => write!(f, "mut {t}"),
-            Type::IndexAccess(TIndexAccess { object, index }) => write!(f, "{object}[{index}]"),
+            TypeKind::Ref(tr) => write!(f, "{tr}"),
+            TypeKind::Tuple(types) => write!(f, "[{}]", join(types, ", ")),
+            TypeKind::Array(t) => write!(f, "{t}[]"),
+            TypeKind::Rest(arg) => write!(f, "...{arg}"),
+            TypeKind::This => write!(f, "this"),
+            TypeKind::KeyOf(t) => write!(f, "keyof {t}"),
+            TypeKind::Mutable(t) => write!(f, "mut {t}"),
+            TypeKind::IndexAccess(TIndexAccess { object, index }) => write!(f, "{object}[{index}]"),
         }
     }
 }


### PR DESCRIPTION
This is preparation for adding provenance information to the `Type` struct which is necessary for assigning literal subtype types to mutable variables, e.g. `let air: mut number[] = [1, 2, 3]`.  These will be handle in separate future PRs.