### PR TITLE
Disallow mutable primitives and tuples

### DIFF
--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -721,8 +721,7 @@ fn infer_property_type(
             match prop {
                 // TODO: lookup methods on Array.prototype
                 MemberProp::Ident(_) => {
-                    // TODO: Make mutable tuples a parse error
-                    let t = ctx.lookup_type("Array", false)?;
+                    let t = ctx.lookup_type("Array", obj_t.mutable)?;
                     // TODO: Instead of instantiating the whole interface for one method, do
                     // the lookup call first and then instantiate the method.
                     // TODO: remove duplicate types

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2933,4 +2933,58 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn primitives_cannot_be_mutable() {
+        let src = r#"
+        declare let mut_str: mut string;
+        declare let mut_bool: mut boolean;
+        declare let mut_number: mut number;
+        "#;
+
+        let mut prog = parse(src).unwrap();
+        let mut ctx: Context = Context::default();
+        match infer::infer_prog(&mut prog, &mut ctx) {
+            Ok(_) => panic!("expected an error"),
+            Err(report) => {
+                println!("{report:#?}");
+                let messages = messages(&report);
+                assert_eq!(
+                    messages,
+                    vec![
+                        "Location",
+                        "TypeError::PrimitivesCantBeMutable: string",
+                        "Location",
+                        "TypeError::PrimitivesCantBeMutable: boolean",
+                        "Location",
+                        "TypeError::PrimitivesCantBeMutable: number"
+                    ]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tuples_cannot_be_mutable() {
+        let src = r#"
+        declare let mut_tuple: mut [string, boolean, number];
+        "#;
+
+        let mut prog = parse(src).unwrap();
+        let mut ctx: Context = Context::default();
+        match infer::infer_prog(&mut prog, &mut ctx) {
+            Ok(_) => panic!("expected an error"),
+            Err(report) => {
+                println!("{report:#?}");
+                let messages = messages(&report);
+                assert_eq!(
+                    messages,
+                    vec![
+                        "Location",
+                        "TypeError::TuplesCantBeMutable: [string, boolean, number]",
+                    ]
+                );
+            }
+        }
+    }
 }

--- a/crates/crochet_infer/src/type_error.rs
+++ b/crates/crochet_infer/src/type_error.rs
@@ -10,6 +10,8 @@ pub enum TypeError {
     UnificationIsUndecidable,
     Unhandled,
     InfiniteType,
+    PrimitivesCantBeMutable(Box<Type>),
+    TuplesCantBeMutable(Box<Type>),
 
     // Async/Await
     AwaitOutsideOfAsync,
@@ -126,6 +128,8 @@ impl fmt::Display for TypeError {
             TypeError::AliasTypeMismatch => write!(fmt, "AliasTypeMismatch"),
             TypeError::CantInferTypeFromItKeys => write!(fmt, "CantInferTypeFromItKeys"),
             TypeError::Unhandled => write!(fmt, "Unhandled"),
+            TypeError::PrimitivesCantBeMutable(t) => write!(fmt, "PrimitivesCantBeMutable: {t}"),
+            TypeError::TuplesCantBeMutable(t) => write!(fmt, "TuplesCantBeMutable: {t}"),
         }
     }
 }


### PR DESCRIPTION
This has implications for parametric function which accept `mut T`, but TBH, doing so doesn't make sense without constrained polymorphism so it's probably okay to disallow `mut string`, `mut boolean`, etc.