### PR TITLE
Update parser to handle 'mut' modifier on properties

### DIFF
--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-12.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-12.snap
@@ -1,0 +1,75 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type MutPoint = mut {x: number, y: number};\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..43,
+                declare: false,
+                id: Ident {
+                    span: 5..13,
+                    name: "MutPoint",
+                },
+                type_ann: TypeAnn {
+                    kind: Mutable(
+                        MutableType {
+                            span: 16..42,
+                            type_ann: TypeAnn {
+                                kind: Object(
+                                    ObjectType {
+                                        span: 20..42,
+                                        elems: [
+                                            Prop(
+                                                TProp {
+                                                    span: 21..30,
+                                                    name: "x",
+                                                    optional: false,
+                                                    mutable: false,
+                                                    type_ann: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                span: 24..30,
+                                                                keyword: Number,
+                                                            },
+                                                        ),
+                                                        span: 24..30,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            Prop(
+                                                TProp {
+                                                    span: 32..41,
+                                                    name: "y",
+                                                    optional: false,
+                                                    mutable: false,
+                                                    type_ann: TypeAnn {
+                                                        kind: Keyword(
+                                                            KeywordType {
+                                                                span: 35..41,
+                                                                keyword: Number,
+                                                            },
+                                                        ),
+                                                        span: 35..41,
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                        ],
+                                    },
+                                ),
+                                span: 20..42,
+                                inferred_type: None,
+                            },
+                        },
+                    ),
+                    span: 16..42,
+                    inferred_type: None,
+                },
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-13.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__type_decls-13.snap
@@ -1,0 +1,66 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type MutPoint = {mut x: number, mut y: number};\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                span: 0..47,
+                declare: false,
+                id: Ident {
+                    span: 5..13,
+                    name: "MutPoint",
+                },
+                type_ann: TypeAnn {
+                    kind: Object(
+                        ObjectType {
+                            span: 16..46,
+                            elems: [
+                                Prop(
+                                    TProp {
+                                        span: 17..30,
+                                        name: "x",
+                                        optional: false,
+                                        mutable: true,
+                                        type_ann: TypeAnn {
+                                            kind: Keyword(
+                                                KeywordType {
+                                                    span: 24..30,
+                                                    keyword: Number,
+                                                },
+                                            ),
+                                            span: 24..30,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                                Prop(
+                                    TProp {
+                                        span: 32..45,
+                                        name: "y",
+                                        optional: false,
+                                        mutable: true,
+                                        type_ann: TypeAnn {
+                                            kind: Keyword(
+                                                KeywordType {
+                                                    span: 39..45,
+                                                    keyword: Number,
+                                                },
+                                            ),
+                                            span: 39..45,
+                                            inferred_type: None,
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                    span: 16..46,
+                    inferred_type: None,
+                },
+                type_params: None,
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-9.snap
@@ -1,0 +1,64 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let mut_arr: mut string[] = [];\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 0..31,
+                pattern: Pattern {
+                    span: 4..11,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "mut_arr",
+                        },
+                    ),
+                    inferred_type: None,
+                },
+                type_ann: Some(
+                    TypeAnn {
+                        kind: Mutable(
+                            MutableType {
+                                span: 13..25,
+                                type_ann: TypeAnn {
+                                    kind: Array(
+                                        ArrayType {
+                                            span: 17..25,
+                                            elem_type: TypeAnn {
+                                                kind: Keyword(
+                                                    KeywordType {
+                                                        span: 17..23,
+                                                        keyword: String,
+                                                    },
+                                                ),
+                                                span: 17..23,
+                                                inferred_type: None,
+                                            },
+                                        },
+                                    ),
+                                    span: 17..25,
+                                    inferred_type: None,
+                                },
+                            },
+                        ),
+                        span: 13..25,
+                        inferred_type: None,
+                    },
+                ),
+                init: Some(
+                    Expr {
+                        span: 28..30,
+                        kind: Tuple(
+                            Tuple {
+                                elems: [],
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
@@ -457,7 +457,7 @@ Property signatures with accessibility modifiers
 ================================================================================
 
 export interface IAppState {
-  public readonly users: ReadonlyArray<User>;
+  public mut users: ReadonlyArray<User>;
 }
 
 export class CloningRepository {
@@ -787,7 +787,7 @@ Classes with method signatures
 class Foo {
   public async waitFor<T>(func: () => T | Promise<T | undefined>, accept?: (result: T) => boolean | Promise<boolean>, timeoutMessage?: string, retryCount?: number): Promise<T>;
 
-  public readonly async bar?<T>();
+  public mut async bar?<T>();
   private static bar();
   private static async bar(): T;
 }

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -40,6 +40,53 @@ module.exports = grammar(tsx, {
     },
     readonly_type: ($, prev) => seq("mut", $._type),
 
+    // Replaces `optional("readonly")` in sequence with `optional("mut")`
+    property_signature: ($, prev) => {
+      const members = prev.members.map((member) => {
+        if (
+          member.type === "CHOICE" &&
+          member.members[0].value === "readonly"
+        ) {
+          return optional("mut");
+        }
+        return member;
+      });
+
+      return seq(...members);
+    },
+
+    // Replaces `optional("readonly")` in sequence with `optional("mut")`
+    method_signature: ($, prev) => {
+      const members = prev.members.map((member) => {
+        if (
+          member.type === "CHOICE" &&
+          member.members[0].value === "readonly"
+        ) {
+          return optional("mut");
+        }
+        return member;
+      });
+
+      return seq(...members);
+    },
+
+    // Replaces `optional("readonly")` in sequence with `optional("mut")`
+    method_definition: ($, prev) => {
+      const members = prev.content.members.map((member) => {
+        if (
+          member.type === "CHOICE" &&
+          member.members[0].value === "readonly"
+        ) {
+          return optional("mut");
+        }
+        return member;
+      });
+
+      return prec.left(seq(...members));
+    },
+
+    // TODO: Do the same for public_field_definition
+
     expression: ($, prev) => {
       // Removes ternary expression
       const choices = prev.members.filter(


### PR DESCRIPTION
Replaces the `readonly` modifier.