### PR TITLE
Add Provenance enum and update .apply() to use it

### DIFF
--- a/crates/crochet_ast/src/types/mod.rs
+++ b/crates/crochet_ast/src/types/mod.rs
@@ -3,6 +3,7 @@ pub mod lam;
 pub mod lit;
 pub mod obj;
 pub mod pat;
+pub mod provenance;
 pub mod r#type;
 
 pub use keyword::*;
@@ -10,4 +11,5 @@ pub use lam::*;
 pub use lit::*;
 pub use obj::*;
 pub use pat::*;
+pub use provenance::*;
 pub use r#type::*;

--- a/crates/crochet_ast/src/types/provenance.rs
+++ b/crates/crochet_ast/src/types/provenance.rs
@@ -1,0 +1,44 @@
+use crate::types::Type;
+use crate::values::Expr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Provenance {
+    Expr(Box<Expr>),
+    Type(Box<Type>),
+}
+
+impl From<Expr> for Provenance {
+    fn from(expr: Expr) -> Self {
+        Provenance::Expr(Box::from(expr))
+    }
+}
+
+impl From<&Expr> for Provenance {
+    fn from(expr: &Expr) -> Self {
+        Provenance::Expr(Box::from(expr.to_owned()))
+    }
+}
+
+impl From<&mut Expr> for Provenance {
+    fn from(expr: &mut Expr) -> Self {
+        Provenance::Expr(Box::from(expr.to_owned()))
+    }
+}
+
+impl From<Type> for Provenance {
+    fn from(t: Type) -> Self {
+        Provenance::Type(Box::from(t))
+    }
+}
+
+impl From<&Type> for Provenance {
+    fn from(t: &Type) -> Self {
+        Provenance::Type(Box::from(t.to_owned()))
+    }
+}
+
+impl From<&mut Type> for Provenance {
+    fn from(t: &mut Type) -> Self {
+        Provenance::Type(Box::from(t.to_owned()))
+    }
+}

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -6,7 +6,7 @@ use crate::types::keyword::TKeyword;
 use crate::types::lam::TLam;
 use crate::types::lit::TLit;
 use crate::types::obj::TObjElem;
-use crate::values::expr::Expr;
+use crate::types::provenance::Provenance;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TApp {
@@ -92,10 +92,11 @@ pub enum TypeKind {
 #[derivative(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Type {
     pub kind: TypeKind,
-    #[derivative(Ord = "ignore")]
-    #[derivative(PartialOrd = "ignore")]
-    pub provenance: Option<Box<Expr>>,
     pub mutable: bool,
+    #[derivative(PartialOrd = "ignore")]
+    #[derivative(Ord = "ignore")]
+    #[derivative(PartialEq = "ignore")] // we don't care about provenance when comparing types
+    pub provenance: Option<Box<Provenance>>,
 }
 
 impl From<TypeKind> for Type {

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -1,5 +1,7 @@
 use crochet_ast::common::*;
-use crochet_ast::types::{self as types, TFnParam, TKeyword, TObject, TPat, TVar, Type, TypeKind};
+use crochet_ast::types::{
+    self as types, Provenance, TFnParam, TKeyword, TObject, TPat, TVar, Type, TypeKind,
+};
 use crochet_ast::values::*;
 
 use types::TObjElem;
@@ -430,7 +432,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
                 simplify_intersection(&all_types)
             };
             expr.inferred_type = Some(t.clone());
-            t.provenance = Some(Box::from(expr.to_owned()));
+            t.provenance = Some(Box::from(Provenance::from(expr)));
             Ok((s, t))
         }
         ExprKind::Await(Await { expr, .. }) => {
@@ -481,7 +483,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), S
             let s = compose_many_subs(&ss);
             let t = Type {
                 kind: TypeKind::Tuple(ts),
-                provenance: Some(Box::from(expr.to_owned())),
+                provenance: Some(Box::from(Provenance::Expr(Box::from(expr.to_owned())))),
                 mutable: false,
             };
             expr.inferred_type = Some(t.clone());

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -69,8 +69,21 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
-                                                    provenance: None,
                                                     mutable: false,
+                                                    provenance: Some(
+                                                        Type(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 2,
+                                                                        constraint: None,
+                                                                    },
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
+                                                    ),
                                                 },
                                             ),
                                         },
@@ -87,8 +100,21 @@ Program {
                                                     kind: Keyword(
                                                         Number,
                                                     ),
-                                                    provenance: None,
                                                     mutable: false,
+                                                    provenance: Some(
+                                                        Type(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 3,
+                                                                        constraint: None,
+                                                                    },
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
+                                                    ),
                                                 },
                                             ),
                                         },
@@ -99,8 +125,8 @@ Program {
                                         kind: Keyword(
                                             Number,
                                         ),
-                                        provenance: None,
                                         mutable: false,
+                                        provenance: None,
                                     },
                                 ),
                             },
@@ -124,8 +150,21 @@ Program {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
-                                                provenance: None,
                                                 mutable: false,
+                                                provenance: Some(
+                                                    Type(
+                                                        Type {
+                                                            kind: Var(
+                                                                TVar {
+                                                                    id: 2,
+                                                                    constraint: None,
+                                                                },
+                                                            ),
+                                                            mutable: false,
+                                                            provenance: None,
+                                                        },
+                                                    ),
+                                                ),
                                             },
                                             optional: false,
                                         },
@@ -139,8 +178,21 @@ Program {
                                                 kind: Keyword(
                                                     Number,
                                                 ),
-                                                provenance: None,
                                                 mutable: false,
+                                                provenance: Some(
+                                                    Type(
+                                                        Type {
+                                                            kind: Var(
+                                                                TVar {
+                                                                    id: 3,
+                                                                    constraint: None,
+                                                                },
+                                                            ),
+                                                            mutable: false,
+                                                            provenance: None,
+                                                        },
+                                                    ),
+                                                ),
                                             },
                                             optional: false,
                                         },
@@ -149,13 +201,13 @@ Program {
                                         kind: Keyword(
                                             Number,
                                         ),
-                                        provenance: None,
                                         mutable: false,
+                                        provenance: None,
                                     },
                                 },
                             ),
-                            provenance: None,
                             mutable: false,
+                            provenance: None,
                         },
                     ),
                 },

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -202,7 +202,69 @@ Program {
                                             Number,
                                         ),
                                         mutable: false,
-                                        provenance: None,
+                                        provenance: Some(
+                                            Expr(
+                                                Expr {
+                                                    span: 20..25,
+                                                    kind: BinaryExpr(
+                                                        BinaryExpr {
+                                                            op: Add,
+                                                            left: Expr {
+                                                                span: 20..21,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 20..21,
+                                                                        name: "a",
+                                                                    },
+                                                                ),
+                                                                inferred_type: Some(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 2,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                            right: Expr {
+                                                                span: 24..25,
+                                                                kind: Ident(
+                                                                    Ident {
+                                                                        span: 24..25,
+                                                                        name: "b",
+                                                                    },
+                                                                ),
+                                                                inferred_type: Some(
+                                                                    Type {
+                                                                        kind: Var(
+                                                                            TVar {
+                                                                                id: 3,
+                                                                                constraint: None,
+                                                                            },
+                                                                        ),
+                                                                        mutable: false,
+                                                                        provenance: None,
+                                                                    },
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: Some(
+                                                        Type {
+                                                            kind: Keyword(
+                                                                Number,
+                                                            ),
+                                                            mutable: false,
+                                                            provenance: None,
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ),
                                     },
                                 },
                             ),

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -41,11 +41,7 @@ impl Substitutable for Type {
                     // is a subtype of it.
                     return norm_type(Type {
                         kind: replacement.kind.to_owned(),
-                        // We purposefully drop the provenance here so that our hacky check
-                        // at the top of `unify()` workss.  Once we've made that less hacky
-                        // we can update this provenance to point back to the type variable's
-                        // containing Type.
-                        provenance: None,
+                        provenance: Some(Box::from(Provenance::from(self))),
                         mutable: replacement.mutable,
                     });
                 }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -24,10 +24,6 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         return unify_mut(t1, t2, ctx);
     }
     if t2.mutable {
-        // Right now we only set `.provenance` when inferring tuple and object
-        // literals, but in the future we'll likely be setting it when inferring
-        // any expression including variables.
-
         // TODO: extract this into a `isLitExpr` helper that checks if the expression
         // is a literal, e.g. 1 + 2, but not something that calls a function or contains
         // variables.
@@ -37,17 +33,16 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, String> {
         // - pure function calls with args that are const expressions
         match &t1.provenance {
             Some(provenance) => match provenance.as_ref() {
-                types::Provenance::Type(t) => (),
                 types::Provenance::Expr(e) => match e.kind {
                     ExprKind::Obj(_) => return Ok(Subst::new()),
                     ExprKind::Tuple(_) => return Ok(Subst::new()),
                     _ => (),
                 },
+                types::Provenance::Type(_) => (),
             },
             None => (),
         };
 
-        println!("t1 = {t1:#?}, t2 = {t2:#?}");
         // It's NOT okay to use an immutable in place of a mutable one
         return Err(String::from(
             "Cannot use immutable type where a mutable type was expected",


### PR DESCRIPTION
This allows us to set `.provenance` to be either an `Expr` or a `Type`.  This allows us to track provenance after applying a `Subst` to a type.