### PR TITLE
Add ParseError and TypeError structs

### DIFF
--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -1,5 +1,6 @@
 use crochet_ast::values::{Program, Statement};
 use crochet_codegen::*;
+use crochet_infer::TypeError;
 use crochet_infer::*;
 use crochet_parser::parse;
 
@@ -12,7 +13,7 @@ fn infer(input: &str) -> String {
             let mut expr = expr.to_owned();
             infer_expr(&mut ctx, &mut expr)
         }
-        _ => Err(String::from("We can't infer decls yet")),
+        _ => Err(TypeError::from("We can't infer decls yet")),
     };
     format!("{}", result.unwrap())
 }
@@ -440,7 +441,7 @@ fn infer_let_decl_with_type_ann() {
 #[test]
 // TODO: improve this error by checking the flags on the types before reporting
 // "Unification failure".
-#[should_panic = "called `Result::unwrap()` on an `Err` value: \"Unification failure\""]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: TypeError { msg: \"Unification failure\" }"]
 fn infer_let_decl_with_incorrect_type_ann() {
     let src = "let x: string = 10;";
     let (_, ctx) = infer_prog(src);
@@ -546,7 +547,7 @@ fn infer_tuple_with_type_annotation_and_extra_element() {
 #[test]
 // TODO: improve this error by checking the flags on the types before reporting
 // "Unification failure".
-#[should_panic = "called `Result::unwrap()` on an `Err` value: \"Unification failure\""]
+#[should_panic = "called `Result::unwrap()` on an `Err` value: TypeError { msg: \"Unification failure\" }"]
 fn infer_tuple_with_type_annotation_and_incorrect_element() {
     let src = r#"let tuple: [number, string, boolean] = [1, "two", 3];"#;
     infer_prog(src);

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -5,10 +5,11 @@ use crate::context::Context;
 use crate::infer_expr::infer_expr as infer_expr_rec;
 use crate::infer_pattern::*;
 use crate::infer_type_ann::*;
+use crate::type_error::TypeError;
 use crate::update::*;
 use crate::util::*;
 
-pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, String> {
+pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, TypeError> {
     // TODO: replace with Class type once it exists
     // We use {_name: "Promise"} to differentiate it from other
     // object types.
@@ -65,7 +66,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
                                     }
                                     None => {
                                         // A type annotation should always be provided when using `declare`
-                                        return Err(String::from(
+                                        return Err(TypeError::from(
                                             "missing type annotation in declare statement",
                                         ));
                                     }
@@ -123,7 +124,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Stri
     Ok(ctx.to_owned())
 }
 
-pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<Type, String> {
+pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<Type, TypeError> {
     let (s, t) = infer_expr_rec(ctx, expr)?;
     Ok(close_over(&s, &t, ctx))
 }

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -7,6 +7,7 @@ use crate::assump::Assump;
 use crate::context::{Binding, Context};
 use crate::infer_pattern::infer_pattern;
 use crate::substitutable::Subst;
+use crate::type_error::TypeError;
 
 // NOTE: The caller is responsible for inserting any new variables introduced
 // into the appropriate context.
@@ -14,7 +15,7 @@ pub fn infer_fn_param(
     param: &mut EFnParam,
     ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
-) -> Result<(Subst, Assump, TFnParam), String> {
+) -> Result<(Subst, Assump, TFnParam), TypeError> {
     // Keeps track of all of the variables the need to be introduced by this pattern.
     // let mut new_vars: Assump = Assump::default();
 

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -8,6 +8,7 @@ use crate::context::{Binding, Context};
 use crate::infer_expr::infer_expr;
 use crate::infer_type_ann::*;
 use crate::substitutable::{Subst, Substitutable};
+use crate::type_error::TypeError;
 use crate::unify::unify;
 use crate::util::*;
 
@@ -18,7 +19,7 @@ pub fn infer_pattern(
     type_ann: &mut Option<TypeAnn>,
     ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
-) -> Result<(Subst, Assump, Type), String> {
+) -> Result<(Subst, Assump, Type), TypeError> {
     // Keeps track of all of the variables the need to be introduced by this pattern.
     let mut new_vars: HashMap<String, Binding> = HashMap::new();
 
@@ -240,7 +241,7 @@ pub fn infer_pattern_and_init(
     init: &mut Expr,
     ctx: &mut Context,
     pu: &PatternUsage,
-) -> Result<(Assump, Subst), String> {
+) -> Result<(Assump, Subst), TypeError> {
     let type_param_map = HashMap::new();
     let (ps, pa, pt) = infer_pattern(pat, type_ann, ctx, &type_param_map)?;
 

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -9,6 +9,7 @@ use crochet_ast::values::*;
 use crate::context::Context;
 use crate::infer_expr::infer_expr;
 use crate::infer_fn_param::pattern_to_tpat;
+use crate::type_error::TypeError;
 use crate::util::compose_many_subs;
 use crate::util::get_type_params;
 use crate::Subst;
@@ -18,7 +19,7 @@ pub fn infer_type_ann(
     type_ann: &mut TypeAnn,
     ctx: &mut Context,
     type_params: &mut Option<Vec<TypeParam>>,
-) -> Result<(Subst, Type), String> {
+) -> Result<(Subst, Type), TypeError> {
     let mut type_params = if type_params.is_none() {
         match &mut type_ann.kind {
             TypeAnnKind::Lam(lam) => lam.type_params.to_owned(),
@@ -49,7 +50,7 @@ pub fn infer_type_ann(
 
                 Ok((param.name.name.to_owned(), tv))
             })
-            .collect::<Result<HashMap<String, Type>, String>>()?,
+            .collect::<Result<HashMap<String, Type>, TypeError>>()?,
         None => HashMap::default(),
     };
 
@@ -60,7 +61,7 @@ pub fn infer_type_ann_with_params(
     type_ann: &mut TypeAnn,
     ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
-) -> Result<(Subst, Type), String> {
+) -> Result<(Subst, Type), TypeError> {
     infer_type_ann_rec(type_ann, ctx, type_param_map)
 }
 
@@ -68,7 +69,7 @@ fn infer_type_ann_rec(
     type_ann: &mut TypeAnn,
     ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
-) -> Result<(Subst, Type), String> {
+) -> Result<(Subst, Type), TypeError> {
     match &mut type_ann.kind {
         TypeAnnKind::Lam(lam) => {
             let mut ss: Vec<Subst> = vec![];

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -6,6 +6,7 @@ mod infer_pattern;
 mod infer_type_ann;
 mod key_of;
 mod substitutable;
+mod type_error;
 mod unify;
 mod unify_mut;
 mod update;
@@ -17,6 +18,7 @@ pub mod infer;
 pub use context::*;
 pub use infer::*;
 pub use substitutable::{Subst, Substitutable};
+pub use type_error::TypeError;
 pub use util::{close_over, generalize, get_type_params, normalize, set_type_params};
 
 #[cfg(test)]

--- a/crates/crochet_infer/src/type_error.rs
+++ b/crates/crochet_infer/src/type_error.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, PartialEq, Eq)]
+pub struct TypeError {
+    pub msg: String,
+}
+
+impl From<String> for TypeError {
+    fn from(msg: String) -> Self {
+        TypeError { msg }
+    }
+}
+
+impl From<&str> for TypeError {
+    fn from(msg: &str) -> Self {
+        TypeError {
+            msg: msg.to_owned(),
+        }
+    }
+}

--- a/crates/crochet_infer/src/unify_mut.rs
+++ b/crates/crochet_infer/src/unify_mut.rs
@@ -2,12 +2,13 @@ use crochet_ast::types::Type;
 
 use crate::context::Context;
 use crate::substitutable::Subst;
+use crate::type_error::TypeError;
 
-pub fn unify_mut(t1: &Type, t2: &Type, _ctx: &Context) -> Result<Subst, String> {
+pub fn unify_mut(t1: &Type, t2: &Type, _ctx: &Context) -> Result<Subst, TypeError> {
     if t1 == t2 {
         println!("unify_mut: {t1} == {t2}");
         Ok(Subst::new())
     } else {
-        Err(format!("Couldn't unify {t1} and {t2}"))
+        Err(TypeError::from(format!("Couldn't unify {t1} and {t2}")))
     }
 }

--- a/crates/crochet_parser/src/parse_error.rs
+++ b/crates/crochet_parser/src/parse_error.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseError {
+    pub msg: String,
+}
+
+impl From<String> for ParseError {
+    fn from(msg: String) -> Self {
+        ParseError { msg }
+    }
+}
+
+impl From<&str> for ParseError {
+    fn from(msg: &str) -> Self {
+        ParseError {
+            msg: msg.to_owned(),
+        }
+    }
+}

--- a/crates/tree_sitter_crochet/bindings/rust/build.rs
+++ b/crates/tree_sitter_crochet/bindings/rust/build.rs
@@ -59,7 +59,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")


### PR DESCRIPTION
The reason for adding structs, is so that we can introduce [error_stack](https://docs.rs/error-stack/latest/error_stack/). This will be done in a followup PR.