### PR TITLE
Require 'fn' to introduce arrow functions (experiment)

### DIFF
--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -813,23 +813,25 @@ Functions
 Arrow functions
 ================================================================================
 
-a => 1;
-() => 2;
-(d, e) => 3;
-(f, g) => {
+fn (a) => 1;
+fn () => 2;
+fn (d, e) => 3;
+fn (f, g) => {
   return h;
 };
-(trailing,) => 4;
-(h, trailing,) => 5;
-(set, kv) => 2;
-async => async + 1;
+fn (trailing,) => 4;
+fn (h, trailing,) => 5;
+fn (set, kv) => 2;
+fn (async) => async + 1;
 
 --------------------------------------------------------------------------------
 
 (program
   (expression_statement
     (arrow_function
-      (identifier)
+      (formal_parameters
+        (required_parameter
+          (identifier)))
       (number)))
   (expression_statement
     (arrow_function
@@ -877,7 +879,9 @@ async => async + 1;
       (number)))
   (expression_statement
     (arrow_function
-      (identifier)
+      (formal_parameters
+        (required_parameter
+          (identifier)))
       (binary_expression
         (identifier)
         (number)))))
@@ -1235,7 +1239,7 @@ class Foo {
   async bar() {}
 }
 
-async (a) => { return foo; };
+async fn (a) => { return foo; };
 
 async function* foo() { yield 1 }
 
@@ -2282,7 +2286,7 @@ let result = try { throw [a, b] } catch ([c, d]) { };
 Throw expressions
 ================================================================================
 
-const foo = (msg) => throw new Error(msg);
+const foo = fn (msg) => throw new Error(msg);
 
 --------------------------------------------------------------------------------
 

--- a/crates/tree_sitter_crochet/corpus/statements.txt
+++ b/crates/tree_sitter_crochet/corpus/statements.txt
@@ -31,7 +31,7 @@ let d = 0;
 let-rec
 ================================================================================
 
-let rec f = () => f();
+let rec f = fn () => f();
 
 --------------------------------------------------------------------------------
 
@@ -88,7 +88,7 @@ import defaultMember, * as name from "module-name";
 import "module-name";
 import { member1 , member2 as alias2, } from "module-name";
 import("a");
-import("a").then((m) => {});
+import("a").then(fn (m) => {});
 import.meta.url;
 
 --------------------------------------------------------------------------------

--- a/crates/tree_sitter_crochet/corpus/tsx/functions.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/functions.txt
@@ -161,13 +161,13 @@ A?.<B>();
 Arrow functions and generators with call signatures
 ================================================================================
 
-<A>(amount, interestRate, duration): number => 2;
+fn <A>(amount, interestRate, duration): number => 2;
 
 function* foo<A>(amount, interestRate, duration): number {
 	yield amount * interestRate * duration / 12;
 }
 
-(module: any): number => 2;
+fn (module: any): number => 2;
 
 --------------------------------------------------------------------------------
 
@@ -226,7 +226,7 @@ function* foo<A>(amount, interestRate, duration): number {
 Arrow function with parameter named async
 ================================================================================
 
-const x = async => async;
+const x = fn (async) => async;
 
 --------------------------------------------------------------------------------
 
@@ -235,7 +235,9 @@ const x = async => async;
     (variable_declarator
       (identifier)
       (arrow_function
-        (identifier)
+        (formal_parameters
+          (required_parameter
+            (identifier)))
         (identifier)))))
 
 ================================================================================

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -104,6 +104,16 @@ module.exports = grammar(tsx, {
     switch_case: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
     switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
 
+    arrow_function: ($, prev) => {
+      const members = [
+        prev.members[0],
+        "fn",
+        $._call_signature,
+        ...prev.members.slice(2),
+      ];
+      return seq(...members);
+    },
+
     if_expression: ($) =>
       prec.right(
         seq(


### PR DESCRIPTION
This PR also requires parens are the params even if there's only one.  The question now is if we're requiring `fn` at the start, do we need to keep the `=>`?

The nice thing about the arrow is that it makes curried functions look nice, e.g.
```
let foo = (a) => (b) => (c) => a + b + c;
```
vs.
```
let foo = fn (a) fn (b) fn (c) a + b + c;
```
We'd probably also want to require braces as well like we do with other constructs that contain statement blocks.
```
let foo = fn (a) {
  fn (b) {
     fn (c) {
        a + b + c
     }
  }
}
```
This also introduces another interesting question about the similarity/differences between how functions are represented at the value level vs at the type level.