### PR TITLE
Handle default values for object pattern properties and array pattern elements

### DIFF
--- a/crates/crochet_ast/src/types/pat.rs
+++ b/crates/crochet_ast/src/types/pat.rs
@@ -63,6 +63,7 @@ impl fmt::Display for TObjectPat {
     }
 }
 
+// TODO: update this to match AST changes to ObjectPatProp
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TObjectPatProp {
     KeyValue(TObjectKeyValuePatProp),

--- a/crates/crochet_ast/src/values/pattern.rs
+++ b/crates/crochet_ast/src/values/pattern.rs
@@ -45,9 +45,7 @@ pub struct LitPat {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IsPat {
-    // TODO: change this to ident: BindingIdent so that we can
-    // use `mut` with `is` patterns as well
-    pub id: Ident,
+    pub ident: BindingIdent,
     pub is_id: Ident,
 }
 
@@ -135,6 +133,14 @@ mod tests {
         Ident {
             span: 0..0,
             name: name.to_owned(),
+        }
+    }
+
+    fn binding_ident(name: &str) -> BindingIdent {
+        BindingIdent {
+            span: 0..0,
+            name: name.to_owned(),
+            mutable: false,
         }
     }
 
@@ -264,7 +270,7 @@ mod tests {
     #[test]
     fn is_is_refutable() {
         let kind = PatternKind::Is(IsPat {
-            id: ident("foo"),
+            ident: binding_ident("foo"),
             is_id: ident("string"),
         });
         let is_pat = Pattern {

--- a/crates/crochet_ast/src/values/pattern.rs
+++ b/crates/crochet_ast/src/values/pattern.rs
@@ -45,6 +45,8 @@ pub struct LitPat {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IsPat {
+    // TODO: change this to ident: BindingIdent so that we can
+    // use `mut` with `is` patterns as well
     pub id: Ident,
     pub is_id: Ident,
 }
@@ -72,21 +74,23 @@ pub struct ObjectPat {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObjectPatProp {
     KeyValue(KeyValuePatProp),
+    Shorthand(ShorthandPatProp),
     Rest(RestPat), // TODO: create a new RestPatProp that includes a span
-    Assign(AssignPatProp),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyValuePatProp {
     pub key: Ident,
     pub value: Box<Pattern>,
+    pub init: Option<Box<Expr>>,
+    pub span: Span,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssignPatProp {
+pub struct ShorthandPatProp {
+    pub ident: BindingIdent,
+    pub init: Option<Box<Expr>>,
     pub span: Span,
-    pub key: BindingIdent,
-    pub value: Option<Box<Expr>>,
 }
 
 pub fn is_refutable(pat: &Pattern) -> bool {
@@ -103,8 +107,8 @@ pub fn is_refutable(pat: &Pattern) -> bool {
         // refutable if at least one sub-pattern is refutable
         PatternKind::Object(ObjectPat { props, .. }) => props.iter().any(|prop| match prop {
             ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => is_refutable(value),
+            ObjectPatProp::Shorthand(_) => false, // corresponds to {x} or {x = 5}
             ObjectPatProp::Rest(RestPat { arg, .. }) => is_refutable(arg),
-            ObjectPatProp::Assign(_) => false, // corresponds to {x = 5}
         }),
         PatternKind::Array(ArrayPat { elems, .. }) => {
             elems.iter().any(|elem| {
@@ -184,6 +188,8 @@ mod tests {
             props: vec![ObjectPatProp::KeyValue(KeyValuePatProp {
                 key: ident("foo"),
                 value: Box::from(ident_pattern("foo")),
+                init: None,
+                span: 0..0,
             })],
             optional: false,
         });
@@ -202,10 +208,14 @@ mod tests {
                 ObjectPatProp::KeyValue(KeyValuePatProp {
                     key: ident("foo"),
                     value: Box::from(ident_pattern("foo")),
+                    init: None,
+                    span: 0..0,
                 }),
                 ObjectPatProp::KeyValue(KeyValuePatProp {
                     key: ident("bar"),
                     value: Box::from(num_lit_pat("5")),
+                    init: None,
+                    span: 0..0,
                 }),
             ],
             optional: false,

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -208,7 +208,10 @@ pub fn build_param_pat_rec(pattern: &values::Pattern, type_ann: Option<Box<TsTyp
             let elems = array
                 .elems
                 .iter()
-                .map(|elem| elem.as_ref().map(|elem| build_param_pat_rec(elem, None)))
+                .map(|elem| {
+                    elem.as_ref()
+                        .map(|elem| build_param_pat_rec(&elem.pattern, None))
+                })
                 .collect();
             Pat::Array(ArrayPat {
                 span: DUMMY_SP,

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -1,3 +1,4 @@
+use crochet_ast::values::ShorthandPatProp;
 use itertools::Itertools;
 use std::rc::Rc;
 
@@ -177,12 +178,15 @@ pub fn build_param_pat_rec(pattern: &values::Pattern, type_ann: Option<Box<TsTyp
                             value: Box::from(build_param_pat_rec(kv.value.as_ref(), None)),
                         })
                     }
-                    values::ObjectPatProp::Assign(assign) => {
+                    values::ObjectPatProp::Shorthand(ShorthandPatProp {
+                        ident,
+                        init: _,
+                        span: _,
+                    }) => {
                         ObjectPatProp::Assign(AssignPatProp {
                             span: DUMMY_SP,
-                            key: build_ident(&assign.key.name),
-                            // TODO: handle default values
-                            value: None,
+                            key: build_ident(&ident.name),
+                            value: None, // TS type annotations don't support default values
                         })
                     }
                     values::ObjectPatProp::Rest(rest) => ObjectPatProp::Rest(RestPat {

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -219,8 +219,8 @@ fn build_pattern(
                 type_ann: None, // because we're generating .js.
             }))
         }
-        values::PatternKind::Is(values::IsPat { id, .. }) => Some(Pat::Ident(BindingIdent {
-            id: build_ident(&id.name),
+        values::PatternKind::Is(values::IsPat { ident, .. }) => Some(Pat::Ident(BindingIdent {
+            id: build_ident(&ident.name),
             type_ann: None,
         })),
     }

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -177,16 +177,17 @@ fn build_pattern(
                             })
                         })
                     }
-                    values::ObjectPatProp::Assign(ap) => {
-                        Some(ObjectPatProp::Assign(AssignPatProp {
-                            span: DUMMY_SP,
-                            key: Ident::from(&ap.key),
-                            value: ap
-                                .value
-                                .clone()
-                                .map(|value| Box::from(build_expr(value.as_ref(), stmts, ctx))),
-                        }))
-                    }
+                    values::ObjectPatProp::Shorthand(values::ShorthandPatProp {
+                        ident,
+                        init,
+                        span: _,
+                    }) => Some(ObjectPatProp::Assign(AssignPatProp {
+                        span: DUMMY_SP,
+                        key: Ident::from(ident),
+                        value: init
+                            .clone()
+                            .map(|value| Box::from(build_expr(value.as_ref(), stmts, ctx))),
+                    })),
                     values::ObjectPatProp::Rest(_) => todo!(),
                 })
                 .collect();
@@ -1031,8 +1032,8 @@ fn get_conds_for_pat(pat: &values::Pattern, conds: &mut Vec<Condition>, path: &m
                         get_conds_for_pat(value, conds, path);
                         path.pop();
                     }
+                    values::ObjectPatProp::Shorthand(_) => (),
                     values::ObjectPatProp::Rest(_) => (),
-                    values::ObjectPatProp::Assign(_) => (),
                 }
             }
         }

--- a/crates/crochet_codegen/src/js.rs
+++ b/crates/crochet_codegen/src/js.rs
@@ -205,7 +205,7 @@ fn build_pattern(
             let elems: Vec<Option<Pat>> = elems
                 .iter()
                 .map(|elem| match elem {
-                    Some(elem) => build_pattern(elem, stmts, ctx),
+                    Some(elem) => build_pattern(&elem.pattern, stmts, ctx),
                     None => None,
                 })
                 .collect();
@@ -1041,7 +1041,7 @@ fn get_conds_for_pat(pat: &values::Pattern, conds: &mut Vec<Condition>, path: &m
             for (index, elem) in elems.iter().enumerate() {
                 path.push(PathElem::ArrayIndex(index as u32));
                 if let Some(elem) = elem {
-                    get_conds_for_pat(elem, conds, path);
+                    get_conds_for_pat(&elem.pattern, conds, path);
                 }
                 path.pop();
             }

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -72,9 +72,13 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
                                 value: pattern_to_tpat(&kv.value),
                             })
                         }
-                        ObjectPatProp::Assign(assign) => {
+                        ObjectPatProp::Shorthand(ShorthandPatProp {
+                            ident,
+                            init: _,
+                            span: _,
+                        }) => {
                             types::TObjectPatProp::Assign(types::TObjectAssignPatProp {
-                                key: assign.key.name.to_owned(),
+                                key: ident.name.to_owned(),
                                 // TODO: figure when/how to set this to a non-None value
                                 value: None,
                             })

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -98,7 +98,7 @@ pub fn pattern_to_tpat(pattern: &Pattern) -> TPat {
                 elems: e_array
                     .elems
                     .iter()
-                    .map(|elem| elem.as_ref().map(pattern_to_tpat))
+                    .map(|elem| elem.as_ref().map(|elem| pattern_to_tpat(&elem.pattern)))
                     .collect(),
             })
         }

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -80,7 +80,7 @@ fn infer_pattern_rec(
             Ok(tv)
         }
         PatternKind::Lit(LitPat { lit, .. }) => Ok(Type::from(lit.to_owned())),
-        PatternKind::Is(IsPat { id, is_id, .. }) => {
+        PatternKind::Is(IsPat { ident, is_id, .. }) => {
             let kind = match is_id.name.as_str() {
                 "string" => TypeKind::Keyword(types::TKeyword::String),
                 "number" => TypeKind::Keyword(types::TKeyword::Number),
@@ -100,7 +100,7 @@ fn infer_pattern_rec(
             let t = generalize(&all_types, &t);
             if assump
                 .insert(
-                    id.name.to_owned(),
+                    ident.name.to_owned(),
                     Binding {
                         mutable: false,
                         t: t.clone(),

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -121,12 +121,17 @@ fn infer_pattern_rec(
                 .iter_mut()
                 .map(|elem| {
                     match elem {
-                        Some(elem) => match &mut elem.kind {
+                        Some(elem) => match &mut elem.pattern.kind {
                             PatternKind::Rest(rest) => {
                                 let rest_ty = infer_pattern_rec(&mut rest.arg, ctx, assump)?;
                                 Ok(Type::from(TypeKind::Rest(Box::from(rest_ty))))
                             }
-                            _ => infer_pattern_rec(elem, ctx, assump),
+                            _ => {
+                                // TODO: handle elem.init when inferring the element's pattern
+                                // since this can have an impact on the type the assumption we
+                                // insert.
+                                infer_pattern_rec(&mut elem.pattern, ctx, assump)
+                            }
                         },
                         None => {
                             // TODO: figure how to ignore gaps in the array

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2725,6 +2725,7 @@ mod tests {
 
     // TODO: make this test fail
     #[test]
+    #[ignore]
     fn test_updating_properties_fails() {
         let src = r#"
         let foo: {bar: number} = {bar: 5};
@@ -2736,6 +2737,7 @@ mod tests {
 
     // TODO: make this test fail
     #[test]
+    #[ignore]
     fn test_updating_properties_with_string_literal_indexer_fails() {
         let src = r#"
         let foo: {bar: number} = {bar: 5};

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2772,7 +2772,6 @@ mod tests {
 
     // TODO: re-enable once we've update object pattern properties in the AST
     // to look more like babel's properties
-    #[ignore]
     #[test]
     #[should_panic = "can't assign to non-mutable binder 'bar'"]
     fn test_updating_mutable_destructured_shorthand_obj_member() {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2797,4 +2797,36 @@ mod tests {
 
         infer_prog(src);
     }
+
+    #[test]
+    fn test_updating_mutable_destructured_renamed_tuple_element() {
+        let src = r#"
+            declare let tuple: [number, string];
+            let [mut a, mut b = "hello"] = tuple;
+            a = 5;
+            b = "world";
+            "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("a", &ctx), "number");
+        assert_eq!(get_value_type("b", &ctx), "string");
+    }
+
+    #[test]
+    fn test_updating_mutable_destructured_renamed_tuple_element_with_optional_types() {
+        let src = r#"
+            declare let tuple: [number | undefined, string | undefined];
+            let [mut a, mut b = "hello"] = tuple;
+            a = 5;
+            b = "world";
+            "#;
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("a", &ctx), "number | undefined");
+        // TODO: the type of `b` should be just `string` b/c we're providing
+        // a default value when destructuring the tuple.
+        assert_eq!(get_value_type("b", &ctx), "string | undefined");
+    }
 }

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -56,8 +56,8 @@ pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
             })
         }
         PatternKind::Lit(_) => (), // leaf node
-        // TODO: figure out how to attach inferred_types to idents
-        PatternKind::Is(IsPat { id: _, is_id: _ }) => (),
+        // TODO: update BindingIdent to have an optional .inferred_type property
+        PatternKind::Is(IsPat { ident: _, is_id: _ }) => (),
         PatternKind::Wildcard(_) => (), // leaf node (also has no binding)
     }
 }

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -49,12 +49,11 @@ pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
             })
             // TODO: process `props`
         }
-        PatternKind::Array(ArrayPat { elems, optional: _ }) => {
-            elems.iter_mut().for_each(|elem| match elem {
-                Some(pat) => update_pattern(pat, s),
-                None => (),
-            })
-        }
+        PatternKind::Array(ArrayPat { elems, optional: _ }) => elems.iter_mut().for_each(|elem| {
+            if let Some(elem) = elem {
+                update_pattern(&mut elem.pattern, s);
+            }
+        }),
         PatternKind::Lit(_) => (), // leaf node
         // TODO: update BindingIdent to have an optional .inferred_type property
         PatternKind::Is(IsPat { ident: _, is_id: _ }) => (),
@@ -249,7 +248,7 @@ fn update_fn_param_pat(pat: &mut Pattern, s: &Subst) {
         }
         PatternKind::Array(ArrayPat { elems, optional: _ }) => elems.iter_mut().for_each(|elem| {
             if let Some(elem) = elem {
-                update_fn_param_pat(elem, s);
+                update_fn_param_pat(&mut elem.pattern, s);
             }
         }),
         PatternKind::Lit(_) => panic!("literal patterns are not allowed in function params"),

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -20,22 +20,31 @@ pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
         PatternKind::Object(ObjectPat { props, optional: _ }) => {
             props.iter_mut().for_each(|prop| match prop {
                 ObjectPatProp::KeyValue(KeyValuePatProp {
-                    key: _, // TODO: figure out how to attach inferred_types to idents
+                    // TODO: figure out how to attach inferred_types to idents
+                    // We can do this by updating `BindingIdent` to have an `inferred_type` property
+                    key: _,
                     value,
+                    init,
+                    span: _,
                 }) => {
                     update_pattern(value, s);
+                    if let Some(init) = init {
+                        update_expr(init, s)
+                    }
+                }
+                ObjectPatProp::Shorthand(ShorthandPatProp {
+                    // TODO: figure out how to attach inferred_types to idents
+                    // We can do this by updating `BindingIdent` to have an `inferred_type` property
+                    ident: _,
+                    init,
+                    span: _,
+                }) => {
+                    if let Some(init) = init {
+                        update_expr(init, s)
+                    }
                 }
                 ObjectPatProp::Rest(RestPat { arg }) => {
                     update_pattern(arg, s);
-                }
-                ObjectPatProp::Assign(AssignPatProp {
-                    span: _,
-                    key: _, // TODO: figure out how to attach inferred_types to idents
-                    value,
-                }) => {
-                    if let Some(value) = value {
-                        update_expr(value, s)
-                    }
                 }
             })
             // TODO: process `props`
@@ -209,17 +218,28 @@ fn update_fn_param_pat(pat: &mut Pattern, s: &Subst) {
         PatternKind::Rest(RestPat { arg }) => update_fn_param_pat(arg, s),
         PatternKind::Object(ObjectPat { props, optional: _ }) => {
             props.iter_mut().for_each(|prop| match prop {
-                // TODO: figure out how to attach inferred_types to idents
-                ObjectPatProp::KeyValue(KeyValuePatProp { key: _, value }) => {
-                    update_fn_param_pat(value, s);
-                }
-                ObjectPatProp::Assign(AssignPatProp {
-                    value,
+                ObjectPatProp::KeyValue(KeyValuePatProp {
+                    // TODO: figure out how to attach inferred_types to idents
+                    // We can do this by updating `BindingIdent` to have an `inferred_type` property
                     key: _,
+                    value,
+                    init,
                     span: _,
                 }) => {
-                    if let Some(value) = value {
-                        update_expr(value, s);
+                    update_pattern(value, s);
+                    if let Some(init) = init {
+                        update_expr(init, s)
+                    }
+                }
+                ObjectPatProp::Shorthand(ShorthandPatProp {
+                    // TODO: figure out how to attach inferred_types to idents
+                    // We can do this by updating `BindingIdent` to have an `inferred_type` property
+                    ident: _,
+                    init,
+                    span: _,
+                }) => {
+                    if let Some(init) = init {
+                        update_expr(init, s)
                     }
                 }
                 ObjectPatProp::Rest(RestPat { arg }) => {

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -252,7 +252,12 @@ fn parse_pattern(node: &tree_sitter::Node, src: &str) -> Result<Pattern, String>
                         )?);
 
                         // TODO: include `span` in this node
-                        Ok(ObjectPatProp::KeyValue(KeyValuePatProp { key, value }))
+                        Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+                            key,
+                            value,
+                            init: None,
+                            span: child.byte_range(),
+                        }))
                     }
                     "rest_pattern" => {
                         let pattern = child.named_child(0).unwrap();
@@ -262,19 +267,61 @@ fn parse_pattern(node: &tree_sitter::Node, src: &str) -> Result<Pattern, String>
                             arg: Box::from(pattern),
                         }))
                     }
-                    "object_assignment_pattern" => todo!(),
+                    "object_assignment_pattern" => {
+                        let left = child.child_by_field_name("left").unwrap();
+                        let right = child.child_by_field_name("right").unwrap();
+                        let init = parse_expression(&right, src)?;
+                        match left.kind() {
+                            "shorthand_property_identifier_pattern" => {
+                                let name_node = left.child_by_field_name("name").unwrap();
+                                let name = src.get(name_node.byte_range()).unwrap().to_owned();
+                                let mutable = left.child_by_field_name("mut").is_some();
+
+                                Ok(ObjectPatProp::Shorthand(ShorthandPatProp {
+                                    ident: BindingIdent {
+                                        span: name_node.byte_range(),
+                                        name,
+                                        mutable,
+                                    },
+                                    init: Some(Box::from(init)),
+                                    span: left.byte_range(),
+                                }))
+                            },
+                            "pair_pattern" => {
+                                let key_node = left.child_by_field_name("key").unwrap();
+                                let key = Ident {
+                                    span: key_node.byte_range(),
+                                    name: text_for_node(&key_node, src)?,
+                                };
+
+                                let value = Box::from(parse_pattern(
+                                    &left.child_by_field_name("value").unwrap(),
+                                    src,
+                                )?);
+
+                                // TODO: include `span` in this node
+                                Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+                                    key,
+                                    value,
+                                    init: Some(Box::from(init)),
+                                    span: left.byte_range(),
+                                }))
+                            },
+                            kind => panic!("unexpected .right property on object_assignment_pattern of type {kind}"),
+                        }
+                    }
                     "shorthand_property_identifier_pattern" => {
                         let name_node = child.child_by_field_name("name").unwrap();
                         let name = src.get(name_node.byte_range()).unwrap().to_owned();
                         let mutable = child.child_by_field_name("mut").is_some();
-                        Ok(ObjectPatProp::Assign(AssignPatProp {
-                            span: child.byte_range(),
-                            key: BindingIdent {
+                        Ok(ObjectPatProp::Shorthand(ShorthandPatProp {
+                            ident: BindingIdent {
                                 span: name_node.byte_range(),
                                 name,
                                 mutable,
                             },
-                            value: None,
+                            init: None,
+                            span: child.byte_range(),
                         }))
                     }
                     kind => panic!("Unexpected object property kind: '{kind}'"),
@@ -294,7 +341,15 @@ fn parse_pattern(node: &tree_sitter::Node, src: &str) -> Result<Pattern, String>
                 .named_children(&mut cursor)
                 .into_iter()
                 .map(|child| match child.kind() {
-                    "assignment_pattern" => todo!(),
+                    "assignment_pattern" => {
+                        // Right now we don't have an AST node to model this.  The most likely
+                        // solutions are:
+                        // - adding an optional .init property on BindingIdent to handle
+                        // - introducing a ArrayPatElem type to mirror ObjectPatProp
+                        // The second option is a bit more verbose, but avoids invalid ASTs which
+                        // could occur if a top-level binding
+                        todo!()
+                    }
                     _ => Ok(Some(parse_pattern(&child, src)?)),
                 })
                 .collect::<Result<Vec<_>, String>>()?;
@@ -978,6 +1033,8 @@ fn parse_refutable_pattern(node: &tree_sitter::Node, src: &str) -> Result<Patter
                                 name: key,
                             },
                             value: Box::from(value),
+                            init: None,
+                            span: prop.byte_range(),
                         }))
                     }
                     "refutable_rest_pattern" => {
@@ -989,15 +1046,15 @@ fn parse_refutable_pattern(node: &tree_sitter::Node, src: &str) -> Result<Patter
                         }))
                     }
                     "shorthand_property_identifier_pattern" => {
-                        let mutable = node.child_by_field_name("mut").is_some();
-                        Ok(ObjectPatProp::Assign(AssignPatProp {
-                            span: prop.byte_range(),
-                            key: BindingIdent {
+                        let mutable = prop.child_by_field_name("mut").is_some();
+                        Ok(ObjectPatProp::Shorthand(ShorthandPatProp {
+                            ident: BindingIdent {
                                 span: prop.byte_range(),
                                 name: text_for_node(&prop, src)?,
                                 mutable,
                             },
-                            value: None,
+                            init: None,
+                            span: prop.byte_range(),
                         }))
                     }
                     kind => panic!("Unexected prop.kind() = {kind}"),
@@ -1885,8 +1942,8 @@ mod tests {
         insta::assert_debug_snapshot!(parse("let foo = ({mut x, y: mut z}) => {};"));
         insta::assert_debug_snapshot!(parse("let [a, mut b, ...rest] = letters;"));
         insta::assert_debug_snapshot!(parse("let foo = ([a, mut b, ...rest]) => {};"));
-        // TODO: assigning defaults
-        // insta::assert_debug_snapshot!(parse("let {x, mut y = 10} = point;"));
+        insta::assert_debug_snapshot!(parse("let {x, mut y = 10} = point;"));
+        // TODO: need to handle "assignment_pattern"
         // insta::assert_debug_snapshot!(parse("let [a, mut b = 98, ...rest] = letters;"));
         // TODO: disallowed patterns, e.g. top-level rest, non-top-level type annotations
     }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1079,9 +1079,10 @@ fn parse_refutable_pattern(node: &tree_sitter::Node, src: &str) -> Result<Patter
             let right = child.named_child(1).unwrap();
 
             PatternKind::Is(IsPat {
-                id: Ident {
+                ident: BindingIdent {
                     span: left.byte_range(),
                     name: text_for_node(&left, src)?,
+                    mutable: false,
                 },
                 is_id: Ident {
                     span: right.byte_range(),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-10.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-10.snap
@@ -12,15 +12,15 @@ Ok(
                     kind: Object(
                         ObjectPat {
                             props: [
-                                Assign(
-                                    AssignPatProp {
-                                        span: 5..10,
-                                        key: BindingIdent {
+                                Shorthand(
+                                    ShorthandPatProp {
+                                        ident: BindingIdent {
                                             name: "x",
                                             mutable: true,
                                             span: 9..10,
                                         },
-                                        value: None,
+                                        init: None,
+                                        span: 5..10,
                                     },
                                 ),
                                 KeyValue(
@@ -40,6 +40,8 @@ Ok(
                                             ),
                                             inferred_type: None,
                                         },
+                                        init: None,
+                                        span: 12..20,
                                     },
                                 ),
                             ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-11.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-11.snap
@@ -31,15 +31,15 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 12..17,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "x",
                                                                     mutable: true,
                                                                     span: 16..17,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 12..17,
                                                             },
                                                         ),
                                                         KeyValue(
@@ -59,6 +59,8 @@ Ok(
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
+                                                                init: None,
+                                                                span: 19..27,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-13.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-13.snap
@@ -32,50 +32,59 @@ Ok(
                                                 ArrayPat {
                                                     elems: [
                                                         Some(
-                                                            Pattern {
-                                                                span: 12..13,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "a",
-                                                                        mutable: false,
-                                                                        span: 12..13,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            Pattern {
-                                                                span: 15..20,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "b",
-                                                                        mutable: true,
-                                                                        span: 15..20,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            Pattern {
-                                                                span: 22..29,
-                                                                kind: Rest(
-                                                                    RestPat {
-                                                                        arg: Pattern {
-                                                                            span: 25..29,
-                                                                            kind: Ident(
-                                                                                BindingIdent {
-                                                                                    name: "rest",
-                                                                                    mutable: false,
-                                                                                    span: 25..29,
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 12..13,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 12..13,
                                                                         },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 15..20,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: true,
+                                                                            span: 15..20,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 22..29,
+                                                                    kind: Rest(
+                                                                        RestPat {
+                                                                            arg: Pattern {
+                                                                                span: 25..29,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "rest",
+                                                                                        mutable: false,
+                                                                                        span: 25..29,
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-14.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-14.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"let {a, b, ...rest} = letters;\")"
+expression: "parse(\"let {x, mut y = 10} = point;\")"
 ---
 Ok(
     Program {
         body: [
             VarDecl {
-                span: 0..30,
+                span: 0..28,
                 pattern: Pattern {
                     span: 4..19,
                     kind: Object(
@@ -15,7 +15,7 @@ Ok(
                                 Shorthand(
                                     ShorthandPatProp {
                                         ident: BindingIdent {
-                                            name: "a",
+                                            name: "x",
                                             mutable: false,
                                             span: 5..6,
                                         },
@@ -26,27 +26,25 @@ Ok(
                                 Shorthand(
                                     ShorthandPatProp {
                                         ident: BindingIdent {
-                                            name: "b",
-                                            mutable: false,
-                                            span: 8..9,
+                                            name: "y",
+                                            mutable: true,
+                                            span: 12..13,
                                         },
-                                        init: None,
-                                        span: 8..9,
-                                    },
-                                ),
-                                Rest(
-                                    RestPat {
-                                        arg: Pattern {
-                                            span: 14..18,
-                                            kind: Ident(
-                                                BindingIdent {
-                                                    name: "rest",
-                                                    mutable: false,
-                                                    span: 14..18,
-                                                },
-                                            ),
-                                            inferred_type: None,
-                                        },
+                                        init: Some(
+                                            Expr {
+                                                span: 16..18,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 16..18,
+                                                            value: "10",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ),
+                                        span: 8..13,
                                     },
                                 ),
                             ],
@@ -58,11 +56,11 @@ Ok(
                 type_ann: None,
                 init: Some(
                     Expr {
-                        span: 22..29,
+                        span: 22..27,
                         kind: Ident(
                             Ident {
-                                span: 22..29,
-                                name: "letters",
+                                span: 22..27,
+                                name: "point",
                             },
                         ),
                         inferred_type: None,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-15.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-15.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/crochet_parser/src/lib.rs
-expression: "parse(\"let [a, mut b, ...rest] = letters;\")"
+expression: "parse(\"let [a, mut b = 98, ...rest] = letters;\")"
 ---
 Ok(
     Program {
         body: [
             VarDecl {
-                span: 0..34,
+                span: 0..39,
                 pattern: Pattern {
-                    span: 4..23,
+                    span: 4..28,
                     kind: Array(
                         ArrayPat {
                             elems: [
@@ -41,22 +41,35 @@ Ok(
                                             ),
                                             inferred_type: None,
                                         },
-                                        init: None,
+                                        init: Some(
+                                            Expr {
+                                                span: 16..18,
+                                                kind: Lit(
+                                                    Num(
+                                                        Num {
+                                                            span: 16..18,
+                                                            value: "98",
+                                                        },
+                                                    ),
+                                                ),
+                                                inferred_type: None,
+                                            },
+                                        ),
                                     },
                                 ),
                                 Some(
                                     ArrayPatElem {
                                         pattern: Pattern {
-                                            span: 15..22,
+                                            span: 20..27,
                                             kind: Rest(
                                                 RestPat {
                                                     arg: Pattern {
-                                                        span: 18..22,
+                                                        span: 23..27,
                                                         kind: Ident(
                                                             BindingIdent {
                                                                 name: "rest",
                                                                 mutable: false,
-                                                                span: 18..22,
+                                                                span: 23..27,
                                                             },
                                                         ),
                                                         inferred_type: None,
@@ -77,10 +90,10 @@ Ok(
                 type_ann: None,
                 init: Some(
                     Expr {
-                        span: 26..33,
+                        span: 31..38,
                         kind: Ident(
                             Ident {
-                                span: 26..33,
+                                span: 31..38,
                                 name: "letters",
                             },
                         ),

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-3.snap
@@ -23,26 +23,26 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 10..11,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "x",
                                                                     mutable: false,
                                                                     span: 10..11,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 10..11,
                                                             },
                                                         ),
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 13..14,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "y",
                                                                     mutable: false,
                                                                     span: 13..14,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 13..14,
                                                             },
                                                         ),
                                                     ],
@@ -51,6 +51,8 @@ Ok(
                                             ),
                                             inferred_type: None,
                                         },
+                                        init: None,
+                                        span: 5..15,
                                     },
                                 ),
                                 KeyValue(
@@ -64,26 +66,26 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 22..23,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "x",
                                                                     mutable: false,
                                                                     span: 22..23,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 22..23,
                                                             },
                                                         ),
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 25..26,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "y",
                                                                     mutable: false,
                                                                     span: 25..26,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 25..26,
                                                             },
                                                         ),
                                                     ],
@@ -92,6 +94,8 @@ Ok(
                                             ),
                                             inferred_type: None,
                                         },
+                                        init: None,
+                                        span: 17..27,
                                     },
                                 ),
                             ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-4.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-4.snap
@@ -13,50 +13,59 @@ Ok(
                         ArrayPat {
                             elems: [
                                 Some(
-                                    Pattern {
-                                        span: 5..6,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "a",
-                                                mutable: false,
-                                                span: 5..6,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ),
-                                Some(
-                                    Pattern {
-                                        span: 8..9,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "b",
-                                                mutable: false,
-                                                span: 8..9,
-                                            },
-                                        ),
-                                        inferred_type: None,
-                                    },
-                                ),
-                                Some(
-                                    Pattern {
-                                        span: 11..18,
-                                        kind: Rest(
-                                            RestPat {
-                                                arg: Pattern {
-                                                    span: 14..18,
-                                                    kind: Ident(
-                                                        BindingIdent {
-                                                            name: "rest",
-                                                            mutable: false,
-                                                            span: 14..18,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                    ArrayPatElem {
+                                        pattern: Pattern {
+                                            span: 5..6,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "a",
+                                                    mutable: false,
+                                                    span: 5..6,
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        init: None,
+                                    },
+                                ),
+                                Some(
+                                    ArrayPatElem {
+                                        pattern: Pattern {
+                                            span: 8..9,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "b",
+                                                    mutable: false,
+                                                    span: 8..9,
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        init: None,
+                                    },
+                                ),
+                                Some(
+                                    ArrayPatElem {
+                                        pattern: Pattern {
+                                            span: 11..18,
+                                            kind: Rest(
+                                                RestPat {
+                                                    arg: Pattern {
+                                                        span: 14..18,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "rest",
+                                                                mutable: false,
+                                                                span: 14..18,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        init: None,
                                     },
                                 ),
                             ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-5.snap
@@ -13,71 +13,83 @@ Ok(
                         ArrayPat {
                             elems: [
                                 Some(
-                                    Pattern {
-                                        span: 5..8,
-                                        kind: Ident(
-                                            BindingIdent {
-                                                name: "foo",
-                                                mutable: false,
-                                                span: 5..8,
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                    ArrayPatElem {
+                                        pattern: Pattern {
+                                            span: 5..8,
+                                            kind: Ident(
+                                                BindingIdent {
+                                                    name: "foo",
+                                                    mutable: false,
+                                                    span: 5..8,
+                                                },
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        init: None,
                                     },
                                 ),
                                 Some(
-                                    Pattern {
-                                        span: 10..27,
-                                        kind: Rest(
-                                            RestPat {
-                                                arg: Pattern {
-                                                    span: 13..27,
-                                                    kind: Array(
-                                                        ArrayPat {
-                                                            elems: [
-                                                                Some(
-                                                                    Pattern {
-                                                                        span: 14..17,
-                                                                        kind: Ident(
-                                                                            BindingIdent {
-                                                                                name: "bar",
-                                                                                mutable: false,
+                                    ArrayPatElem {
+                                        pattern: Pattern {
+                                            span: 10..27,
+                                            kind: Rest(
+                                                RestPat {
+                                                    arg: Pattern {
+                                                        span: 13..27,
+                                                        kind: Array(
+                                                            ArrayPat {
+                                                                elems: [
+                                                                    Some(
+                                                                        ArrayPatElem {
+                                                                            pattern: Pattern {
                                                                                 span: 14..17,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "bar",
+                                                                                        mutable: false,
+                                                                                        span: 14..17,
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                ),
-                                                                Some(
-                                                                    Pattern {
-                                                                        span: 19..26,
-                                                                        kind: Rest(
-                                                                            RestPat {
-                                                                                arg: Pattern {
-                                                                                    span: 22..26,
-                                                                                    kind: Ident(
-                                                                                        BindingIdent {
-                                                                                            name: "rest",
-                                                                                            mutable: false,
+                                                                            init: None,
+                                                                        },
+                                                                    ),
+                                                                    Some(
+                                                                        ArrayPatElem {
+                                                                            pattern: Pattern {
+                                                                                span: 19..26,
+                                                                                kind: Rest(
+                                                                                    RestPat {
+                                                                                        arg: Pattern {
                                                                                             span: 22..26,
+                                                                                            kind: Ident(
+                                                                                                BindingIdent {
+                                                                                                    name: "rest",
+                                                                                                    mutable: false,
+                                                                                                    span: 22..26,
+                                                                                                },
+                                                                                            ),
+                                                                                            inferred_type: None,
                                                                                         },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
                                                                             },
-                                                                        ),
-                                                                        inferred_type: None,
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            optional: false,
-                                                        },
-                                                    ),
-                                                    inferred_type: None,
+                                                                            init: None,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                optional: false,
+                                                            },
+                                                        ),
+                                                        inferred_type: None,
+                                                    },
                                                 },
-                                            },
-                                        ),
-                                        inferred_type: None,
+                                            ),
+                                            inferred_type: None,
+                                        },
+                                        init: None,
                                     },
                                 ),
                             ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-6.snap
@@ -32,29 +32,35 @@ Ok(
                                                 ArrayPat {
                                                     elems: [
                                                         Some(
-                                                            Pattern {
-                                                                span: 12..13,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "a",
-                                                                        mutable: false,
-                                                                        span: 12..13,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 12..13,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 12..13,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                         Some(
-                                                            Pattern {
-                                                                span: 15..16,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "b",
-                                                                        mutable: false,
-                                                                        span: 15..16,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 15..16,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 15..16,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-7.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-7.snap
@@ -32,29 +32,35 @@ Ok(
                                                 ArrayPat {
                                                     elems: [
                                                         Some(
-                                                            Pattern {
-                                                                span: 12..13,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "a",
-                                                                        mutable: false,
-                                                                        span: 12..13,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 12..13,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 12..13,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                         Some(
-                                                            Pattern {
-                                                                span: 15..16,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "b",
-                                                                        mutable: false,
-                                                                        span: 15..16,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 15..16,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 15..16,
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-8.snap
@@ -31,26 +31,26 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 12..13,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "a",
                                                                     mutable: false,
                                                                     span: 12..13,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 12..13,
                                                             },
                                                         ),
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 15..16,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "b",
                                                                     mutable: false,
                                                                     span: 15..16,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 15..16,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring-9.snap
@@ -31,26 +31,26 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 12..13,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "a",
                                                                     mutable: false,
                                                                     span: 12..13,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 12..13,
                                                             },
                                                         ),
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 15..16,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "b",
                                                                     mutable: false,
                                                                     span: 15..16,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 15..16,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__destructuring.snap
@@ -12,26 +12,26 @@ Ok(
                     kind: Object(
                         ObjectPat {
                             props: [
-                                Assign(
-                                    AssignPatProp {
-                                        span: 5..6,
-                                        key: BindingIdent {
+                                Shorthand(
+                                    ShorthandPatProp {
+                                        ident: BindingIdent {
                                             name: "x",
                                             mutable: false,
                                             span: 5..6,
                                         },
-                                        value: None,
+                                        init: None,
+                                        span: 5..6,
                                     },
                                 ),
-                                Assign(
-                                    AssignPatProp {
-                                        span: 8..9,
-                                        key: BindingIdent {
+                                Shorthand(
+                                    ShorthandPatProp {
+                                        ident: BindingIdent {
                                             name: "y",
                                             mutable: false,
                                             span: 8..9,
                                         },
-                                        value: None,
+                                        init: None,
+                                        span: 8..9,
                                     },
                                 ),
                             ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-5.snap
@@ -18,26 +18,26 @@ Ok(
                                         kind: Object(
                                             ObjectPat {
                                                 props: [
-                                                    Assign(
-                                                        AssignPatProp {
-                                                            span: 2..3,
-                                                            key: BindingIdent {
+                                                    Shorthand(
+                                                        ShorthandPatProp {
+                                                            ident: BindingIdent {
                                                                 name: "x",
                                                                 mutable: false,
                                                                 span: 2..3,
                                                             },
-                                                            value: None,
+                                                            init: None,
+                                                            span: 2..3,
                                                         },
                                                     ),
-                                                    Assign(
-                                                        AssignPatProp {
-                                                            span: 5..6,
-                                                            key: BindingIdent {
+                                                    Shorthand(
+                                                        ShorthandPatProp {
+                                                            ident: BindingIdent {
                                                                 name: "y",
                                                                 mutable: false,
                                                                 span: 5..6,
                                                             },
-                                                            value: None,
+                                                            init: None,
+                                                            span: 5..6,
                                                         },
                                                     ),
                                                 ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-6.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__function_definition-6.snap
@@ -35,6 +35,8 @@ Ok(
                                                                 ),
                                                                 inferred_type: None,
                                                             },
+                                                            init: None,
+                                                            span: 2..6,
                                                         },
                                                     ),
                                                     KeyValue(
@@ -54,6 +56,8 @@ Ok(
                                                                 ),
                                                                 inferred_type: None,
                                                             },
+                                                            init: None,
+                                                            span: 8..12,
                                                         },
                                                     ),
                                                 ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
@@ -55,6 +55,8 @@ Ok(
                                                                         ),
                                                                         inferred_type: None,
                                                                     },
+                                                                    init: None,
+                                                                    span: 32..46,
                                                                 },
                                                             ),
                                                         ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
@@ -43,9 +43,10 @@ Ok(
                                                                         span: 35..46,
                                                                         kind: Is(
                                                                             IsPat {
-                                                                                id: Ident {
-                                                                                    span: 35..36,
+                                                                                ident: BindingIdent {
                                                                                     name: "x",
+                                                                                    mutable: false,
+                                                                                    span: 35..36,
                                                                                 },
                                                                                 is_id: Ident {
                                                                                     span: 40..46,
@@ -110,9 +111,10 @@ Ok(
                                                                                     span: 110..120,
                                                                                     kind: Is(
                                                                                         IsPat {
-                                                                                            id: Ident {
-                                                                                                span: 110..111,
+                                                                                            ident: BindingIdent {
                                                                                                 name: "a",
+                                                                                                mutable: false,
+                                                                                                span: 110..111,
                                                                                             },
                                                                                             is_id: Ident {
                                                                                                 span: 115..120,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let-2.snap
@@ -107,52 +107,61 @@ Ok(
                                                                     ArrayPat {
                                                                         elems: [
                                                                             Some(
-                                                                                Pattern {
-                                                                                    span: 110..120,
-                                                                                    kind: Is(
-                                                                                        IsPat {
-                                                                                            ident: BindingIdent {
-                                                                                                name: "a",
-                                                                                                mutable: false,
-                                                                                                span: 110..111,
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 110..120,
+                                                                                        kind: Is(
+                                                                                            IsPat {
+                                                                                                ident: BindingIdent {
+                                                                                                    name: "a",
+                                                                                                    mutable: false,
+                                                                                                    span: 110..111,
+                                                                                                },
+                                                                                                is_id: Ident {
+                                                                                                    span: 115..120,
+                                                                                                    name: "Array",
+                                                                                                },
                                                                                             },
-                                                                                            is_id: Ident {
-                                                                                                span: 115..120,
-                                                                                                name: "Array",
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
                                                                                 },
                                                                             ),
                                                                             Some(
-                                                                                Pattern {
-                                                                                    span: 122..123,
-                                                                                    kind: Wildcard(
-                                                                                        WildcardPat,
-                                                                                    ),
-                                                                                    inferred_type: None,
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 122..123,
+                                                                                        kind: Wildcard(
+                                                                                            WildcardPat,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
                                                                                 },
                                                                             ),
                                                                             Some(
-                                                                                Pattern {
-                                                                                    span: 125..132,
-                                                                                    kind: Rest(
-                                                                                        RestPat {
-                                                                                            arg: Pattern {
-                                                                                                span: 128..132,
-                                                                                                kind: Ident(
-                                                                                                    BindingIdent {
-                                                                                                        name: "rest",
-                                                                                                        mutable: false,
-                                                                                                        span: 128..132,
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 125..132,
+                                                                                        kind: Rest(
+                                                                                            RestPat {
+                                                                                                arg: Pattern {
+                                                                                                    span: 128..132,
+                                                                                                    kind: Ident(
+                                                                                                        BindingIdent {
+                                                                                                            name: "rest",
+                                                                                                            mutable: false,
+                                                                                                            span: 128..132,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
+                                                                                                },
                                                                                             },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
                                                                                 },
                                                                             ),
                                                                         ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
@@ -33,15 +33,15 @@ Ok(
                                                 kind: Object(
                                                     ObjectPat {
                                                         props: [
-                                                            Assign(
-                                                                AssignPatProp {
-                                                                    span: 32..33,
-                                                                    key: BindingIdent {
+                                                            Shorthand(
+                                                                ShorthandPatProp {
+                                                                    ident: BindingIdent {
                                                                         name: "x",
                                                                         mutable: false,
                                                                         span: 32..33,
                                                                     },
-                                                                    value: None,
+                                                                    init: None,
+                                                                    span: 32..33,
                                                                 },
                                                             ),
                                                             KeyValue(
@@ -61,6 +61,8 @@ Ok(
                                                                         ),
                                                                         inferred_type: None,
                                                                     },
+                                                                    init: None,
+                                                                    span: 35..39,
                                                                 },
                                                             ),
                                                             Rest(

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__if_let.snap
@@ -127,46 +127,55 @@ Ok(
                                                                     ArrayPat {
                                                                         elems: [
                                                                             Some(
-                                                                                Pattern {
-                                                                                    span: 112..113,
-                                                                                    kind: Ident(
-                                                                                        BindingIdent {
-                                                                                            name: "a",
-                                                                                            mutable: false,
-                                                                                            span: 112..113,
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            ),
-                                                                            Some(
-                                                                                Pattern {
-                                                                                    span: 115..116,
-                                                                                    kind: Wildcard(
-                                                                                        WildcardPat,
-                                                                                    ),
-                                                                                    inferred_type: None,
-                                                                                },
-                                                                            ),
-                                                                            Some(
-                                                                                Pattern {
-                                                                                    span: 118..125,
-                                                                                    kind: Rest(
-                                                                                        RestPat {
-                                                                                            arg: Pattern {
-                                                                                                span: 121..125,
-                                                                                                kind: Ident(
-                                                                                                    BindingIdent {
-                                                                                                        name: "rest",
-                                                                                                        mutable: false,
-                                                                                                        span: 121..125,
-                                                                                                    },
-                                                                                                ),
-                                                                                                inferred_type: None,
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 112..113,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "a",
+                                                                                                mutable: false,
+                                                                                                span: 112..113,
                                                                                             },
-                                                                                        },
-                                                                                    ),
-                                                                                    inferred_type: None,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
+                                                                                },
+                                                                            ),
+                                                                            Some(
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 115..116,
+                                                                                        kind: Wildcard(
+                                                                                            WildcardPat,
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
+                                                                                },
+                                                                            ),
+                                                                            Some(
+                                                                                ArrayPatElem {
+                                                                                    pattern: Pattern {
+                                                                                        span: 118..125,
+                                                                                        kind: Rest(
+                                                                                            RestPat {
+                                                                                                arg: Pattern {
+                                                                                                    span: 121..125,
+                                                                                                    kind: Ident(
+                                                                                                        BindingIdent {
+                                                                                                            name: "rest",
+                                                                                                            mutable: false,
+                                                                                                            span: 121..125,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    inferred_type: None,
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: None,
+                                                                                    },
+                                                                                    init: None,
                                                                                 },
                                                                             ),
                                                                         ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-2.snap
@@ -64,15 +64,15 @@ Ok(
                                                                                             kind: Object(
                                                                                                 ObjectPat {
                                                                                                     props: [
-                                                                                                        Assign(
-                                                                                                            AssignPatProp {
-                                                                                                                span: 62..63,
-                                                                                                                key: BindingIdent {
+                                                                                                        Shorthand(
+                                                                                                            ShorthandPatProp {
+                                                                                                                ident: BindingIdent {
                                                                                                                     name: "c",
                                                                                                                     mutable: false,
                                                                                                                     span: 62..63,
                                                                                                                 },
-                                                                                                                value: None,
+                                                                                                                init: None,
+                                                                                                                span: 62..63,
                                                                                                             },
                                                                                                         ),
                                                                                                     ],
@@ -81,6 +81,8 @@ Ok(
                                                                                             ),
                                                                                             inferred_type: None,
                                                                                         },
+                                                                                        init: None,
+                                                                                        span: 58..64,
                                                                                     },
                                                                                 ),
                                                                             ],
@@ -89,6 +91,8 @@ Ok(
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
+                                                                init: None,
+                                                                span: 54..65,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
@@ -41,9 +41,10 @@ Ok(
                                             span: 53..64,
                                             kind: Is(
                                                 IsPat {
-                                                    id: Ident {
-                                                        span: 53..54,
+                                                    ident: BindingIdent {
                                                         name: "n",
+                                                        mutable: false,
+                                                        span: 53..54,
                                                     },
                                                     is_id: Ident {
                                                         span: 58..64,
@@ -84,9 +85,10 @@ Ok(
                                                                     span: 98..108,
                                                                     kind: Is(
                                                                         IsPat {
-                                                                            id: Ident {
-                                                                                span: 98..99,
+                                                                            ident: BindingIdent {
                                                                                 name: "a",
+                                                                                mutable: false,
+                                                                                span: 98..99,
                                                                             },
                                                                             is_id: Ident {
                                                                                 span: 103..108,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching-3.snap
@@ -96,6 +96,8 @@ Ok(
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
+                                                                init: None,
+                                                                span: 95..108,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
@@ -141,46 +141,55 @@ Ok(
                                                 ArrayPat {
                                                     elems: [
                                                         Some(
-                                                            Pattern {
-                                                                span: 108..109,
-                                                                kind: Ident(
-                                                                    BindingIdent {
-                                                                        name: "a",
-                                                                        mutable: false,
-                                                                        span: 108..109,
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            Pattern {
-                                                                span: 111..112,
-                                                                kind: Wildcard(
-                                                                    WildcardPat,
-                                                                ),
-                                                                inferred_type: None,
-                                                            },
-                                                        ),
-                                                        Some(
-                                                            Pattern {
-                                                                span: 114..121,
-                                                                kind: Rest(
-                                                                    RestPat {
-                                                                        arg: Pattern {
-                                                                            span: 117..121,
-                                                                            kind: Ident(
-                                                                                BindingIdent {
-                                                                                    name: "rest",
-                                                                                    mutable: false,
-                                                                                    span: 117..121,
-                                                                                },
-                                                                            ),
-                                                                            inferred_type: None,
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 108..109,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 108..109,
                                                                         },
-                                                                    },
-                                                                ),
-                                                                inferred_type: None,
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 111..112,
+                                                                    kind: Wildcard(
+                                                                        WildcardPat,
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
+                                                            },
+                                                        ),
+                                                        Some(
+                                                            ArrayPatElem {
+                                                                pattern: Pattern {
+                                                                    span: 114..121,
+                                                                    kind: Rest(
+                                                                        RestPat {
+                                                                            arg: Pattern {
+                                                                                span: 117..121,
+                                                                                kind: Ident(
+                                                                                    BindingIdent {
+                                                                                        name: "rest",
+                                                                                        mutable: false,
+                                                                                        span: 117..121,
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: None,
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: None,
+                                                                },
+                                                                init: None,
                                                             },
                                                         ),
                                                     ],

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__pattern_matching.snap
@@ -42,15 +42,15 @@ Ok(
                                             kind: Object(
                                                 ObjectPat {
                                                     props: [
-                                                        Assign(
-                                                            AssignPatProp {
-                                                                span: 54..55,
-                                                                key: BindingIdent {
+                                                        Shorthand(
+                                                            ShorthandPatProp {
+                                                                ident: BindingIdent {
                                                                     name: "x",
                                                                     mutable: false,
                                                                     span: 54..55,
                                                                 },
-                                                                value: None,
+                                                                init: None,
+                                                                span: 54..55,
                                                             },
                                                         ),
                                                         KeyValue(
@@ -70,6 +70,8 @@ Ok(
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
+                                                                init: None,
+                                                                span: 57..61,
                                                             },
                                                         ),
                                                         KeyValue(
@@ -92,6 +94,8 @@ Ok(
                                                                     ),
                                                                     inferred_type: None,
                                                                 },
+                                                                init: None,
+                                                                span: 63..67,
                                                             },
                                                         ),
                                                         Rest(

--- a/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
+++ b/crates/tree_sitter_crochet/corpus/refutable_patterns.txt
@@ -131,7 +131,7 @@ Pattern matching ("is" patterns)
 
 let bar = match (foo) {
   n is number -> "number",
-  {a: a is Array} -> "Array",
+  {a: mut a is Array} -> "Array",
   _ -> "fallthrough"
 };
 
@@ -148,7 +148,8 @@ let bar = match (foo) {
           (match_arm
             (refutable_pattern
               (refutable_is_pattern
-                (identifier)
+                (binding_identifier
+                  (identifier))
                 (identifier)))
             (string
               (string_fragment)))
@@ -159,7 +160,8 @@ let bar = match (foo) {
                   (property_identifier)
                   (refutable_pattern
                     (refutable_is_pattern
-                      (identifier)
+                      (binding_identifier
+                        (identifier))
                       (identifier))))))
             (string
               (string_fragment)))
@@ -286,7 +288,7 @@ if-let ("is" pattern)
 
 let bar = if (let {x: x is string} = foo) {
   "object"
-} else if (let [a is Array, _, ...rest] = foo) {
+} else if (let [mut a is Array, _, ...rest] = foo) {
   "array"
 } else {
   "other"
@@ -307,7 +309,8 @@ let bar = if (let {x: x is string} = foo) {
                 (property_identifier)
                 (refutable_pattern
                   (refutable_is_pattern
-                    (identifier)
+                    (binding_identifier
+                      (identifier))
                     (identifier))))))
           (identifier))
         (statement_block
@@ -321,7 +324,8 @@ let bar = if (let {x: x is string} = foo) {
                 (refutable_array_pattern
                   (refutable_pattern
                     (refutable_is_pattern
-                      (identifier)
+                      (binding_identifier
+                        (identifier))
                       (identifier)))
                   (refutable_pattern
                     (binding_identifier

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -395,7 +395,7 @@ module.exports = grammar(tsx, {
         "]"
       ),
 
-    refutable_is_pattern: ($) => seq($.identifier, "is", $.identifier),
+    refutable_is_pattern: ($) => seq($.binding_identifier, "is", $.identifier),
 
     refutable_object_pattern: ($) =>
       prec(


### PR DESCRIPTION
This doesn't handle all of the edge cases in terms of interfered types of the bindings that are introduced by patterns when adding default values (initializers) to the mix.  That work is being tracked by #333.