### PR TITLE
Report all errors unifying args and params

### DIFF
--- a/crates/crochet/src/diagnostics.rs
+++ b/crates/crochet/src/diagnostics.rs
@@ -104,7 +104,10 @@ pub fn get_diagnostics(report: Report<CompileError>, src: &str) -> Vec<String> {
                     "for tuples",
                     &format!("{prop_t} is not a valid index"),
                 ),
-                _ => None,
+                error => {
+                    println!("TODO: handle {error}");
+                    None
+                }
             },
             None => None,
         })

--- a/crates/crochet/tests/errors/incompatible_types.crochet
+++ b/crates/crochet/tests/errors/incompatible_types.crochet
@@ -1,5 +1,5 @@
 let add = (a: number, b: number): number => a + b;
-add("hello", "world");
+let sum: string = add("hello", "world");
 
 let add = (a, b) => a + b;
 add("hello", "world");

--- a/crates/crochet/tests/errors/incompatible_types.error
+++ b/crates/crochet/tests/errors/incompatible_types.error
@@ -1,12 +1,23 @@
 Error: Incompatible types
-   ╭─[<unknown>:2:5]
+   ╭─[<unknown>:2:23]
    │
  1 │ let add = (a: number, b: number): number => a + b;
    ·               ───┬──  
    ·                  ╰──── number
- 2 │ add("hello", "world");
-   ·     ───┬───  
-   ·        ╰───── "hello"
+ 2 │ let sum: string = add("hello", "world");
+   ·                       ───┬───  
+   ·                          ╰───── "hello"
+───╯
+
+Error: Incompatible types
+   ╭─[<unknown>:2:32]
+   │
+ 1 │ let add = (a: number, b: number): number => a + b;
+   ·                          ───┬──  
+   ·                             ╰──── number
+ 2 │ let sum: string = add("hello", "world");
+   ·                                ───┬───  
+   ·                                   ╰───── "world"
 ───╯
 
 Error: Incompatible types
@@ -18,6 +29,17 @@ Error: Incompatible types
  5 │ add("hello", "world");
    ·     ───┬───  
    ·        ╰───── "hello"
+───╯
+
+Error: Incompatible types
+   ╭─[<unknown>:5:14]
+   │
+ 4 │ let add = (a, b) => a + b;
+   ·               ┬  
+   ·               ╰── number
+ 5 │ add("hello", "world");
+   ·              ───┬───  
+   ·                 ╰───── "world"
 ───╯
 
 Error: Incompatible types

--- a/crates/crochet/tests/errors/rest_param.crochet
+++ b/crates/crochet/tests/errors/rest_param.crochet
@@ -1,0 +1,3 @@
+let add = (...args: [number, number]): number => args[0] + args[1];
+let sum = add("hello", "world");
+add();

--- a/crates/crochet/tests/errors/rest_param.error
+++ b/crates/crochet/tests/errors/rest_param.error
@@ -1,0 +1,33 @@
+Error: Incompatible types
+   ╭─[<unknown>:2:15]
+   │
+ 1 │ let add = (...args: [number, number]): number => args[0] + args[1];
+   ·                      ───┬──  
+   ·                         ╰──── number
+ 2 │ let sum = add("hello", "world");
+   ·               ───┬───  
+   ·                  ╰───── "hello"
+───╯
+
+Error: Incompatible types
+   ╭─[<unknown>:2:24]
+   │
+ 1 │ let add = (...args: [number, number]): number => args[0] + args[1];
+   ·                              ───┬──  
+   ·                                 ╰──── number
+ 2 │ let sum = add("hello", "world");
+   ·                        ───┬───  
+   ·                           ╰───── "world"
+───╯
+
+Error: Not enough args provided
+   ╭─[<unknown>:3:1]
+   │
+ 1 │ let add = (...args: [number, number]): number => args[0] + args[1];
+   ·           ────────────────────────────┬───────────────────────────  
+   ·                                       ╰───────────────────────────── expected 1 args
+   · 
+ 3 │ add();
+   · ──┬──  
+   ·   ╰──── was passed 0 args
+───╯

--- a/crates/crochet/tests/pass/rest_param.crochet
+++ b/crates/crochet/tests/pass/rest_param.crochet
@@ -1,0 +1,10 @@
+let foo = (a: number, b?: number, ...c: number[]) => a;
+foo(5);
+foo(5, 10);
+foo(5, 10, 15);
+foo(5, 10, 15, 20);
+
+let bar = (a: number, b?: number, ...c: [number, number]) => a;
+// TODO: update the parser to handle parsing `null` and `undefined`
+// bar(5, undefined, 15, 20);
+bar(5, 10, 15, 20);

--- a/crates/crochet/tests/pass/rest_param.d.ts
+++ b/crates/crochet/tests/pass/rest_param.d.ts
@@ -1,0 +1,2 @@
+export declare const bar: (a: number, b?: number, ...c: readonly [number, number]) => number;
+export declare const foo: (a: number, b?: number, ...c: readonly number[]) => number;

--- a/crates/crochet/tests/pass/rest_param.js
+++ b/crates/crochet/tests/pass/rest_param.js
@@ -1,0 +1,7 @@
+export const foo = (a, b, ...c)=>a;
+foo(5);
+foo(5, 10);
+foo(5, 10, 15);
+foo(5, 10, 15, 20);
+export const bar = (a, b, ...c)=>a;
+bar(5, 10, 15, 20);

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1137,6 +1137,25 @@ mod tests {
     }
 
     #[test]
+    fn call_fn_with_rest_param_and_optional_param() {
+        let src = r#"
+        // let add = (a, b?: number, ...c: number[]) => a;
+        // let add5 = add(5);
+        let foo = (a: number, b?: number, ...c: number[]) => a;
+        foo(5);
+        foo(5, 10);
+        foo(5, 10, 15);
+        foo(5, 10, 15, 20);
+
+        let bar = (a: number, b?: number, ...c: [number, number]) => a;
+        // bar(5, undefined, 15, 20);
+        bar(5, 10, 15, 20);
+        "#;
+
+        infer_prog(src);
+    }
+
+    #[test]
     fn infer_optional_param_type() {
         let src = r#"
         let plus_one = (a, b?) => {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1137,25 +1137,6 @@ mod tests {
     }
 
     #[test]
-    fn call_fn_with_rest_param_and_optional_param() {
-        let src = r#"
-        // let add = (a, b?: number, ...c: number[]) => a;
-        // let add5 = add(5);
-        let foo = (a: number, b?: number, ...c: number[]) => a;
-        foo(5);
-        foo(5, 10);
-        foo(5, 10, 15);
-        foo(5, 10, 15, 20);
-
-        let bar = (a: number, b?: number, ...c: [number, number]) => a;
-        // bar(5, undefined, 15, 20);
-        bar(5, 10, 15, 20);
-        "#;
-
-        infer_prog(src);
-    }
-
-    #[test]
     fn infer_optional_param_type() {
         let src = r#"
         let plus_one = (a, b?) => {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2899,36 +2899,6 @@ mod tests {
     }
 
     #[test]
-    fn report_multiple_errors() {
-        let src = r#"
-        declare let add: (a: number, b: number) => number;
-        add("hello", "world");
-        add(true, false);
-        "#;
-
-        let mut prog = parse(src).unwrap();
-        let mut ctx: Context = Context::default();
-        match infer::infer_prog(&mut prog, &mut ctx) {
-            Ok(_) => panic!("expected an error"),
-            Err(report) => {
-                println!("{report:#?}");
-                let messages = messages(&report);
-                assert_eq!(
-                    messages,
-                    vec![
-                        "Unification failure",
-                        "Location",
-                        "TypeError::UnificationError: \"hello\", number",
-                        "Unification failure",
-                        "Location",
-                        "TypeError::UnificationError: true, number"
-                    ]
-                );
-            }
-        }
-    }
-
-    #[test]
     fn primitives_cannot_be_mutable() {
         let src = r#"
         declare let mut_str: mut string;

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -189,14 +189,6 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, TypeError> {
                     false => accum,
                 });
 
-            // TODO: We need to check whether the rest param is a tuple or an
-            // array.  If it's a tuple then we can know the exact number of params
-            // ahead of time.
-            // let param_count_low_bound = match maybe_rest_param {
-            //     Some(_) => lam.params.len() - optional_count - 1,
-            //     None => lam.params.len() - optional_count,
-            // };
-
             // NOTE: placeholder spreads must come last because we don't know they're
             // length.  This will also be true for spreading arrays, but in the case
             // of array spreads, they also need to come after the start of a rest param.
@@ -212,14 +204,6 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, TypeError> {
                     _ => args.push(arg.to_owned()),
                 }
             }
-
-            // if args.len() < param_count_low_bound {
-            //     return Err(Report::new(TypeError::TooFewArguments(
-            //         Box::from(t1.to_owned()),
-            //         Box::from(t2.to_owned()),
-            //     ))
-            //     .attach_printable("Not enough args provided"));
-            // }
 
             // TODO: Add a `variadic` boolean to the Lambda type as a convenience
             // so that we don't have to search through all the params for the rest


### PR DESCRIPTION
If there were type mismatches between multiple args and params in a function call, we were only reporting the first mismatch.  With this PR we now report all mismatches.

This PR also deduplicates some of the unification logic between calls to functions with a rest param and those without.