### PR TITLE
Add .provenance field to Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
 name = "crochet_ast"
 version = "0.1.0"
 dependencies = [
+ "derivative",
  "itertools",
  "swc_atoms",
  "swc_common",
@@ -326,6 +327,17 @@ name = "defaultmap"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c4d4fbd66561c3acff86b297b024826505a715eb1b0984a78013b349d0e834"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "diff"

--- a/crates/crochet_ast/Cargo.toml
+++ b/crates/crochet_ast/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+derivative = "2.2.0"
 itertools = "0.10.3"
 # TODO: hide these behind a feature and then only use that feature in the codegen crate
 swc_atoms = "0.4.21"

--- a/crates/crochet_ast/src/types/lam.rs
+++ b/crates/crochet_ast/src/types/lam.rs
@@ -31,9 +31,11 @@ impl TFnParam {
             true => {
                 let undefined = Type {
                     kind: TypeKind::Keyword(TKeyword::Undefined),
+                    provenance: None,
                 };
                 Type {
                     kind: TypeKind::Union(vec![self.t.to_owned(), undefined]),
+                    provenance: None,
                 }
             }
             false => self.t.to_owned(),

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -1,3 +1,4 @@
+use derivative::*;
 use itertools::{join, Itertools};
 use std::fmt;
 
@@ -5,6 +6,7 @@ use crate::types::keyword::TKeyword;
 use crate::types::lam::TLam;
 use crate::types::lit::TLit;
 use crate::types::obj::TObjElem;
+use crate::values::expr::Expr;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TApp {
@@ -87,15 +89,20 @@ pub enum TypeKind {
     Generic(TGeneric),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Derivative)]
+#[derivative(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Type {
     pub kind: TypeKind,
+    #[derivative(Ord = "ignore")]
+    #[derivative(PartialOrd = "ignore")]
+    pub provenance: Option<Box<Expr>>,
 }
 
 impl From<TLit> for Type {
     fn from(lit: TLit) -> Self {
         Type {
             kind: TypeKind::Lit(lit),
+            provenance: None,
         }
     }
 }

--- a/crates/crochet_ast/src/values/keyword.rs
+++ b/crates/crochet_ast/src/values/keyword.rs
@@ -52,6 +52,7 @@ impl From<Keyword> for Type {
                 Keyword::Symbol => TKeyword::Symbol,
                 Keyword::Undefined => TKeyword::Undefined,
             }),
+            provenance: None,
         }
     }
 }

--- a/crates/crochet_ast/src/values/lit.rs
+++ b/crates/crochet_ast/src/values/lit.rs
@@ -108,6 +108,7 @@ impl From<Lit> for Type {
                 Lit::Bool(b) => TLit::Bool(b.value),
                 Lit::Str(s) => TLit::Str(s.value),
             }),
+            provenance: None,
         }
     }
 }

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -628,6 +628,7 @@ pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType
                 return build_type(
                     &Type {
                         kind: TypeKind::Object(TObject { elems }),
+                        provenance: None,
                     },
                     type_params,
                 );

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -29,27 +29,34 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
             TsKeywordTypeKind::TsUnknownKeyword => Ok(ctx.fresh_var()),
             TsKeywordTypeKind::TsNumberKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Number),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsObjectKeyword => Err(String::from("can't parse Objects yet")),
             TsKeywordTypeKind::TsBooleanKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Boolean),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsBigIntKeyword => Err(String::from("can't parse BigInt yet")),
             TsKeywordTypeKind::TsStringKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::String),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsSymbolKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Symbol),
+                provenance: None,
             }),
             // NOTE: `void` is treated the same as `undefined` ...for now.
             TsKeywordTypeKind::TsVoidKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Undefined),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsUndefinedKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Undefined),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsNullKeyword => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Null),
+                provenance: None,
             }),
             TsKeywordTypeKind::TsNeverKeyword => Err(String::from("can't parse never keyword yet")),
             TsKeywordTypeKind::TsIntrinsicKeyword => {
@@ -58,6 +65,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
         },
         TsType::TsThisType(_) => Ok(Type {
             kind: TypeKind::This,
+            provenance: None,
         }),
         TsType::TsFnOrConstructorType(fn_or_constructor) => match &fn_or_constructor {
             TsFnOrConstructorType::TsFnType(fn_type) => {
@@ -69,6 +77,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                         params,
                         ret: Box::from(ret),
                     }),
+                    provenance: None,
                 };
 
                 match &fn_type.type_params {
@@ -101,6 +110,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                             name,
                             type_args: result.ok(),
                         }),
+                        provenance: None,
                     })
                 }
                 None => Ok(Type {
@@ -108,6 +118,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                         name,
                         type_args: None,
                     }),
+                    provenance: None,
                 }),
             }
         }
@@ -117,6 +128,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
             let elem_type = infer_ts_type_ann(&array.elem_type, ctx)?;
             Ok(Type {
                 kind: TypeKind::Array(Box::from(elem_type)),
+                provenance: None,
             })
         }
         TsType::TsTupleType(_) => Err(String::from("can't parse tuple type yet")),
@@ -131,6 +143,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                     .collect();
                 Ok(Type {
                     kind: TypeKind::Union(types?),
+                    provenance: None,
                 })
             }
             TsUnionOrIntersectionType::TsIntersectionType(intersection) => {
@@ -141,6 +154,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                     .collect();
                 Ok(Type {
                     kind: TypeKind::Intersection(types?),
+                    provenance: None,
                 })
             }
         },
@@ -159,6 +173,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                     let type_ann = infer_ts_type_ann(type_ann, ctx)?;
                     Ok(Type {
                         kind: TypeKind::KeyOf(Box::from(type_ann)),
+                        provenance: None,
                     })
                 }
                 TsTypeOperatorOp::Unique => todo!(),
@@ -245,6 +260,7 @@ fn infer_method_sig(sig: &TsMethodSignature, ctx: &Context) -> Result<Type, Stri
             params,
             ret: Box::from(ret?),
         }),
+        provenance: None,
     };
 
     let t = match &sig.type_params {
@@ -371,6 +387,7 @@ fn infer_interface_decl(decl: &TsInterfaceDecl, ctx: &Context) -> Result<Type, S
     // TODO: make this generic if the decl has any type params
     let t = Type {
         kind: TypeKind::Object(TObject { elems }),
+        provenance: None,
     };
 
     let t = match &decl.type_params {

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -53,6 +53,7 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                     t: Box::from(replace_aliases_rec(t, map)),
                     type_params: type_params.to_owned(),
                 }),
+                provenance: None,
             }
         }
         TypeKind::Var(_) => t.to_owned(),
@@ -61,6 +62,7 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                 args: args.iter().map(|t| replace_aliases_rec(t, map)).collect(),
                 ret: Box::from(replace_aliases_rec(ret, map)),
             }),
+            provenance: None,
         },
         TypeKind::Lam(types::TLam { params, ret }) => Type {
             kind: TypeKind::Lam(types::TLam {
@@ -73,16 +75,19 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                     .collect(),
                 ret: Box::from(replace_aliases_rec(ret, map)),
             }),
+            provenance: None,
         },
         TypeKind::Lit(_) => t.to_owned(),
         TypeKind::Keyword(_) => t.to_owned(),
         TypeKind::Union(types) => Type {
             kind: TypeKind::Union(types.iter().map(|t| replace_aliases_rec(t, map)).collect()),
+            provenance: None,
         },
         TypeKind::Intersection(types) => Type {
             kind: TypeKind::Intersection(
                 types.iter().map(|t| replace_aliases_rec(t, map)).collect(),
             ),
+            provenance: None,
         },
         TypeKind::Object(obj) => {
             let elems: Vec<TObjElem> = obj
@@ -143,37 +148,46 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                 .collect();
             Type {
                 kind: TypeKind::Object(TObject { elems }),
+                provenance: None,
             }
         }
         TypeKind::Ref(alias) => match map.get(&alias.name) {
             Some(tv) => Type {
                 kind: TypeKind::Var(tv.to_owned()),
+                provenance: None,
             },
             None => t.to_owned(),
         },
         TypeKind::Tuple(types) => Type {
             kind: TypeKind::Tuple(types.iter().map(|t| replace_aliases_rec(t, map)).collect()),
+            provenance: None,
         },
         TypeKind::Array(t) => Type {
             kind: TypeKind::Array(Box::from(replace_aliases_rec(t, map))),
+            provenance: None,
         },
         TypeKind::Rest(t) => Type {
             kind: TypeKind::Rest(Box::from(replace_aliases_rec(t, map))),
+            provenance: None,
         },
         TypeKind::This => Type {
             kind: TypeKind::This,
+            provenance: None,
         },
         TypeKind::KeyOf(t) => Type {
             kind: TypeKind::KeyOf(Box::from(replace_aliases_rec(t, map))),
+            provenance: None,
         },
         TypeKind::IndexAccess(TIndexAccess { object, index }) => Type {
             kind: TypeKind::IndexAccess(TIndexAccess {
                 object: Box::from(replace_aliases_rec(object, map)),
                 index: Box::from(replace_aliases_rec(index, map)),
             }),
+            provenance: None,
         },
         TypeKind::Mutable(t) => Type {
             kind: TypeKind::Mutable(Box::from(replace_aliases_rec(t, map))),
+            provenance: None,
         },
     }
 }
@@ -192,6 +206,7 @@ pub fn merge_types(t1: &Type, t2: &Type) -> Type {
         .map(|tv| tv.id.to_owned())
         .zip(tp1.iter().map(|tv| Type {
             kind: TypeKind::Var(tv.to_owned()),
+            provenance: None,
         }))
         .collect();
 
@@ -223,6 +238,7 @@ pub fn merge_types(t1: &Type, t2: &Type) -> Type {
 
             Type {
                 kind: TypeKind::Object(TObject { elems }),
+                provenance: None,
             }
         }
         (_, _) => todo!(),
@@ -236,6 +252,7 @@ pub fn merge_types(t1: &Type, t2: &Type) -> Type {
                 t: Box::from(t),
                 type_params,
             }),
+            provenance: None,
         }
     }
 }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -164,6 +164,7 @@ impl Context {
                                 id: self.fresh_id(),
                                 constraint: tp.constraint.to_owned(),
                             }),
+                            provenance: None,
                         }))
                         .collect()
                     }
@@ -184,6 +185,7 @@ impl Context {
                         id: self.fresh_id(),
                         constraint: tp.constraint.to_owned(),
                     }),
+                    provenance: None,
                 });
                 let subs: Subst = ids.zip(fresh_params).collect();
 
@@ -213,6 +215,7 @@ impl Context {
                 id: self.fresh_id(),
                 constraint: None,
             }),
+            provenance: None,
         }
     }
 }

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -21,6 +21,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
     })];
     let promise_type = Type {
         kind: TypeKind::Object(TObject { elems }),
+        provenance: None,
     };
     ctx.insert_type(String::from("Promise"), promise_type);
     // TODO: replace with Class type once it exists
@@ -34,6 +35,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
     })];
     let jsx_element_type = Type {
         kind: TypeKind::Object(TObject { elems }),
+        provenance: None,
     };
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -30,6 +30,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         TypeKind::Tuple(types) => arg_types.extend(types.to_owned()),
                         _ => arg_types.push(Type {
                             kind: TypeKind::Rest(Box::from(arg_t)),
+                            provenance: None,
                         }),
                     }
                 } else {
@@ -46,6 +47,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                     args: arg_types,
                     ret: Box::from(ret_type.clone()),
                 }),
+                provenance: None,
             };
             let s3 = unify(&call_type, &lam_type, ctx)?;
 
@@ -73,6 +75,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         params: vec![param],
                         ret: Box::from(tv),
                     }),
+                    provenance: None,
                 },
                 &t,
                 ctx,
@@ -119,6 +122,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                             &t1,
                             &Type {
                                 kind: TypeKind::Keyword(TKeyword::Boolean),
+                                provenance: None,
                             },
                             ctx,
                         )?;
@@ -138,6 +142,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         &t1,
                         &Type {
                             kind: TypeKind::Keyword(TKeyword::Undefined),
+                            provenance: None,
                         },
                         ctx,
                     ) {
@@ -158,6 +163,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         &t1,
                         &Type {
                             kind: TypeKind::Keyword(TKeyword::Boolean),
+                            provenance: None,
                         },
                         ctx,
                     )?;
@@ -165,6 +171,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         &t2,
                         &Type {
                             kind: TypeKind::Keyword(TKeyword::Undefined),
+                            provenance: None,
                         },
                         ctx,
                     ) {
@@ -226,15 +233,18 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                                 name: String::from("JSXElement"),
                                 type_args: None,
                             }),
+                            provenance: None,
                         };
 
                         let call_type = Type {
                             kind: TypeKind::App(types::TApp {
                                 args: vec![Type {
                                     kind: TypeKind::Object(TObject { elems }),
+                                    provenance: None,
                                 }],
                                 ret: Box::from(ret_type.clone()),
                             }),
+                            provenance: None,
                         };
 
                         let s1 = compose_many_subs(&ss);
@@ -255,6 +265,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                     name: String::from("JSXElement"),
                     type_args: None,
                 }),
+                provenance: None,
             };
             expr.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -282,6 +293,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                                         id: ctx.fresh_id(),
                                         constraint: Some(Box::from(t)),
                                     }),
+                                    provenance: None,
                                 }
                             }
                             None => ctx.fresh_var(),
@@ -321,6 +333,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                         name: String::from("Promise"),
                         type_args: Some(vec![rt_1]),
                     }),
+                    provenance: None,
                 }
             } else {
                 rt_1
@@ -342,6 +355,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                     params: t_params,
                     ret: Box::from(rt_1),
                 }),
+                provenance: None,
             };
 
             let s = compose_many_subs(&ss);
@@ -394,6 +408,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                 &t1,
                 &Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 ctx,
             )?;
@@ -401,39 +416,50 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                 &t2,
                 &Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 ctx,
             )?;
             let t = match op {
                 BinOp::Add => Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 BinOp::Sub => Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 BinOp::Mul => Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 BinOp::Div => Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 BinOp::EqEq => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
                 BinOp::NotEq => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
                 BinOp::Gt => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
                 BinOp::GtEq => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
                 BinOp::Lt => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
                 BinOp::LtEq => Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
             };
             expr.inferred_type = Some(t.clone());
@@ -445,12 +471,14 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                 &t1,
                 &Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
                 ctx,
             )?;
             let t = match op {
                 UnaryOp::Minus => Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
             };
             expr.inferred_type = Some(t.clone());
@@ -499,11 +527,13 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
             let t = if spread_types.is_empty() {
                 Type {
                     kind: TypeKind::Object(TObject { elems }),
+                    provenance: None,
                 }
             } else {
                 let mut all_types = spread_types;
                 all_types.push(Type {
                     kind: TypeKind::Object(TObject { elems }),
+                    provenance: None,
                 });
                 simplify_intersection(&all_types)
             };
@@ -522,6 +552,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                     name: String::from("Promise"),
                     type_args: Some(vec![wrapped_type.clone()]),
                 }),
+                provenance: None,
             };
 
             let s2 = unify(&t1, &promise_type, ctx)?;
@@ -540,10 +571,8 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                     Some(_) => {
                         let (s, t) = infer_expr(ctx, expr)?;
                         ss.push(s);
-                        match &t {
-                            Type {
-                                kind: TypeKind::Tuple(types),
-                            } => {
+                        match &t.kind {
+                            TypeKind::Tuple(types) => {
                                 ts.extend(types.to_owned());
                             }
                             _ => {
@@ -564,6 +593,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Tuple(ts),
+                provenance: None,
             };
             expr.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -580,6 +610,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
         ExprKind::Empty => {
             let t = Type {
                 kind: TypeKind::Keyword(TKeyword::Undefined),
+                provenance: None,
             };
             let s = Subst::default();
             expr.inferred_type = Some(t.clone());
@@ -590,6 +621,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
         }) => {
             let t = Type {
                 kind: TypeKind::Keyword(TKeyword::String),
+                provenance: None,
             };
             let result: Result<Vec<(Subst, Type)>, String> =
                 exprs.iter_mut().map(|expr| infer_expr(ctx, expr)).collect();
@@ -666,7 +698,7 @@ fn infer_let(
 }
 
 fn is_promise(t: &Type) -> bool {
-    matches!(&t, Type {kind: TypeKind::Ref(types::TRef { name, .. })} if name == "Promise")
+    matches!(&t, Type {kind: TypeKind::Ref(types::TRef { name, .. }), ..} if name == "Promise")
 }
 
 // TODO: try to dedupe with key_of()
@@ -749,6 +781,7 @@ fn infer_property_type(
                     // TODO: remove duplicate types
                     let type_param = Type {
                         kind: TypeKind::Union(elem_types.to_owned()),
+                        provenance: None,
                     };
                     let type_params = get_type_params(&t); // ReadonlyArray type params
 
@@ -766,9 +799,11 @@ fn infer_property_type(
                                 let mut elem_types = elem_types.to_owned();
                                 elem_types.push(Type {
                                     kind: TypeKind::Keyword(TKeyword::Undefined),
+                                    provenance: None,
                                 });
                                 let t = Type {
                                     kind: TypeKind::Union(elem_types),
+                                    provenance: None,
                                 };
                                 Ok((prop_s, t))
                             }
@@ -853,9 +888,11 @@ fn get_prop_value(
                         // key is a string whose exact value is unknown at compile time.
                         value_types.push(Type {
                             kind: TypeKind::Keyword(TKeyword::Undefined),
+                            provenance: None,
                         });
                         let t = Type {
                             kind: TypeKind::Union(value_types),
+                            provenance: None,
                         };
 
                         Ok((prop_s, t))
@@ -914,6 +951,7 @@ fn get_prop_value(
                                 // we include `| undefined` in the return type here.
                                 let undefined = Type {
                                     kind: TypeKind::Keyword(TKeyword::Undefined),
+                                    provenance: None,
                                 };
                                 let t = union_types(&indexer.t, &undefined);
                                 return Ok((s, t));

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -24,6 +24,7 @@ pub fn infer_fn_param(
     let pt = if let TypeKind::Rest(arg) = &pt.kind {
         Type {
             kind: TypeKind::Array(arg.to_owned()),
+            provenance: None,
         }
     } else {
         pt
@@ -36,8 +37,10 @@ pub fn infer_fn_param(
                     t.to_owned(),
                     Type {
                         kind: TypeKind::Keyword(TKeyword::Undefined),
+                        provenance: None,
                     },
                 ]),
+                provenance: None,
             };
             pa.insert(name.to_owned(), t);
         };

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -81,7 +81,10 @@ fn infer_pattern_rec(
                     type_args: None,
                 }),
             };
-            let t = Type { kind };
+            let t = Type {
+                kind,
+                provenance: None,
+            };
             // TODO: we need a method on Context to get all types that currently in
             // scope so that we can pass them to generalize()
             let all_types = ctx.get_all_types();
@@ -95,6 +98,7 @@ fn infer_pattern_rec(
             let t = infer_pattern_rec(arg, ctx, assump)?;
             Ok(Type {
                 kind: TypeKind::Rest(Box::from(t)),
+                provenance: None,
             })
         }
         PatternKind::Array(ArrayPat { elems, .. }) => {
@@ -107,6 +111,7 @@ fn infer_pattern_rec(
                                 let rest_ty = infer_pattern_rec(&mut rest.arg, ctx, assump)?;
                                 Ok(Type {
                                     kind: TypeKind::Rest(Box::from(rest_ty)),
+                                    provenance: None,
                                 })
                             }
                             _ => infer_pattern_rec(elem, ctx, assump),
@@ -121,6 +126,7 @@ fn infer_pattern_rec(
 
             Ok(Type {
                 kind: TypeKind::Tuple(elems?),
+                provenance: None,
             })
         }
         // TODO: infer type_params
@@ -177,6 +183,7 @@ fn infer_pattern_rec(
 
             let obj_type = Type {
                 kind: TypeKind::Object(TObject { elems }),
+                provenance: None,
             };
 
             match rest_opt_ty {
@@ -184,6 +191,7 @@ fn infer_pattern_rec(
                 // See https://github.com/microsoft/TypeScript/issues/10727
                 Some(rest_ty) => Ok(Type {
                     kind: TypeKind::Intersection(vec![obj_type, rest_ty]),
+                    provenance: None,
                 }),
                 None => Ok(obj_type),
             }

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -44,6 +44,7 @@ pub fn infer_type_ann(
                                 id: ctx.fresh_id(),
                                 constraint: Some(Box::from(t)),
                             }),
+                            provenance: None,
                         }
                     }
                     None => ctx.fresh_var(),
@@ -94,6 +95,7 @@ fn infer_type_ann_rec(
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Lam(types::TLam { params, ret }),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -153,6 +155,7 @@ fn infer_type_ann_rec(
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Object(TObject { elems }),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -191,6 +194,7 @@ fn infer_type_ann_rec(
                             Some(type_args)
                         },
                     }),
+                    provenance: None,
                 };
                 type_ann.inferred_type = Some(t.clone());
                 Ok((s, t))
@@ -210,6 +214,7 @@ fn infer_type_ann_rec(
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Union(ts),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -228,6 +233,7 @@ fn infer_type_ann_rec(
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Intersection(ts),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -246,6 +252,7 @@ fn infer_type_ann_rec(
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Tuple(ts),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -255,6 +262,7 @@ fn infer_type_ann_rec(
             let s = elem_s;
             let t = Type {
                 kind: TypeKind::Array(Box::from(elem_t)),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -264,6 +272,7 @@ fn infer_type_ann_rec(
             let s = arg_s;
             let t = Type {
                 kind: TypeKind::KeyOf(Box::from(arg_t)),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -273,6 +282,7 @@ fn infer_type_ann_rec(
             let (s, t) = infer_type_ann_rec(type_ann, ctx, type_param_map)?;
             let t = Type {
                 kind: TypeKind::Mutable(Box::from(t)),
+                provenance: None,
             };
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
@@ -405,6 +415,7 @@ fn infer_property_type(
             // TODO: remove duplicate types
             let type_param = Type {
                 kind: TypeKind::Union(elem_types.to_owned()),
+                provenance: None,
             };
             let type_params = get_type_params(&t); // ReadonlyArray type params
 

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -23,6 +23,7 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
                     TObjElem::Index(_) => todo!(),
                     TObjElem::Prop(prop) => Some(Type {
                         kind: TypeKind::Lit(TLit::Str(prop.name.to_owned())),
+                        provenance: None,
                     }),
                 })
                 .collect();
@@ -39,6 +40,7 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
             for i in 0..tuple.len() {
                 elems.push(Type {
                     kind: TypeKind::Lit(TLit::Num(i.to_string())),
+                    provenance: None,
                 })
             }
             elems.push(key_of(
@@ -50,6 +52,7 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
         TypeKind::Array(_) => Ok(union_many_types(&[
             Type {
                 kind: TypeKind::Keyword(TKeyword::Number),
+                provenance: None,
             },
             key_of(&ctx.lookup_type_and_instantiate("ReadonlyArray")?, ctx)?,
         ])),
@@ -64,12 +67,15 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, String> {
             TKeyword::Symbol => key_of(&ctx.lookup_type_and_instantiate("Symbol")?, ctx),
             TKeyword::Null => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Never),
+                provenance: None,
             }),
             TKeyword::Undefined => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Never),
+                provenance: None,
             }),
             TKeyword::Never => Ok(Type {
                 kind: TypeKind::Keyword(TKeyword::Never),
+                provenance: None,
             }),
         },
         TypeKind::Union(_) => todo!(),

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -69,6 +69,7 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
+                                                    provenance: None,
                                                 },
                                             ),
                                         },
@@ -85,6 +86,7 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
+                                                    provenance: None,
                                                 },
                                             ),
                                         },
@@ -95,6 +97,7 @@ Program {
                                         kind: Keyword(
                                             Number,
                                         ),
+                                        provenance: None,
                                     },
                                 ),
                             },
@@ -118,6 +121,7 @@ Program {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
+                                                provenance: None,
                                             },
                                             optional: false,
                                         },
@@ -131,6 +135,7 @@ Program {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
+                                                provenance: None,
                                             },
                                             optional: false,
                                         },
@@ -139,9 +144,11 @@ Program {
                                         kind: Keyword(
                                             Number,
                                         ),
+                                        provenance: None,
                                     },
                                 },
                             ),
+                            provenance: None,
                         },
                     ),
                 },

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -76,7 +76,10 @@ impl Substitutable for Type {
                 })
             }
         };
-        norm_type(Type { kind })
+        norm_type(Type {
+            kind,
+            provenance: None,
+        })
     }
     fn ftv(&self) -> Vec<TVar> {
         match &self.kind {
@@ -279,6 +282,7 @@ fn norm_type(t: Type) -> Type {
             } else {
                 Type {
                     kind: TypeKind::Union(types),
+                    provenance: None,
                 }
             }
         }
@@ -293,6 +297,7 @@ fn norm_type(t: Type) -> Type {
             } else {
                 Type {
                     kind: TypeKind::Intersection(types),
+                    provenance: None,
                 }
             }
         }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -81,6 +81,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                                 params: call.params.to_owned(),
                                 ret: call.ret.to_owned(),
                             }),
+                            provenance: None,
                         };
                         let t = if call.type_params.is_empty() {
                             lam
@@ -90,6 +91,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                                     t: Box::from(lam),
                                     type_params: call.type_params.to_owned(),
                                 }),
+                                provenance: None,
                             }
                         };
                         Some(t)
@@ -179,6 +181,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 let regular_args: Vec<_> = args.drain(0..regular_arg_count).collect();
                 let rest_arg = Type {
                     kind: TypeKind::Tuple(args),
+                    provenance: None,
                 };
 
                 let mut params = lam.params.clone();
@@ -329,6 +332,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                 let s = unify(
                     &Type {
                         kind: TypeKind::Tuple(rest1),
+                        provenance: None,
                     },
                     &rest2,
                     ctx,
@@ -416,6 +420,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     let s1 = unify(
                         &Type {
                             kind: TypeKind::Object(TObject { elems: obj_elems }),
+                            provenance: None,
                         },
                         &obj_type,
                         ctx,
@@ -425,6 +430,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                     let s2 = unify(
                         &Type {
                             kind: TypeKind::Object(TObject { elems: rest_elems }),
+                            provenance: None,
                         },
                         rest_type,
                         ctx,
@@ -474,6 +480,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         &obj_type,
                         &Type {
                             kind: TypeKind::Object(TObject { elems: obj_elems }),
+                            provenance: None,
                         },
                         ctx,
                     )?;
@@ -483,6 +490,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
                         rest_type,
                         &Type {
                             kind: TypeKind::Object(TObject { elems: rest_elems }),
+                            provenance: None,
                         },
                         ctx,
                     )?;
@@ -587,11 +595,12 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &Context) -> Result<Subst, Stri
                         // Converts set back to an array
                         let types: Vec<Type> = types.into_iter().collect();
 
-                        let t = if types.len() == 1 {
+                        let t: Type = if types.len() == 1 {
                             types.get(0).unwrap().to_owned()
                         } else {
                             Type {
                                 kind: TypeKind::Union(types),
+                                provenance: None,
                             }
                         };
 
@@ -620,6 +629,7 @@ fn bind(tv: &TVar, t: &Type, rel: Relation, ctx: &Context) -> Result<Subst, Stri
                             id.to_owned(),
                             Type {
                                 kind: TypeKind::Var(tv.to_owned()),
+                                provenance: None,
                             },
                         )]);
                         return Ok(s);
@@ -663,6 +673,7 @@ mod tests {
             &Type::from(num("5")),
             &Type {
                 kind: TypeKind::Keyword(TKeyword::Number),
+                provenance: None,
             },
             &ctx,
         );
@@ -672,6 +683,7 @@ mod tests {
             &Type::from(str("hello")),
             &Type {
                 kind: TypeKind::Keyword(TKeyword::String),
+                provenance: None,
             },
             &ctx,
         );
@@ -681,6 +693,7 @@ mod tests {
             &Type::from(bool(&true)),
             &Type {
                 kind: TypeKind::Keyword(TKeyword::Boolean),
+                provenance: None,
             },
             &ctx,
         );
@@ -711,11 +724,13 @@ mod tests {
                 mutable: false,
                 t: Type {
                     kind: TypeKind::Keyword(TKeyword::String),
+                    provenance: None,
                 },
             }),
         ];
         let t1 = Type {
             kind: TypeKind::Object(TObject { elems }),
+            provenance: None,
         };
 
         let elems = vec![
@@ -725,6 +740,7 @@ mod tests {
                 mutable: false,
                 t: Type {
                     kind: TypeKind::Keyword(TKeyword::Number),
+                    provenance: None,
                 },
             }),
             types::TObjElem::Prop(types::TProp {
@@ -733,6 +749,7 @@ mod tests {
                 mutable: false,
                 t: Type {
                     kind: TypeKind::Keyword(TKeyword::Boolean),
+                    provenance: None,
                 },
             }),
             // It's okay for qux to not appear in the subtype since
@@ -743,11 +760,13 @@ mod tests {
                 mutable: false,
                 t: Type {
                     kind: TypeKind::Keyword(TKeyword::String),
+                    provenance: None,
                 },
             }),
         ];
         let t2 = Type {
             kind: TypeKind::Object(TObject { elems }),
+            provenance: None,
         };
 
         let result = unify(&t1, &t2, &ctx);
@@ -763,6 +782,7 @@ mod tests {
         let result = unify(
             &Type {
                 kind: TypeKind::Keyword(TKeyword::Number),
+                provenance: None,
             },
             &Type::from(num("5")),
             &ctx,


### PR DESCRIPTION
It's currently set to `None`, but we'll want to set it to the assigned expression if it's a literal, object, or tuple.  This is to support assigning these things to mutable types.  I'll tackle this in the next PR since the changes in this one were pretty mechanical, but the other changes won't be.