### PR TITLE
Update triggers in ci.yml so that checks will run on PRs from contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "**.crochet"
+      - "**.js"
+      - "**.rs"
 
 jobs:
   clippy:


### PR DESCRIPTION
This also updates ci.yml to only run if there are changes to .rs, .js, or .crochet files.  We really don't need to be running the checks for PRs that only modify .md files.