### PR TITLE
Treat the last statement in a block the same as if it were an expression

### DIFF
--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -255,9 +255,10 @@ fn infer_if_else_with_widening() {
 }
 
 #[test]
-#[should_panic = "statement blocks cannot end with a declaration"]
-fn infer_value_of_let_decl_is_undefined() {
-    infer_prog("let x = if (true) { let a = 5; };");
+fn infer_value_of_let_from_a_block_return_is_undefined() {
+    let (_, ctx) = infer_prog("let x = if (true) { let a = 5; };");
+    let result = format!("{}", ctx.lookup_value("x").unwrap());
+    assert_eq!(result, "undefined");
 }
 
 #[test]
@@ -1242,7 +1243,6 @@ fn return_empty() {
 }
 
 #[test]
-#[should_panic = "statement blocks cannot end with a declaration"]
 fn return_empty_with_body() {
     let src = r#"
     let foo = () => {
@@ -1250,7 +1250,10 @@ fn return_empty_with_body() {
     };
     "#;
 
-    infer_prog(src);
+    let (_, ctx) = infer_prog(src);
+
+    let func = format!("{}", ctx.lookup_value("foo").unwrap());
+    assert_eq!(func, "() => undefined");
 }
 
 #[test]

--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -255,16 +255,16 @@ fn infer_if_else_with_widening() {
 }
 
 #[test]
-fn infer_only_if_must_be_undefined() {
-    let (_, ctx) = infer_prog("let x = if (true) { let a = 5; };");
-    let result = format!("{}", ctx.lookup_value("x").unwrap());
-    assert_eq!(result, "undefined");
+#[should_panic = "statement blocks cannot end with a declaration"]
+fn infer_value_of_let_decl_is_undefined() {
+    infer_prog("let x = if (true) { let a = 5; };");
 }
 
 #[test]
-#[should_panic = "Consequent for 'if' without 'else' must not return a value"]
-fn infer_only_if_must_be_undefined_error() {
-    infer_prog("let x = if (true) { let a = 5; a };");
+fn infer_only_if() {
+    let (_, ctx) = infer_prog("let x = if (true) { let a = 5; a };");
+    let result = format!("{}", ctx.lookup_value("x").unwrap());
+    assert_eq!(result, "5 | undefined");
 }
 
 #[test]
@@ -1242,18 +1242,15 @@ fn return_empty() {
 }
 
 #[test]
+#[should_panic = "statement blocks cannot end with a declaration"]
 fn return_empty_with_body() {
     let src = r#"
     let foo = () => {
         let a = 5;
     };
     "#;
-    let (_, ctx) = infer_prog(src);
 
-    assert_eq!(
-        format!("{}", ctx.lookup_value("foo").unwrap()),
-        "() => undefined"
-    );
+    infer_prog(src);
 }
 
 #[test]
@@ -1316,8 +1313,7 @@ fn codegen_if_let() {
     const $temp_1 = p;
     {
         const { x , y  } = $temp_1;
-        x + y;
-        $temp_0 = undefined;
+        $temp_0 = x + y;
     }$temp_0;
     "###);
 
@@ -1352,8 +1348,7 @@ fn codegen_if_let_with_rename() {
     const $temp_1 = p;
     {
         const { x: a , y: b  } = $temp_1;
-        a + b;
-        $temp_0 = undefined;
+        $temp_0 = a + b;
     }$temp_0;
     "###);
 
@@ -1406,8 +1401,7 @@ fn infer_if_let_refutable_pattern_obj() {
     const $temp_1 = p;
     if ($temp_1.x === 5) {
         const { y  } = $temp_1;
-        y;
-        $temp_0 = undefined;
+        $temp_0 = y;
     }
     $temp_0;
     "###);
@@ -1446,8 +1440,7 @@ fn infer_if_let_refutable_pattern_nested_obj() {
     const $temp_1 = action;
     if ($temp_1.type === "moveto") {
         const { point: { x , y  }  } = $temp_1;
-        x + y;
-        $temp_0 = undefined;
+        $temp_0 = x + y;
     }
     $temp_0;
     "###);
@@ -1487,8 +1480,7 @@ fn infer_if_let_refutable_pattern_with_disjoint_union() {
     const $temp_1 = action;
     if ($temp_1.type === "moveto") {
         const { point: { x , y  }  } = $temp_1;
-        x + y;
-        $temp_0 = undefined;
+        $temp_0 = x + y;
     }
     $temp_0;
     "###);
@@ -1534,8 +1526,7 @@ fn infer_if_let_refutable_pattern_array() {
     const $temp_1 = p;
     if ($temp_1[0] === 5) {
         const [, y] = $temp_1;
-        y;
-        $temp_0 = undefined;
+        $temp_0 = y;
     }
     $temp_0;
     "###);
@@ -1570,8 +1561,7 @@ fn infer_if_let_refutable_pattern_nested_array() {
     const $temp_1 = action;
     if ($temp_1[0] === "moveto") {
         const [, [x, y]] = $temp_1;
-        x + y;
-        $temp_0 = undefined;
+        $temp_0 = x + y;
     }
     $temp_0;
     "###);
@@ -1600,8 +1590,7 @@ fn codegen_if_let_with_is_prim() {
     const $temp_1 = b;
     if (typeof $temp_1 === "number") {
         const a = $temp_1;
-        a + 5;
-        $temp_0 = undefined;
+        $temp_0 = a + 5;
     }
     $temp_0;
     "###);
@@ -1663,8 +1652,7 @@ fn codegen_if_let_with_is_class() {
     const $temp_1 = b;
     if ($temp_1 instanceof Foo) {
         const a = $temp_1;
-        a.getNum() + 5;
-        $temp_0 = undefined;
+        $temp_0 = a.getNum() + 5;
     }
     $temp_0;
     "###);

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -179,24 +179,26 @@ mod tests {
     }
 
     #[test]
-    fn infer_if() {
+    fn infer_if_with_semi() {
         let src = r#"
         let n = 0;
         let result = if (n == 0) { 5; };
         "#;
         let ctx = infer_prog(src);
 
-        assert_eq!(get_value_type("result", &ctx), "undefined");
+        assert_eq!(get_value_type("result", &ctx), "5 | undefined");
     }
 
     #[test]
-    #[should_panic = "Consequent for 'if' without 'else' must not return a value"]
-    fn infer_if_must_be_undefined() {
+    fn infer_if_without_semi() {
         let src = r#"
         let n = 0;
         let result = if (n == 0) { 5 };
         "#;
-        infer_prog(src);
+
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("result", &ctx), "5 | undefined");
     }
 
     #[test]
@@ -648,28 +650,31 @@ mod tests {
     }
 
     #[test]
-    fn infer_if_let_without_else_no_return() {
+    fn infer_if_let_without_else_with_semi() {
         let src = r#"
         let p = {x: 5, y: 10};
-        if (let {x, y} = p) {
+        let result = if (let {x, y} = p) {
             x + y;
         };
         "#;
 
-        infer_prog(src);
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("result", &ctx), "number | undefined");
     }
 
     #[test]
-    #[should_panic = "Consequent for 'if' without 'else' must not return a value"]
-    fn infer_if_let_without_else_errors_with_return() {
+    fn infer_if_let_without_else_without_semi() {
         let src = r#"
         let p = {x: 5, y: 10};
-        if (let {x, y} = p) {
+        let result = if (let {x, y} = p) {
             x + y
         };
         "#;
 
-        infer_prog(src);
+        let ctx = infer_prog(src);
+
+        assert_eq!(get_value_type("result", &ctx), "number | undefined");
     }
 
     #[test]

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -451,16 +451,6 @@ fn parse_block_statement(node: &tree_sitter::Node, src: &str) -> Result<Expr, Pa
                 })
             } else {
                 let mut result = parse_statement(&child, src)?;
-                // TODO: get the span of the semicolon
-                let expr = Expr {
-                    span: 0..0,
-                    kind: ExprKind::Empty,
-                    inferred_type: None,
-                };
-                result.push(Statement::Expr {
-                    span: 0..0,
-                    expr: Box::from(expr),
-                });
                 stmts.append(&mut result);
             }
         } else {
@@ -473,7 +463,7 @@ fn parse_block_statement(node: &tree_sitter::Node, src: &str) -> Result<Expr, Pa
 
     let last: Expr = match iter.next() {
         Some(term) => match term {
-            Statement::VarDecl { .. } => panic!("Didn't expect `let` here"),
+            Statement::VarDecl { .. } => panic!("statement blocks cannot end with a declaration"),
             Statement::TypeDecl { .. } => {
                 todo!("decide how to handle type decls within BlockStatements")
             }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -463,7 +463,33 @@ fn parse_block_statement(node: &tree_sitter::Node, src: &str) -> Result<Expr, Pa
 
     let last: Expr = match iter.next() {
         Some(term) => match term {
-            Statement::VarDecl { .. } => panic!("statement blocks cannot end with a declaration"),
+            // TODO: warn that the variable introduced here will go unused.
+            Statement::VarDecl {
+                span,
+                pattern,
+                init,
+                type_ann,
+                ..
+            } => Expr {
+                span: span.to_owned(),
+                kind: ExprKind::Let(Let {
+                    pattern: Some(pattern.to_owned()),
+                    // TODO: Think about how to deal with variable declarations
+                    // without initializers.  Right now these are allowed by our
+                    // tree-sitter grammar, but aren't handled by the rust code
+                    // which processes its CST.  We probably don't want to allow
+                    // this for normal `let` declarations, we need to allow this
+                    // for `declare let`.
+                    init: init.as_ref().unwrap().to_owned(),
+                    type_ann: type_ann.to_owned(),
+                    body: Box::from(Expr {
+                        span: 0..0,
+                        kind: ExprKind::Empty,
+                        inferred_type: None,
+                    }),
+                }),
+                inferred_type: None,
+            },
             Statement::TypeDecl { .. } => {
                 todo!("decide how to handle type decls within BlockStatements")
             }

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__rust_style_functions-2.snap
@@ -77,26 +77,11 @@ Ok(
                                                 inferred_type: None,
                                             },
                                             body: Expr {
-                                                span: 41..43,
-                                                kind: Let(
-                                                    Let {
-                                                        pattern: None,
-                                                        type_ann: None,
-                                                        init: Expr {
-                                                            span: 41..42,
-                                                            kind: Ident(
-                                                                Ident {
-                                                                    span: 41..42,
-                                                                    name: "x",
-                                                                },
-                                                            ),
-                                                            inferred_type: None,
-                                                        },
-                                                        body: Expr {
-                                                            span: 0..0,
-                                                            kind: Empty,
-                                                            inferred_type: None,
-                                                        },
+                                                span: 41..42,
+                                                kind: Ident(
+                                                    Ident {
+                                                        span: 41..42,
+                                                        name: "x",
                                                     },
                                                 ),
                                                 inferred_type: None,


### PR DESCRIPTION
This PR is an attempt to minimize the difference between a trailing expression vs trailing statement in a block.  When the last line in a block is followed by a `;` it's a statement and when it isn't then it's an expression.  In both cases, the inferred type of the block is the type of the last statement/expression.  The reason for not requiring `undefined;` when there's nothing to "return" is that this would require adding this to all blocks where that's the case including functions, try-catch, etc.

Since an `if` (without an `else`) could appear at the end of a block, we need to allow that an infer a sensible value for this it.  This PR does this, inferring its type as `T | undefined` if the consequent's value is `T`.

Variable declarations are now allowed at the end of a block.  While introducing a variable there might not make much sense since it will go unused, the initializer could be doing useful work.  I'd rather this be a warning instead of an error.

NOTE: This behaviour is quite different from TC39's [do-expression proposal](https://github.com/tc39/proposal-do-expressions) which prevents the last statement in a do-expression block from being an `if` or a `let`.