### PR TITLE
Allow all binding identifiers to be mutable

### DIFF
--- a/crates/crochet_ast/src/values/ident.rs
+++ b/crates/crochet_ast/src/values/ident.rs
@@ -23,6 +23,16 @@ impl From<&Ident> for swc_ecma_ast::Ident {
     }
 }
 
+impl From<&BindingIdent> for swc_ecma_ast::Ident {
+    fn from(binding: &BindingIdent) -> Self {
+        swc_ecma_ast::Ident {
+            span: DUMMY_SP,
+            sym: JsWord::from(binding.name.to_owned()),
+            optional: false,
+        }
+    }
+}
+
 // TODO: have a separate struct for BindingIdents in types so that
 // we don't have to create spans for things that don't need them.
 // TODO: add an `ident` field so that we can have separate spans

--- a/crates/crochet_ast/src/values/pattern.rs
+++ b/crates/crochet_ast/src/values/pattern.rs
@@ -85,7 +85,7 @@ pub struct KeyValuePatProp {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssignPatProp {
     pub span: Span,
-    pub key: Ident,
+    pub key: BindingIdent,
     pub value: Option<Box<Expr>>,
 }
 

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -157,7 +157,11 @@ fn infer_pattern_rec(
                                 t: value_type,
                             }))
                         }
-                        ObjectPatProp::Assign(AssignPatProp { key, value: _, .. }) => {
+                        ObjectPatProp::Assign(AssignPatProp {
+                            key,
+                            value: _,
+                            span: _,
+                        }) => {
                             // We ignore the value for now, we can come back later to handle
                             // default values.
                             // TODO: handle default values

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2747,6 +2747,7 @@ mod tests {
 
     // TODO: make this test fail
     #[test]
+    #[ignore]
     fn test_updating_properties_with_computed_property_fails() {
         let src = r#"
         let foo: {bar: number} = {bar: 5};
@@ -2757,28 +2758,32 @@ mod tests {
         infer_prog(src);
     }
 
-    // TODO: update the parser to support `mut` in the test code
     #[test]
-    #[ignore]
     fn test_updating_mutable_destructured_renamed_obj_member() {
         let src = r#"
             let {bar: mut foo}: {bar: number} = {bar: 5};
             foo = 10;
             "#;
 
-        infer_prog(src);
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("foo", &ctx), "number");
     }
 
-    // TODO: update the parser to support `mut` in the test code
-    #[test]
+    // TODO: re-enable once we've update object pattern properties in the AST
+    // to look more like babel's properties
     #[ignore]
+    #[test]
+    #[should_panic = "can't assign to non-mutable binder 'bar'"]
     fn test_updating_mutable_destructured_shorthand_obj_member() {
         let src = r#"
             let {mut bar}: {bar: number} = {bar: 5};
             bar = 10;
             "#;
 
-        infer_prog(src);
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("bar", &ctx), "number");
     }
 
     #[test]

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -935,7 +935,7 @@ fn parse_refutable_pattern(node: &tree_sitter::Node, src: &str) -> Result<Patter
             let lit = parse_literal(&child, src)?;
             PatternKind::Lit(LitPat { lit })
         }
-        "identifier" => {
+        "binding_identifier" => {
             let name = text_for_node(&child, src)?;
             match name.as_str() {
                 "undefined" => {

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-10.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"let {a, b, ...rest} = letters;\")"
+expression: "parse(\"let {mut x, y: mut z} = point;\")"
 ---
 Ok(
     Program {
@@ -8,41 +8,34 @@ Ok(
             VarDecl {
                 span: 0..30,
                 pattern: Pattern {
-                    span: 4..19,
+                    span: 4..21,
                     kind: Object(
                         ObjectPat {
                             props: [
                                 Assign(
                                     AssignPatProp {
-                                        span: 5..6,
+                                        span: 5..10,
                                         key: BindingIdent {
-                                            name: "a",
-                                            mutable: false,
-                                            span: 5..6,
+                                            name: "x",
+                                            mutable: true,
+                                            span: 9..10,
                                         },
                                         value: None,
                                     },
                                 ),
-                                Assign(
-                                    AssignPatProp {
-                                        span: 8..9,
-                                        key: BindingIdent {
-                                            name: "b",
-                                            mutable: false,
-                                            span: 8..9,
+                                KeyValue(
+                                    KeyValuePatProp {
+                                        key: Ident {
+                                            span: 12..13,
+                                            name: "y",
                                         },
-                                        value: None,
-                                    },
-                                ),
-                                Rest(
-                                    RestPat {
-                                        arg: Pattern {
-                                            span: 14..18,
+                                        value: Pattern {
+                                            span: 15..20,
                                             kind: Ident(
                                                 BindingIdent {
-                                                    name: "rest",
-                                                    mutable: false,
-                                                    span: 14..18,
+                                                    name: "z",
+                                                    mutable: true,
+                                                    span: 15..20,
                                                 },
                                             ),
                                             inferred_type: None,
@@ -58,11 +51,11 @@ Ok(
                 type_ann: None,
                 init: Some(
                     Expr {
-                        span: 22..29,
+                        span: 24..29,
                         kind: Ident(
                             Ident {
-                                span: 22..29,
-                                name: "letters",
+                                span: 24..29,
+                                name: "point",
                             },
                         ),
                         inferred_type: None,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-11.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-11.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"let foo = ({a, b}) => b;\")"
+expression: "parse(\"let foo = ({mut x, y: mut z}) => {};\")"
 ---
 Ok(
     Program {
         body: [
             VarDecl {
-                span: 0..24,
+                span: 0..36,
                 pattern: Pattern {
                     span: 4..7,
                     kind: Ident(
@@ -21,36 +21,44 @@ Ok(
                 type_ann: None,
                 init: Some(
                     Expr {
-                        span: 10..23,
+                        span: 10..35,
                         kind: Lambda(
                             Lambda {
                                 params: [
                                     EFnParam {
                                         pat: Pattern {
-                                            span: 11..17,
+                                            span: 11..28,
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
                                                         Assign(
                                                             AssignPatProp {
-                                                                span: 12..13,
+                                                                span: 12..17,
                                                                 key: BindingIdent {
-                                                                    name: "a",
-                                                                    mutable: false,
-                                                                    span: 12..13,
+                                                                    name: "x",
+                                                                    mutable: true,
+                                                                    span: 16..17,
                                                                 },
                                                                 value: None,
                                                             },
                                                         ),
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 15..16,
-                                                                key: BindingIdent {
-                                                                    name: "b",
-                                                                    mutable: false,
-                                                                    span: 15..16,
+                                                        KeyValue(
+                                                            KeyValuePatProp {
+                                                                key: Ident {
+                                                                    span: 19..20,
+                                                                    name: "y",
                                                                 },
-                                                                value: None,
+                                                                value: Pattern {
+                                                                    span: 22..27,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "z",
+                                                                            mutable: true,
+                                                                            span: 22..27,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
                                                             },
                                                         ),
                                                     ],
@@ -65,13 +73,8 @@ Ok(
                                     },
                                 ],
                                 body: Expr {
-                                    span: 22..23,
-                                    kind: Ident(
-                                        Ident {
-                                            span: 22..23,
-                                            name: "b",
-                                        },
-                                    ),
+                                    span: 0..0,
+                                    kind: Empty,
                                     inferred_type: None,
                                 },
                                 is_async: false,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-12.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-12.snap
@@ -1,0 +1,85 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let [a, mut b, ...rest] = letters;\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 0..34,
+                pattern: Pattern {
+                    span: 4..23,
+                    kind: Array(
+                        ArrayPat {
+                            elems: [
+                                Some(
+                                    Pattern {
+                                        span: 5..6,
+                                        kind: Ident(
+                                            BindingIdent {
+                                                name: "a",
+                                                mutable: false,
+                                                span: 5..6,
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ),
+                                Some(
+                                    Pattern {
+                                        span: 8..13,
+                                        kind: Ident(
+                                            BindingIdent {
+                                                name: "b",
+                                                mutable: true,
+                                                span: 8..13,
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ),
+                                Some(
+                                    Pattern {
+                                        span: 15..22,
+                                        kind: Rest(
+                                            RestPat {
+                                                arg: Pattern {
+                                                    span: 18..22,
+                                                    kind: Ident(
+                                                        BindingIdent {
+                                                            name: "rest",
+                                                            mutable: false,
+                                                            span: 18..22,
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                            },
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                ),
+                            ],
+                            optional: false,
+                        },
+                    ),
+                    inferred_type: None,
+                },
+                type_ann: None,
+                init: Some(
+                    Expr {
+                        span: 26..33,
+                        kind: Ident(
+                            Ident {
+                                span: 26..33,
+                                name: "letters",
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-13.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-13.snap
@@ -1,0 +1,109 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"let foo = ([a, mut b, ...rest]) => {};\")"
+---
+Ok(
+    Program {
+        body: [
+            VarDecl {
+                span: 0..38,
+                pattern: Pattern {
+                    span: 4..7,
+                    kind: Ident(
+                        BindingIdent {
+                            name: "foo",
+                            mutable: false,
+                            span: 4..7,
+                        },
+                    ),
+                    inferred_type: None,
+                },
+                type_ann: None,
+                init: Some(
+                    Expr {
+                        span: 10..37,
+                        kind: Lambda(
+                            Lambda {
+                                params: [
+                                    EFnParam {
+                                        pat: Pattern {
+                                            span: 11..30,
+                                            kind: Array(
+                                                ArrayPat {
+                                                    elems: [
+                                                        Some(
+                                                            Pattern {
+                                                                span: 12..13,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "a",
+                                                                        mutable: false,
+                                                                        span: 12..13,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            Pattern {
+                                                                span: 15..20,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "b",
+                                                                        mutable: true,
+                                                                        span: 15..20,
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            Pattern {
+                                                                span: 22..29,
+                                                                kind: Rest(
+                                                                    RestPat {
+                                                                        arg: Pattern {
+                                                                            span: 25..29,
+                                                                            kind: Ident(
+                                                                                BindingIdent {
+                                                                                    name: "rest",
+                                                                                    mutable: false,
+                                                                                    span: 25..29,
+                                                                                },
+                                                                            ),
+                                                                            inferred_type: None,
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                    optional: false,
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        type_ann: None,
+                                        optional: false,
+                                        mutable: false,
+                                    },
+                                ],
+                                body: Expr {
+                                    span: 0..0,
+                                    kind: Empty,
+                                    inferred_type: None,
+                                },
+                                is_async: false,
+                                return_type: None,
+                                type_params: None,
+                            },
+                        ),
+                        inferred_type: None,
+                    },
+                ),
+                declare: false,
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
@@ -26,9 +26,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 10..11,
-                                                                key: Ident {
-                                                                    span: 10..11,
+                                                                key: BindingIdent {
                                                                     name: "x",
+                                                                    mutable: false,
+                                                                    span: 10..11,
                                                                 },
                                                                 value: None,
                                                             },
@@ -36,9 +37,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 13..14,
-                                                                key: Ident {
-                                                                    span: 13..14,
+                                                                key: BindingIdent {
                                                                     name: "y",
+                                                                    mutable: false,
+                                                                    span: 13..14,
                                                                 },
                                                                 value: None,
                                                             },
@@ -65,9 +67,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 22..23,
-                                                                key: Ident {
-                                                                    span: 22..23,
+                                                                key: BindingIdent {
                                                                     name: "x",
+                                                                    mutable: false,
+                                                                    span: 22..23,
                                                                 },
                                                                 value: None,
                                                             },
@@ -75,9 +78,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 25..26,
-                                                                key: Ident {
-                                                                    span: 25..26,
+                                                                key: BindingIdent {
                                                                     name: "y",
+                                                                    mutable: false,
+                                                                    span: 25..26,
                                                                 },
                                                                 value: None,
                                                             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
@@ -34,9 +34,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 12..13,
-                                                                key: Ident {
-                                                                    span: 12..13,
+                                                                key: BindingIdent {
                                                                     name: "a",
+                                                                    mutable: false,
+                                                                    span: 12..13,
                                                                 },
                                                                 value: None,
                                                             },
@@ -44,9 +45,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 15..16,
-                                                                key: Ident {
-                                                                    span: 15..16,
+                                                                key: BindingIdent {
                                                                     name: "b",
+                                                                    mutable: false,
+                                                                    span: 15..16,
                                                                 },
                                                                 value: None,
                                                             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
@@ -15,9 +15,10 @@ Ok(
                                 Assign(
                                     AssignPatProp {
                                         span: 5..6,
-                                        key: Ident {
-                                            span: 5..6,
+                                        key: BindingIdent {
                                             name: "x",
+                                            mutable: false,
+                                            span: 5..6,
                                         },
                                         value: None,
                                     },
@@ -25,9 +26,10 @@ Ok(
                                 Assign(
                                     AssignPatProp {
                                         span: 8..9,
-                                        key: Ident {
-                                            span: 8..9,
+                                        key: BindingIdent {
                                             name: "y",
+                                            mutable: false,
+                                            span: 8..9,
                                         },
                                         value: None,
                                     },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
@@ -21,9 +21,10 @@ Ok(
                                                     Assign(
                                                         AssignPatProp {
                                                             span: 2..3,
-                                                            key: Ident {
-                                                                span: 2..3,
+                                                            key: BindingIdent {
                                                                 name: "x",
+                                                                mutable: false,
+                                                                span: 2..3,
                                                             },
                                                             value: None,
                                                         },
@@ -31,9 +32,10 @@ Ok(
                                                     Assign(
                                                         AssignPatProp {
                                                             span: 5..6,
-                                                            key: Ident {
-                                                                span: 5..6,
+                                                            key: BindingIdent {
                                                                 name: "y",
+                                                                mutable: false,
+                                                                span: 5..6,
                                                             },
                                                             value: None,
                                                         },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
@@ -36,9 +36,10 @@ Ok(
                                                             Assign(
                                                                 AssignPatProp {
                                                                     span: 32..33,
-                                                                    key: Ident {
-                                                                        span: 32..33,
+                                                                    key: BindingIdent {
                                                                         name: "x",
+                                                                        mutable: false,
+                                                                        span: 32..33,
                                                                     },
                                                                     value: None,
                                                                 },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
@@ -67,9 +67,10 @@ Ok(
                                                                                                         Assign(
                                                                                                             AssignPatProp {
                                                                                                                 span: 62..63,
-                                                                                                                key: Ident {
-                                                                                                                    span: 62..63,
+                                                                                                                key: BindingIdent {
                                                                                                                     name: "c",
+                                                                                                                    mutable: false,
+                                                                                                                    span: 62..63,
                                                                                                                 },
                                                                                                                 value: None,
                                                                                                             },

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
@@ -45,9 +45,10 @@ Ok(
                                                         Assign(
                                                             AssignPatProp {
                                                                 span: 54..55,
-                                                                key: Ident {
-                                                                    span: 54..55,
+                                                                key: BindingIdent {
                                                                     name: "x",
+                                                                    mutable: false,
+                                                                    span: 54..55,
                                                                 },
                                                                 value: None,
                                                             },

--- a/crates/tree_sitter_crochet/corpus/destructuring.txt
+++ b/crates/tree_sitter_crochet/corpus/destructuring.txt
@@ -12,35 +12,43 @@ const {a, b: {c, d}} = object;
   (expression_statement
     (parenthesized_expression
       (assignment_expression
-        (object_pattern
-          (shorthand_property_identifier_pattern)
-          (pair_pattern
-            (property_identifier)
-            (member_expression
-              (identifier)
-              (property_identifier)))
-          (rest_pattern
-            (subscript_expression
-              (identifier)
-              (identifier))))
+        (non_null_expression
+          (object
+            (shorthand_property_identifier)
+            (pair
+              (property_identifier)
+              (member_expression
+                (identifier)
+                (property_identifier)))
+            (spread_element
+              (subscript_expression
+                (identifier)
+                (identifier))))
+          (MISSING "!"))
         (identifier))))
   (lexical_declaration
     (variable_declarator
       (object_pattern
-        (shorthand_property_identifier_pattern)
-        (shorthand_property_identifier_pattern)
+        (shorthand_property_identifier_pattern
+          (identifier))
+        (shorthand_property_identifier_pattern
+          (identifier))
         (rest_pattern
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (identifier)))
   (lexical_declaration
     (variable_declarator
       (object_pattern
-        (shorthand_property_identifier_pattern)
+        (shorthand_property_identifier_pattern
+          (identifier))
         (pair_pattern
           (property_identifier)
           (object_pattern
-            (shorthand_property_identifier_pattern)
-            (shorthand_property_identifier_pattern))))
+            (shorthand_property_identifier_pattern
+              (identifier))
+            (shorthand_property_identifier_pattern
+              (identifier)))))
       (identifier))))
 
 ================================================================================
@@ -57,11 +65,14 @@ function a ({b, c}, {d}) {}
     (formal_parameters
       (required_parameter
         (object_pattern
-          (shorthand_property_identifier_pattern)
-          (shorthand_property_identifier_pattern)))
+          (shorthand_property_identifier_pattern
+            (identifier))
+          (shorthand_property_identifier_pattern
+            (identifier))))
       (required_parameter
         (object_pattern
-          (shorthand_property_identifier_pattern))))
+          (shorthand_property_identifier_pattern
+            (identifier)))))
     (statement_block)))
 
 ================================================================================
@@ -77,29 +88,35 @@ Array destructuring assignments
 (program
   (expression_statement
     (assignment_expression
-      (array_pattern
-        (identifier)
-        (member_expression
+      (non_null_expression
+        (array
           (identifier)
-          (property_identifier))
-        (rest_pattern
-          (subscript_expression
+          (member_expression
             (identifier)
-            (identifier))))
+            (property_identifier))
+          (spread_element
+            (subscript_expression
+              (identifier)
+              (identifier))))
+        (MISSING "!"))
       (identifier)))
   (expression_statement
     (assignment_expression
-      (array_pattern
-        (identifier)
-        (identifier)
-        (rest_pattern
-          (identifier)))
+      (non_null_expression
+        (array
+          (identifier)
+          (identifier)
+          (spread_element
+            (identifier)))
+        (MISSING "!"))
       (identifier)))
   (expression_statement
     (assignment_expression
-      (array_pattern
-        (identifier)
-        (identifier))
+      (non_null_expression
+        (array
+          (identifier)
+          (identifier))
+        (MISSING "!"))
       (identifier))))
 
 ================================================================================
@@ -117,20 +134,22 @@ function b({c} = {}) {}
   (lexical_declaration
     (variable_declarator
       (object_pattern
-        (pair_pattern
-          (property_identifier)
-          (assignment_pattern
-            (identifier)
-            (identifier))))
+        (object_assignment_pattern
+          (pair_pattern
+            (property_identifier)
+            (binding_identifier
+              (identifier)))
+          (identifier)))
       (identifier)))
   (for_in_statement
     (object_pattern
-      (pair_pattern
-        (property_identifier)
-        (assignment_pattern
+      (object_assignment_pattern
+        (pair_pattern
+          (property_identifier)
           (object_pattern
-            (shorthand_property_identifier_pattern))
-          (identifier))))
+            (shorthand_property_identifier_pattern
+              (identifier))))
+        (identifier)))
     (identifier)
     (statement_block))
   (function_declaration
@@ -139,13 +158,16 @@ function b({c} = {}) {}
       (required_parameter
         (object_pattern
           (object_assignment_pattern
-            (shorthand_property_identifier_pattern)
+            (shorthand_property_identifier_pattern
+              (identifier))
             (true))))
       (required_parameter
         (array_pattern
-          (identifier)
+          (binding_identifier
+            (identifier))
           (assignment_pattern
-            (identifier)
+            (binding_identifier
+              (identifier))
             (false)))))
     (statement_block))
   (function_declaration
@@ -153,6 +175,7 @@ function b({c} = {}) {}
     (formal_parameters
       (required_parameter
         (object_pattern
-          (shorthand_property_identifier_pattern))
+          (shorthand_property_identifier_pattern
+            (identifier)))
         (object)))
     (statement_block)))

--- a/crates/tree_sitter_crochet/corpus/expressions.txt
+++ b/crates/tree_sitter_crochet/corpus/expressions.txt
@@ -408,9 +408,11 @@ Objects with method definitions
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier))
+            (binding_identifier
+              (identifier)))
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (binary_expression
@@ -426,7 +428,8 @@ Objects with method definitions
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (expression_statement
             (assignment_expression
@@ -529,7 +532,8 @@ class Foo extends require('another-class') {
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier))))
@@ -537,7 +541,8 @@ class Foo extends require('another-class') {
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier))))
@@ -545,7 +550,8 @@ class Foo extends require('another-class') {
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier))))
@@ -553,7 +559,8 @@ class Foo extends require('another-class') {
         (private_property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (member_expression
@@ -771,10 +778,12 @@ Functions
       (function
         (formal_parameters
           (required_parameter
-            (identifier))
+            (binding_identifier
+              (identifier)))
           (required_parameter
             (rest_pattern
-              (identifier))))
+              (binding_identifier
+                (identifier)))))
         (statement_block
           (expression_statement
             (identifier))))
@@ -786,21 +795,25 @@ Functions
         (identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block))
       (function
         (identifier)
         (formal_parameters
           (required_parameter
-            (identifier))
+            (binding_identifier
+              (identifier)))
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block))
       (function
         (identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block))
       (function
         (identifier)
@@ -809,7 +822,8 @@ Functions
             (rest_pattern
               (array_pattern
                 (assignment_pattern
-                  (identifier)
+                  (binding_identifier
+                    (identifier))
                   (identifier))))))
         (statement_block)))))
 
@@ -843,17 +857,21 @@ async => async + 1;
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier))
+          (binding_identifier
+            (identifier)))
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (number)))
   (expression_statement
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier))
+          (binding_identifier
+            (identifier)))
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (statement_block
         (return_statement
           (identifier)))))
@@ -861,23 +879,28 @@ async => async + 1;
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (number)))
   (expression_statement
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier))
+          (binding_identifier
+            (identifier)))
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (number)))
   (expression_statement
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier))
+          (binding_identifier
+            (identifier)))
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (number)))
   (expression_statement
     (arrow_function
@@ -911,9 +934,11 @@ Generator Functions
         (identifier)
         (formal_parameters
           (required_parameter
-            (identifier))
+            (binding_identifier
+              (identifier)))
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (expression_statement
             (yield_expression))
@@ -941,15 +966,19 @@ function a({b}, c = d, e = f, async = true) {
     (formal_parameters
       (required_parameter
         (object_pattern
-          (shorthand_property_identifier_pattern)))
+          (shorthand_property_identifier_pattern
+            (identifier))))
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (identifier))
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (identifier))
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (true)))
     (statement_block)))
 
@@ -1038,7 +1067,8 @@ return this.map(function (a) {
             (function
               (formal_parameters
                 (required_parameter
-                  (identifier)))
+                  (binding_identifier
+                    (identifier))))
               (statement_block
                 (return_statement
                   (member_expression
@@ -1050,7 +1080,8 @@ return this.map(function (a) {
         (function
           (formal_parameters
             (required_parameter
-              (identifier)))
+              (binding_identifier
+                (identifier))))
           (statement_block
             (return_statement
               (member_expression
@@ -1083,9 +1114,11 @@ function(x, y) {
       (function
         (formal_parameters
           (required_parameter
-            (identifier))
+            (binding_identifier
+              (identifier)))
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block))
       (arguments
         (identifier)
@@ -1267,7 +1300,8 @@ async function* foo() { yield 1 }
     (arrow_function
       (formal_parameters
         (required_parameter
-          (identifier)))
+          (binding_identifier
+            (identifier))))
       (statement_block
         (return_statement
           (identifier)))))
@@ -1881,11 +1915,15 @@ b = <Text {...j}></Text>;
           (identifier))))))
 
 ================================================================================
-Expressions with rest elements
+Expressions with spread elements
 ================================================================================
 
-foo(...rest);
-foo = [...[bar] = [baz]];
+foo(...spread);
+foo(...[a, b]);
+foo = [...spread];
+foo = [...[a, b]];
+foo = {...spread};
+foo = {...{a, b}};
 
 --------------------------------------------------------------------------------
 
@@ -1897,15 +1935,41 @@ foo = [...[bar] = [baz]];
         (spread_element
           (identifier)))))
   (expression_statement
+    (call_expression
+      (identifier)
+      (arguments
+        (spread_element
+          (array
+            (identifier)
+            (identifier))))))
+  (expression_statement
     (assignment_expression
       (identifier)
       (array
         (spread_element
-          (assignment_expression
-            (array_pattern
-              (identifier))
-            (array
-              (identifier))))))))
+          (identifier)))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (array
+        (spread_element
+          (array
+            (identifier)
+            (identifier))))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (object
+        (spread_element
+          (identifier)))))
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (object
+        (spread_element
+          (object
+            (shorthand_property_identifier)
+            (shorthand_property_identifier)))))))
 
 ================================================================================
 Forward slashes after parenthesized expressions
@@ -2243,7 +2307,8 @@ let result = try { throw [a, b] } catch ([c, d]) { };
           (expression
             (identifier)))
         (catch_clause
-          (identifier)
+          (binding_identifier
+            (identifier))
           (statement_block
             (expression
               (identifier)))))))
@@ -2288,8 +2353,10 @@ let result = try { throw [a, b] } catch ([c, d]) { };
                 (identifier)))))
         (catch_clause
           (array_pattern
-            (identifier)
-            (identifier))
+            (binding_identifier
+              (identifier))
+            (binding_identifier
+              (identifier)))
           (statement_block))))))
 
 ================================================================================
@@ -2308,7 +2375,8 @@ const foo = (msg) => throw new Error(msg);
       (arrow_function
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (unary_expression
           (new_expression
             (identifier)

--- a/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
+++ b/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
@@ -25,28 +25,34 @@ let bar = match (foo) {
           (match_arm
             (refutable_pattern
               (refutable_object_pattern
-                (shorthand_property_identifier_pattern)
+                (shorthand_property_identifier_pattern
+                  (identifier))
                 (refutable_pair_pattern
                   (property_identifier)
                   (refutable_pattern
-                    (identifier)))
+                    (binding_identifier
+                      (identifier))))
                 (refutable_pair_pattern
                   (property_identifier)
                   (refutable_pattern
                     (number)))
                 (refutable_rest_pattern
-                  (identifier))))
+                  (binding_identifier
+                    (identifier)))))
             (string
               (string_fragment)))
           (match_arm
             (refutable_pattern
               (refutable_array_pattern
                 (refutable_pattern
-                  (identifier))
+                  (binding_identifier
+                    (identifier)))
                 (refutable_pattern
-                  (identifier))
+                  (binding_identifier
+                    (identifier)))
                 (refutable_rest_pattern
-                  (identifier))))
+                  (binding_identifier
+                    (identifier)))))
             (string
               (string_fragment)))
           (match_arm
@@ -67,12 +73,14 @@ let bar = match (foo) {
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (string
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (string
               (string_fragment))))))))
 
@@ -106,12 +114,14 @@ let bar = match (foo) {
                         (property_identifier)
                         (refutable_pattern
                           (refutable_object_pattern
-                            (shorthand_property_identifier_pattern)))))))))
+                            (shorthand_property_identifier_pattern
+                              (identifier))))))))))
             (string
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (string
               (string_fragment))))))))
 
@@ -155,7 +165,8 @@ let bar = match (foo) {
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (string
               (string_fragment))))))))
 
@@ -192,7 +203,8 @@ let bar = match (foo) {
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (binary_expression
               (identifier)
               (number))
@@ -200,7 +212,8 @@ let bar = match (foo) {
               (string_fragment)))
           (match_arm
             (refutable_pattern
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (string
               (string_fragment))))))))
 
@@ -227,13 +240,16 @@ let bar = if (let {x, y: b, ...rest} = foo) {
         (let_expression
           (refutable_pattern
             (refutable_object_pattern
-              (shorthand_property_identifier_pattern)
+              (shorthand_property_identifier_pattern
+                (identifier))
               (refutable_pair_pattern
                 (property_identifier)
                 (refutable_pattern
-                  (identifier)))
+                  (binding_identifier
+                    (identifier))))
               (refutable_rest_pattern
-                (identifier))))
+                (binding_identifier
+                  (identifier)))))
           (identifier))
         (statement_block
           (expression
@@ -245,11 +261,14 @@ let bar = if (let {x, y: b, ...rest} = foo) {
               (refutable_pattern
                 (refutable_array_pattern
                   (refutable_pattern
-                    (identifier))
+                    (binding_identifier
+                      (identifier)))
                   (refutable_pattern
-                    (identifier))
+                    (binding_identifier
+                      (identifier)))
                   (refutable_rest_pattern
-                    (identifier))))
+                    (binding_identifier
+                      (identifier)))))
               (identifier))
             (statement_block
               (expression
@@ -305,9 +324,11 @@ let bar = if (let {x: x is string} = foo) {
                       (identifier)
                       (identifier)))
                   (refutable_pattern
-                    (identifier))
+                    (binding_identifier
+                      (identifier)))
                   (refutable_rest_pattern
-                    (identifier))))
+                    (binding_identifier
+                      (identifier)))))
               (identifier))
             (statement_block
               (expression

--- a/crates/tree_sitter_crochet/corpus/statements.txt
+++ b/crates/tree_sitter_crochet/corpus/statements.txt
@@ -84,17 +84,17 @@ let undefined = 42;
   (variable_declaration
     (variable_declarator
       (binding_identifier
-        (identifier))
+        (undefined))
       (number)))
   (lexical_declaration
     (variable_declarator
       (binding_identifier
-        (identifier))
+        (undefined))
       (number)))
   (lexical_declaration
     (variable_declarator
       (binding_identifier
-        (identifier))
+        (undefined))
       (number))))
 
 ================================================================================
@@ -204,7 +204,8 @@ import.meta.url;
         (arrow_function
           (formal_parameters
             (required_parameter
-              (identifier)))
+              (binding_identifier
+                (identifier))))
           (statement_block)))))
   (expression_statement
     (member_expression
@@ -526,13 +527,7 @@ for (const {thing} in things) {
   thing();
 }
 
-for (x[i] in a) {}
-
-for (x.y in a) {}
-
-for ([a, b] in c) {}
-
-for ((a) in b) {}
+for (let [a, b] in c) {}
 
 --------------------------------------------------------------------------------
 
@@ -546,7 +541,8 @@ for ((a) in b) {}
           (identifier)
           (arguments)))))
   (for_in_statement
-    (identifier)
+    (binding_identifier
+      (identifier))
     (binary_expression
       (identifier)
       (object))
@@ -557,7 +553,8 @@ for ((a) in b) {}
           (arguments)))))
   (for_in_statement
     (object_pattern
-      (shorthand_property_identifier_pattern))
+      (shorthand_property_identifier_pattern
+        (identifier)))
     (identifier)
     (statement_block
       (expression_statement
@@ -565,26 +562,11 @@ for ((a) in b) {}
           (identifier)
           (arguments)))))
   (for_in_statement
-    (subscript_expression
-      (identifier)
-      (identifier))
-    (identifier)
-    (statement_block))
-  (for_in_statement
-    (member_expression
-      (identifier)
-      (property_identifier))
-    (identifier)
-    (statement_block))
-  (for_in_statement
     (array_pattern
-      (identifier)
-      (identifier))
-    (identifier)
-    (statement_block))
-  (for_in_statement
-    (parenthesized_expression
-      (identifier))
+      (binding_identifier
+        (identifier))
+      (binding_identifier
+        (identifier)))
     (identifier)
     (statement_block)))
 
@@ -646,8 +628,10 @@ for (let {a, b} of items || []) {
             (identifier))))))
   (for_in_statement
     (object_pattern
-      (shorthand_property_identifier_pattern)
-      (shorthand_property_identifier_pattern))
+      (shorthand_property_identifier_pattern
+        (identifier))
+      (shorthand_property_identifier_pattern
+        (identifier)))
     (binary_expression
       (identifier)
       (array))
@@ -671,7 +655,8 @@ for await (const chunk of stream) {
 
 (program
   (for_in_statement
-    (identifier)
+    (binding_identifier
+      (identifier))
     (identifier)
     (statement_block
       (expression_statement
@@ -844,7 +829,8 @@ var thing = {
           (function
             (formal_parameters
               (required_parameter
-                (identifier))
+                (binding_identifier
+                  (identifier)))
               (comment))
             (statement_block
               (comment)
@@ -1006,7 +992,8 @@ try { throw [a, b] } catch ([c, d]) { };
         (expression
           (identifier)))
       (catch_clause
-        (identifier)
+        (binding_identifier
+          (identifier))
         (statement_block
           (expression
             (identifier))))))
@@ -1042,8 +1029,10 @@ try { throw [a, b] } catch ([c, d]) { };
               (identifier)))))
       (catch_clause
         (array_pattern
-          (identifier)
-          (identifier))
+          (binding_identifier
+            (identifier))
+          (binding_identifier
+            (identifier)))
         (statement_block)))))
 
 ================================================================================

--- a/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/declarations.txt
@@ -89,7 +89,8 @@ declare module Foo {
       name: (identifier)
       parameters: (formal_parameters
         (required_parameter
-          pattern: (identifier)
+          pattern: (binding_identifier
+            name: (identifier))
           type: (type_annotation
             (predefined_type))))
       return_type: (type_annotation
@@ -102,7 +103,8 @@ declare module Foo {
           name: (identifier)
           parameters: (formal_parameters
             (required_parameter
-              pattern: (identifier)
+              pattern: (binding_identifier
+                name: (identifier))
               type: (type_annotation
                 (predefined_type))))
           return_type: (type_annotation
@@ -143,7 +145,8 @@ declare module Foo {
           name: (property_identifier)
           parameters: (formal_parameters
             (required_parameter
-              pattern: (identifier)
+              pattern: (binding_identifier
+                name: (identifier))
               type: (type_annotation
                 (predefined_type)))))
         (public_field_definition
@@ -214,7 +217,8 @@ declare module Foo {
           (try_statement
             body: (statement_block)
             handler: (catch_clause
-              parameter: (identifier)
+              parameter: (binding_identifier
+                name: (identifier))
               body: (statement_block))
             finalizer: (finally_clause
               body: (statement_block))))))))
@@ -234,7 +238,8 @@ finally {}
     (try_statement
       body: (statement_block)
       handler: (catch_clause
-        parameter: (identifier)
+        parameter: (binding_identifier
+          name: (identifier))
         type: (type_annotation
           (predefined_type))
         body: (statement_block))
@@ -329,11 +334,13 @@ export async function readFile(filename: string): Promise<Buffer>;
       (identifier)
       (formal_parameters
         (required_parameter
-          (identifier)
+          (binding_identifier
+            (identifier))
           (type_annotation
             (predefined_type)))
         (required_parameter
-          (identifier)
+          (binding_identifier
+            (identifier))
           (type_annotation
             (predefined_type))))
       (statement_block
@@ -351,7 +358,8 @@ export async function readFile(filename: string): Promise<Buffer>;
       (identifier)
       (formal_parameters
         (required_parameter
-          (identifier)
+          (binding_identifier
+            (identifier))
           (type_annotation
             (predefined_type))))
       (type_annotation
@@ -554,7 +562,8 @@ declare module "example" { }
               (type_identifier)))
           (formal_parameters
             (optional_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (generic_type
                   (type_identifier)
@@ -638,7 +647,8 @@ export interface Foo {
                 (type_identifier)))
             (formal_parameters
               (required_parameter
-                (identifier)
+                (binding_identifier
+                  (identifier))
                 (type_annotation
                   (generic_type
                     (nested_type_identifier
@@ -784,7 +794,8 @@ class Foo {
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block)))))
 
 ================================================================================
@@ -813,7 +824,8 @@ class Foo {
             (type_identifier)))
         (formal_parameters
           (required_parameter
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (function_type
                 (formal_parameters)
@@ -827,12 +839,14 @@ class Foo {
                         (literal_type
                           (undefined)))))))))
           (optional_parameter
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (function_type
                 (formal_parameters
                   (required_parameter
-                    (identifier)
+                    (binding_identifier
+                      (identifier))
                     (type_annotation
                       (type_identifier))))
                 (union_type
@@ -842,11 +856,13 @@ class Foo {
                     (type_arguments
                       (predefined_type)))))))
           (optional_parameter
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (predefined_type)))
           (optional_parameter
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (predefined_type))))
         (type_annotation
@@ -983,13 +999,15 @@ Classes with decorators
           (required_parameter
             (decorator
               (identifier))
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (predefined_type)))
           (optional_parameter
             (decorator
               (identifier))
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (predefined_type))))
         (statement_block)))))
@@ -1019,7 +1037,8 @@ class Foo<Bar> extends Baz { bar = 5; static one(a) { return a; }; two(b) { retu
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier))))
@@ -1027,7 +1046,8 @@ class Foo<Bar> extends Baz { bar = 5; static one(a) { return a; }; two(b) { retu
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier))))
@@ -1035,7 +1055,8 @@ class Foo<Bar> extends Baz { bar = 5; static one(a) { return a; }; two(b) { retu
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (statement_block
           (return_statement
             (identifier)))))))

--- a/crates/tree_sitter_crochet/corpus/tsx/functions.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/functions.txt
@@ -25,7 +25,8 @@ function foo<T, U>(this: T[]): U[] {
     name: (identifier)
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier)
+        pattern: (binding_identifier
+          name: (identifier))
         type: (type_annotation
           (predefined_type))))
     body: (statement_block
@@ -41,7 +42,8 @@ function foo<T, U>(this: T[]): U[] {
         name: (type_identifier)))
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier)
+        pattern: (binding_identifier
+          name: (identifier))
         type: (type_annotation
           (type_identifier))))
     return_type: (type_annotation
@@ -56,17 +58,20 @@ function foo<T, U>(this: T[]): U[] {
         name: (type_identifier)))
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier)
+        pattern: (binding_identifier
+          name: (identifier))
         type: (type_annotation
           (array_type
             (type_identifier))))
       (required_parameter
-        pattern: (identifier)
+        pattern: (binding_identifier
+          name: (identifier))
         type: (type_annotation
           (function_type
             parameters: (formal_parameters
               (required_parameter
-                pattern: (identifier)
+                pattern: (binding_identifier
+                  name: (identifier))
                 type: (type_annotation
                   (type_identifier))))
             return_type: (type_identifier)))))
@@ -180,11 +185,14 @@ function* foo<A>(amount, interestRate, duration): number {
           name: (type_identifier)))
       parameters: (formal_parameters
         (required_parameter
-          pattern: (identifier))
+          pattern: (binding_identifier
+            name: (identifier)))
         (required_parameter
-          pattern: (identifier))
+          pattern: (binding_identifier
+            name: (identifier)))
         (required_parameter
-          pattern: (identifier)))
+          pattern: (binding_identifier
+            name: (identifier))))
       return_type: (type_annotation
         (predefined_type))
       body: (number)))
@@ -195,11 +203,14 @@ function* foo<A>(amount, interestRate, duration): number {
         name: (type_identifier)))
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier))
+        pattern: (binding_identifier
+          name: (identifier)))
       (required_parameter
-        pattern: (identifier))
+        pattern: (binding_identifier
+          name: (identifier)))
       (required_parameter
-        pattern: (identifier)))
+        pattern: (binding_identifier
+          name: (identifier))))
     return_type: (type_annotation
       (predefined_type))
     body: (statement_block
@@ -216,7 +227,8 @@ function* foo<A>(amount, interestRate, duration): number {
     (arrow_function
       parameters: (formal_parameters
         (required_parameter
-          pattern: (identifier)
+          pattern: (binding_identifier
+            name: (identifier))
           type: (type_annotation
             (predefined_type))))
       return_type: (type_annotation
@@ -266,11 +278,13 @@ class A extends B {
         name: (property_identifier)
         parameters: (formal_parameters
           (required_parameter
-            pattern: (identifier)
+            pattern: (binding_identifier
+              name: (identifier))
             type: (type_annotation
               (predefined_type)))
           (required_parameter
-            pattern: (identifier)
+            pattern: (binding_identifier
+              name: (identifier))
             type: (type_annotation
               (predefined_type))))
         body: (statement_block
@@ -339,19 +353,22 @@ function foo(): () => { [key: foo]: bar } {}
     name: (identifier)
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier))))
+        pattern: (binding_identifier
+          name: (identifier)))))
   (function_signature
     name: (identifier)
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier)))
+        pattern: (binding_identifier
+          name: (identifier))))
     return_type: (type_annotation
       (type_identifier)))
   (function_signature
     name: (identifier)
     parameters: (formal_parameters
       (required_parameter
-        pattern: (identifier))))
+        pattern: (binding_identifier
+          name: (identifier)))))
   (function_signature
     name: (identifier)
     parameters: (formal_parameters)

--- a/crates/tree_sitter_crochet/corpus/tsx/types.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/types.txt
@@ -142,7 +142,8 @@ let MyFunction: {
           (call_signature
             (formal_parameters
               (required_parameter
-                (identifier)))
+                (binding_identifier
+                  (identifier))))
             (type_annotation
               (predefined_type)))
           (property_signature
@@ -199,7 +200,8 @@ type Something = {
       (call_signature
         (formal_parameters
           (required_parameter
-            (identifier)))
+            (binding_identifier
+              (identifier))))
         (type_annotation
           (predefined_type)))
       (index_signature
@@ -290,7 +292,8 @@ const foo: (this: Readable, size?: number) => any;
         (function_type
           (formal_parameters
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (predefined_type))))
           (predefined_type)))))
@@ -306,7 +309,8 @@ const foo: (this: Readable, size?: number) => any;
               (type_annotation
                 (type_identifier)))
             (optional_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (predefined_type))))
           (predefined_type))))))
@@ -329,7 +333,8 @@ let foo: ({a}: Foo) => number;
           (formal_parameters
             (required_parameter
               (object_pattern
-                (shorthand_property_identifier_pattern))
+                (shorthand_property_identifier_pattern
+                  (identifier)))
               (type_annotation
                 (type_identifier))))
           (predefined_type))))))
@@ -356,9 +361,11 @@ let x: new < T1, T2 > ( p1, p2 ) => R;
               (type_identifier)))
           (formal_parameters
             (required_parameter
-              (identifier))
+              (binding_identifier
+                (identifier)))
             (required_parameter
-              (identifier)))
+              (binding_identifier
+                (identifier))))
           (type_identifier))))))
 
 ================================================================================
@@ -705,7 +712,8 @@ interface Enum extends Bar, Baz, Foo<A> {
         (property_identifier)
         (formal_parameters
           (required_parameter
-            (identifier)
+            (binding_identifier
+              (identifier))
             (type_annotation
               (type_identifier))))
         (type_annotation
@@ -1006,11 +1014,13 @@ let score: (string: string, query: string) => number;
         (function_type
           (formal_parameters
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (predefined_type)))
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (predefined_type))))
           (predefined_type))))))
@@ -1188,7 +1198,8 @@ function f(x: any): asserts x {
     (identifier)
     (formal_parameters
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (type_annotation
           (predefined_type))))
     (asserts
@@ -1217,7 +1228,8 @@ function isT(t: T): t is T {
     (identifier)
     (formal_parameters
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (type_annotation
           (predefined_type))))
     (asserts
@@ -1243,7 +1255,8 @@ function isT(t: T): t is T {
     (identifier)
     (formal_parameters
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (type_annotation
           (type_identifier))))
     (type_predicate_annotation
@@ -1271,7 +1284,8 @@ function isFish(object: Fish): object is Fish {
     (identifier)
     (formal_parameters
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (type_annotation
           (type_identifier))))
     (type_predicate_annotation
@@ -1283,7 +1297,8 @@ function isFish(object: Fish): object is Fish {
     (identifier)
     (formal_parameters
       (required_parameter
-        (identifier)
+        (binding_identifier
+          (identifier))
         (type_annotation
           (type_identifier))))
     (type_predicate_annotation
@@ -1399,7 +1414,8 @@ type t = [a: A, b?: B, ...c: C[]];
           (type_identifier)))
       (required_parameter
         (rest_pattern
-          (identifier))
+          (binding_identifier
+            (identifier)))
         (type_annotation
           (array_type
             (type_identifier)))))))
@@ -1449,7 +1465,8 @@ type T<X> = T extends { x: infer X } ? X : never;
         (function_type
           (formal_parameters
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (type_identifier))))
           (conditional_type
@@ -1461,7 +1478,8 @@ type T<X> = T extends { x: infer X } ? X : never;
         (function_type
           (formal_parameters
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (type_identifier))))
           (conditional_type
@@ -1483,7 +1501,8 @@ type T<X> = T extends { x: infer X } ? X : never;
     (function_type
       (formal_parameters
         (required_parameter
-          (identifier)
+          (binding_identifier
+            (identifier))
           (type_annotation
             (type_identifier))))
       (conditional_type
@@ -1495,7 +1514,8 @@ type T<X> = T extends { x: infer X } ? X : never;
         (function_type
           (formal_parameters
             (required_parameter
-              (identifier)
+              (binding_identifier
+                (identifier))
               (type_annotation
                 (type_identifier))))
           (conditional_type
@@ -1829,7 +1849,8 @@ type Foo<T extends new (...args: any) => any> = T;
             (formal_parameters
               (required_parameter
                 (rest_pattern
-                  (identifier))
+                  (binding_identifier
+                    (identifier)))
                 (type_annotation
                   (predefined_type))))
             (predefined_type)))))
@@ -1844,7 +1865,8 @@ type Foo<T extends new (...args: any) => any> = T;
             (formal_parameters
               (required_parameter
                 (rest_pattern
-                  (identifier))
+                  (binding_identifier
+                    (identifier)))
                 (type_annotation
                   (predefined_type))))
             (predefined_type)))))

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -19,6 +19,27 @@ const dropLastMember = (node) => {
 module.exports = grammar(tsx, {
   name: "crochet",
 
+  // Always pick $.binding_identifer last when there's a conflict
+  conflicts: ($, previous) =>
+    previous.concat([
+      [$.assignment_expression, $.binding_identifier],
+
+      [$.primary_expression, $.binding_identifier],
+      [$._primary_type, $.binding_identifier],
+      [$.primary_expression, $._primary_type, $.binding_identifier],
+
+      [$.object, $.binding_identifier],
+      [$.object, $._property_name, $.binding_identifier],
+      [$._property_name, $.binding_identifier],
+
+      [$.literal_type, $.binding_identifier],
+      [$.predefined_type, $.binding_identifier],
+      [$.primary_expression, $.literal_type, $.binding_identifier],
+      [$.primary_expression, $.predefined_type, $.binding_identifier],
+
+      [$.export_statement, $.binding_identifier],
+    ]),
+
   rules: {
     // Removes sequence expression and optional flow-style type assertion
     parenthesized_expression: ($, prev) => seq("(", $.expression, ")"),
@@ -71,6 +92,9 @@ module.exports = grammar(tsx, {
     },
 
     // Replaces `optional("readonly")` in sequence with `optional("mut")`
+    // TODO: Do the same for public_field_definition
+    // TODO: Create a function that can replace all nodes of a certain type
+    // in a rule declaration.
     method_definition: ($, prev) => {
       const members = prev.content.members.map((member) => {
         if (
@@ -84,8 +108,6 @@ module.exports = grammar(tsx, {
 
       return prec.left(seq(...members));
     },
-
-    // TODO: Do the same for public_field_definition
 
     expression: ($, prev) => {
       // Removes ternary expression
@@ -133,16 +155,28 @@ module.exports = grammar(tsx, {
       ),
 
     binding_identifier: ($) =>
-      seq(optional(field("mut", "mut")), field("name", $.identifier)),
+      seq(
+        optional(field("mut", "mut")),
+        field(
+          "name",
+          // NOTE: I thought about disallowing reserved identifiers here, but there
+          // are too many reserved identifiers and some of them are just too handy,
+          // e.g. let set = new Set();
+          choice($._identifier, alias($._reserved_identifier, $.identifier))
+        )
+      ),
 
-    // adapted from define-grammar.js
+    // Adapted from define-grammar.js
     // TODO: Create a function that can replace all nodes of a certain type
     // in a rule declaration.
     variable_declarator: ($) =>
       choice(
         seq(
           // field("name", choice($.identifier, $._destructuring_pattern)),
-          field("name", choice($.binding_identifier, $._destructuring_pattern)),
+          field(
+            "name",
+            choice($.binding_identifier, $._binding_destructuring_pattern)
+          ),
           field("type", optional($.type_annotation)),
           optional($._initializer)
         ),
@@ -187,19 +221,38 @@ module.exports = grammar(tsx, {
       return choice(...choices);
     },
 
+    // Removes _destructuring_pattern from _lhs_expression
+    // NOTE: we can't use prev.members.filter here b/c define-grammar.js does
+    // ($, previous) => choice(previous, ...).
+    // TODO: write a function to flatten choices
+    _lhs_expression: ($) =>
+      choice(
+        $.member_expression,
+        $.subscript_expression,
+        $._identifier,
+        alias($._reserved_identifier, $.identifier),
+        // $._destructuring_pattern,
+        $.non_null_expression
+      ),
+
     _for_header: ($) =>
       seq(
         "(",
         choice(
           field("left", choice($._lhs_expression, $.parenthesized_expression)),
+          // We remove this choice b/c we don't want to support `var`
           // seq(
           //   field("kind", "var"),
           //   field("left", choice($.identifier, $._destructuring_pattern)),
           //   optional($._initializer)
           // ),
           seq(
+            // TODO: get rid of `const`
             field("kind", choice("let", "const")),
-            field("left", choice($.identifier, $._destructuring_pattern))
+            field(
+              "left",
+              choice($.binding_identifier, $._binding_destructuring_pattern)
+            )
           )
         ),
         field("operator", choice("in", "of")),
@@ -211,7 +264,7 @@ module.exports = grammar(tsx, {
       seq(
         "{",
         repeat($.statement),
-        // We define an alias here so that it's easyt to check if the
+        // We define an alias here so that it's easy to check if the
         // last named child in the block is an expression or not.
         optional(alias($.expression, $.expression)),
         "}"
@@ -223,8 +276,8 @@ module.exports = grammar(tsx, {
       replaceField(prev, "body", $.statement_block),
     while_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
     do_statement: ($, prev) => replaceField(prev, "body", $.statement_block),
-    switch_case: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
-    switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeate($.statement)
+    switch_case: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeat($.statement)
+    switch_default: ($, prev) => replaceField(prev, "body", $.statement_block), // replaces repeat($.statement)
 
     if_expression: ($) =>
       prec.right(
@@ -251,6 +304,30 @@ module.exports = grammar(tsx, {
           ),
           field("argument", $.expression)
         )
+      ),
+
+    // Adapted from define-grammar.js
+    // TODO: Create a function that can replace all nodes of a certain type
+    // in a rule declaration.
+    catch_clause: ($) =>
+      seq(
+        "catch",
+        optional(
+          seq(
+            "(",
+            field(
+              "parameter",
+              choice($.binding_identifier, $._binding_destructuring_pattern)
+            ),
+            optional(
+              // only types that resolve to 'any' or 'unknown' are supported
+              // by the language but it's simpler to accept any type here.
+              field("type", $.type_annotation)
+            ),
+            ")"
+          )
+        ),
+        field("body", $.statement_block)
       ),
 
     //
@@ -304,7 +381,7 @@ module.exports = grammar(tsx, {
         $.false,
         // TOOD: support regex literals
 
-        $._identifier, // identifiers + undefined
+        $.binding_identifier, // identifiers + undefined
 
         $.refutable_array_pattern,
         $.refutable_is_pattern,
@@ -331,7 +408,7 @@ module.exports = grammar(tsx, {
                 $.refutable_pair_pattern,
                 $.refutable_rest_pattern,
                 alias(
-                  choice($.identifier, $._reserved_identifier),
+                  $.binding_identifier,
                   $.shorthand_property_identifier_pattern
                 )
               )
@@ -352,10 +429,96 @@ module.exports = grammar(tsx, {
       seq(
         "...",
         choice(
-          $.identifier,
+          $.binding_identifier,
           $.refutable_array_pattern,
           $.refutable_object_pattern
         )
+      ),
+
+    //
+    // Patterns
+    //
+    // We reimplement $.pattern and its dependencies here so that:
+    // - bindings that are introduced can now have an optional `mut` modifier, e.g.
+    //   let {x, mut y} = point;
+    // - LHS expressions are no longer allowed valid patterns
+    ///
+
+    pattern: ($) =>
+      prec.dynamic(
+        -1,
+        choice(
+          $.binding_identifier,
+          $.array_pattern,
+          $.object_pattern,
+          $.rest_pattern
+        )
+      ),
+
+    array_pattern: ($) =>
+      seq("[", commaSep(choice($.pattern, $.assignment_pattern)), "]"),
+
+    assignment_pattern: ($) =>
+      seq(field("left", $.pattern), "=", field("right", $.expression)),
+
+    object_pattern: ($) =>
+      prec(
+        "object",
+        seq(
+          "{",
+          commaSep(
+            optional(
+              choice(
+                $.pair_pattern,
+                $.rest_pattern,
+                alias(
+                  $.binding_identifier,
+                  $.shorthand_property_identifier_pattern
+                ),
+                $.object_assignment_pattern
+              )
+            )
+          ),
+          "}"
+        )
+      ),
+
+    object_assignment_pattern: ($) =>
+      seq(
+        field(
+          "left",
+          choice(
+            $.pair_pattern,
+            alias($.binding_identifier, $.shorthand_property_identifier_pattern)
+          )
+        ),
+        "=",
+        field("right", $.expression)
+      ),
+
+    pair_pattern: ($) =>
+      seq(field("key", $._property_name), ":", field("value", $.pattern)),
+
+    rest_pattern: ($) =>
+      prec.right(
+        seq(
+          "...",
+          choice($.binding_identifier, $.array_pattern, $.object_pattern)
+        )
+      ),
+
+    // We use this instead of _destructuring_pattern in places where new bindings
+    // will be introduced b/c of the destructuring.
+    _binding_destructuring_pattern: ($) =>
+      choice($.object_pattern, $.array_pattern),
+
+    _parameter_name: ($) =>
+      seq(
+        repeat(field("decorator", $.decorator)),
+        optional($.accessibility_modifier),
+        optional($.override_modifier),
+        optional("readonly"),
+        field("pattern", choice($.pattern, $.this))
       ),
   },
 });


### PR DESCRIPTION
This is going to allow us to specify which binding identifiers we want to be mutable when destructuring values as part of variable declarations and parameters in functions, e.g.
```
let {a, mut b} = obj;
let foo = ({p, q: mut r}) => { ... }
let [x, mut y, z] = arr;
```

This avoids having to do multiple destructurings if you want some variables to be `const` and others to be `let` like you do now in JS/TS, e.g.
```
const {a} = obj;
let {b} = obj;
```

This PR also updates the tree-sitter grammar to disallow the use of LHS expressions as patterns.

TODO:
- [x] update `crochet_parser` to read the `mut` field on all patterns
- [x] update `crochet_infer` to handle the `mutable` field on all `Pattern`s

NOTE: We still have to handle shorthand props and assignment props.  I'll do this in a separate PR because I want to rework how we model object properties in patterns in the AST to be more like what babel does which is a lot simpler than what we're doing now.