### PR TITLE
Replace uses of HashSet with BTreeSet

### DIFF
--- a/crates/crochet_ast/src/common/binding.rs
+++ b/crates/crochet_ast/src/common/binding.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BindingIdent {
     pub name: String,
 }

--- a/crates/crochet_ast/src/types/keyword.rs
+++ b/crates/crochet_ast/src/types/keyword.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::hash::Hash;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TKeyword {
     Number,
     Boolean,

--- a/crates/crochet_ast/src/types/lam.rs
+++ b/crates/crochet_ast/src/types/lam.rs
@@ -1,28 +1,14 @@
 use itertools::join;
 use std::fmt;
-use std::hash::Hash;
 
 use crate::types::keyword::TKeyword;
 use crate::types::pat::TPat;
 use crate::types::r#type::{Type, TypeKind};
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TLam {
     pub params: Vec<TFnParam>,
     pub ret: Box<Type>,
-}
-
-impl PartialEq for TLam {
-    fn eq(&self, other: &Self) -> bool {
-        self.params == other.params && self.ret == other.ret
-    }
-}
-
-impl Hash for TLam {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.params.hash(state);
-        self.ret.hash(state);
-    }
 }
 
 impl fmt::Display for TLam {
@@ -32,7 +18,7 @@ impl fmt::Display for TLam {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TFnParam {
     pub pat: TPat,
     pub t: Type,

--- a/crates/crochet_ast/src/types/lit.rs
+++ b/crates/crochet_ast/src/types/lit.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::hash::Hash;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TLit {
     // We store all of the values as strings since f64 doesn't
     // support the Eq trait because NaN and 0.1 + 0.2 != 0.3.

--- a/crates/crochet_ast/src/types/obj.rs
+++ b/crates/crochet_ast/src/types/obj.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::types::r#type::{TVar, Type};
 use crate::types::TFnParam;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TCallable {
     pub params: Vec<TFnParam>,
     pub ret: Box<Type>,
@@ -39,7 +39,7 @@ impl fmt::Display for TCallable {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TObjElem {
     Call(TCallable),
     Constructor(TCallable),
@@ -61,7 +61,7 @@ impl fmt::Display for TObjElem {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TIndex {
     // TODO: update this to only allow `<ident>: string` or `<ident>: number`
     pub key: TFnParam,
@@ -79,7 +79,7 @@ impl fmt::Display for TIndex {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TProp {
     pub name: String,
     pub optional: bool,

--- a/crates/crochet_ast/src/types/pat.rs
+++ b/crates/crochet_ast/src/types/pat.rs
@@ -1,11 +1,10 @@
 use itertools::join;
 use std::fmt;
-use std::hash::Hash;
 
 use crate::common::binding::*;
 use crate::types::r#type::Type;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TPat {
     Ident(BindingIdent),
     Rest(RestPat),
@@ -24,7 +23,7 @@ impl fmt::Display for TPat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RestPat {
     pub arg: Box<TPat>,
 }
@@ -36,7 +35,7 @@ impl fmt::Display for RestPat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArrayPat {
     pub elems: Vec<Option<TPat>>,
 }
@@ -52,7 +51,7 @@ impl fmt::Display for ArrayPat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TObjectPat {
     pub props: Vec<TObjectPatProp>,
 }
@@ -64,7 +63,7 @@ impl fmt::Display for TObjectPat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TObjectPatProp {
     KeyValue(TObjectKeyValuePatProp),
     Assign(TObjectAssignPatProp),
@@ -81,7 +80,7 @@ impl fmt::Display for TObjectPatProp {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TObjectKeyValuePatProp {
     pub key: String,
     pub value: TPat,
@@ -94,7 +93,7 @@ impl fmt::Display for TObjectKeyValuePatProp {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TObjectAssignPatProp {
     pub key: String,
     pub value: Option<Type>,

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -1,37 +1,23 @@
 use itertools::{join, Itertools};
 use std::fmt;
-use std::hash::Hash;
 
 use crate::types::keyword::TKeyword;
 use crate::types::lam::TLam;
 use crate::types::lit::TLit;
 use crate::types::obj::TObjElem;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TApp {
     pub args: Vec<Type>,
     pub ret: Box<Type>,
     // TODO: add type_args property to support explicit specification of type args
 }
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TRef {
     pub name: String,
     // TODO: make this non-optional
     pub type_args: Option<Vec<Type>>,
-}
-
-impl PartialEq for TRef {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.type_args == other.type_args
-    }
-}
-
-impl Hash for TRef {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        self.type_args.hash(state);
-    }
 }
 
 impl fmt::Display for TRef {
@@ -44,24 +30,24 @@ impl fmt::Display for TRef {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TObject {
     pub elems: Vec<TObjElem>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TIndexAccess {
     pub object: Box<Type>,
     pub index: Box<Type>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TGeneric {
     pub t: Box<Type>,
     pub type_params: Vec<TVar>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TVar {
     pub id: i32,
     pub constraint: Option<Box<Type>>,
@@ -79,7 +65,7 @@ pub struct TVar {
 //     }
 // }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TypeKind {
     Var(TVar),
     App(TApp),
@@ -101,7 +87,7 @@ pub enum TypeKind {
     Generic(TGeneric),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Type {
     pub kind: TypeKind,
 }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -1,5 +1,5 @@
 use array_tool::vec::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 use crochet_ast::types::*;
 
@@ -270,7 +270,7 @@ fn norm_type(t: Type) -> Type {
     match &t.kind {
         TypeKind::Union(types) => {
             // Removes duplicates
-            let types: HashSet<Type> = types.clone().into_iter().collect();
+            let types: BTreeSet<Type> = types.clone().into_iter().collect();
             // Converts set back to an array
             let types: Vec<Type> = types.into_iter().collect();
 
@@ -284,7 +284,7 @@ fn norm_type(t: Type) -> Type {
         }
         TypeKind::Intersection(types) => {
             // Removes duplicates
-            let types: HashSet<Type> = types.clone().into_iter().collect();
+            let types: BTreeSet<Type> = types.clone().into_iter().collect();
             // Converts set back to an array
             let types: Vec<Type> = types.into_iter().collect();
 

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use crochet_ast::types::{self as types, TGeneric, TLam, TObjElem, TObject, TVar, Type, TypeKind};
 use types::TKeyword;
@@ -583,7 +583,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &Context) -> Result<Subst, Stri
                         // TODO: dedupe with `norm_type()` in substitutable.rs
                         // TODO: restrict this special case handling to recursive functions?
                         // Removes duplicates
-                        let types: HashSet<Type> = elem_types_without_id.into_iter().collect();
+                        let types: BTreeSet<Type> = elem_types_without_id.into_iter().collect();
                         // Converts set back to an array
                         let types: Vec<Type> = types.into_iter().collect();
 

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -1,6 +1,6 @@
 use array_tool::vec::*;
 use defaultmap::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::iter::Iterator;
 
 use crochet_ast::types::*;
@@ -258,7 +258,7 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
         .collect();
 
     // The use of HashSet<Type> here is to avoid duplicate types
-    let mut props_map: DefaultHashMap<String, HashSet<Type>> = defaulthashmap!();
+    let mut props_map: DefaultHashMap<String, BTreeSet<Type>> = defaulthashmap!();
     for obj in obj_types {
         for elem in &obj.elems {
             match elem {
@@ -342,15 +342,15 @@ pub fn union_types(t1: &Type, t2: &Type) -> Type {
 pub fn union_many_types(ts: &[Type]) -> Type {
     let types: Vec<_> = ts.iter().flat_map(flatten_types).collect();
 
-    let types_set: HashSet<_> = types.iter().cloned().collect();
+    let types_set: BTreeSet<_> = types.iter().cloned().collect();
 
-    let keyword_types: HashSet<_> = types_set
+    let keyword_types: BTreeSet<_> = types_set
         .iter()
         .cloned()
         .filter(|t| matches!(&t.kind, TypeKind::Keyword(_)))
         .collect();
 
-    let lit_types: HashSet<_> = types_set
+    let lit_types: BTreeSet<_> = types_set
         .iter()
         .cloned()
         .filter(|t| match &t.kind {
@@ -370,7 +370,7 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         })
         .collect();
 
-    let other_types: HashSet<_> = types_set
+    let other_types: BTreeSet<_> = types_set
         .iter()
         .cloned()
         .filter(|t| !matches!(&t.kind, TypeKind::Lit(_) | TypeKind::Keyword(_)))


### PR DESCRIPTION
`BTreeSet` has a stable ordering and `PartialOrd` and `Ord` traits can both be derived automatically for structs and enums.  The order of enum variants is based on the order they appear in the code.