### PR TITLE
Mapped types

### DIFF
--- a/crates/crochet/tests/pass/mapped_types.crochet
+++ b/crates/crochet/tests/pass/mapped_types.crochet
@@ -1,0 +1,4 @@
+type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+type PartialObj = Partial<Obj>;
+
+let partial_obj: PartialObj = {b: "hello"};

--- a/crates/crochet/tests/pass/mapped_types.d.ts
+++ b/crates/crochet/tests/pass/mapped_types.d.ts
@@ -1,0 +1,8 @@
+declare type Obj = {
+    readonly a: number;
+    readonly b?: string;
+    c: boolean;
+    d?: number;
+};
+declare type PartialObj = Partial<Obj>;
+export declare const partial_obj: PartialObj;

--- a/crates/crochet/tests/pass/mapped_types.js
+++ b/crates/crochet/tests/pass/mapped_types.js
@@ -1,0 +1,5 @@
+;
+;
+export const partial_obj = {
+    b: "hello"
+};

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -76,21 +76,19 @@ pub struct TypeParam {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TMappedType {
     pub type_param: TVar,
-    pub optional: Option<TMappedTypeOptional>,
-    pub readonly: Option<TMappedTypeReadonly>,
+    pub optional: Option<TMappedTypeChangeProp>,
+    pub mutable: Option<TMappedTypeChangeProp>,
     pub t: Box<Type>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TMappedTypeOptional {
-    True,
+pub enum TMappedTypeChangeProp {
     Plus,
     Minus,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TMappedTypeReadonly {
-    True,
+pub enum TMappedTypeMutable {
     Plus,
     Minus,
 }
@@ -200,16 +198,15 @@ impl fmt::Display for Type {
             TypeKind::MappedType(TMappedType {
                 type_param,
                 optional,
-                readonly,
+                mutable,
                 t,
             }) => {
                 write!(f, "{{")?;
 
-                if let Some(readonly) = readonly {
-                    match readonly {
-                        TMappedTypeReadonly::True => write!(f, "readonly ")?,
-                        TMappedTypeReadonly::Plus => write!(f, "+readonly ")?,
-                        TMappedTypeReadonly::Minus => write!(f, "-readonly ")?,
+                if let Some(mutable) = mutable {
+                    match mutable {
+                        TMappedTypeChangeProp::Plus => write!(f, "+mut ")?,
+                        TMappedTypeChangeProp::Minus => write!(f, "-mut ")?,
                     }
                 }
 
@@ -221,9 +218,8 @@ impl fmt::Display for Type {
 
                 if let Some(optional) = optional {
                     match optional {
-                        TMappedTypeOptional::True => write!(f, "?")?,
-                        TMappedTypeOptional::Plus => write!(f, "+?")?,
-                        TMappedTypeOptional::Minus => write!(f, "-?")?,
+                        TMappedTypeChangeProp::Plus => write!(f, "+?")?,
+                        TMappedTypeChangeProp::Minus => write!(f, "-?")?,
                     }
                 }
 

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -88,12 +88,6 @@ pub enum TMappedTypeChangeProp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum TMappedTypeMutable {
-    Plus,
-    Minus,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TypeKind {
     Var(TVar),
     App(TApp),
@@ -229,4 +223,45 @@ impl fmt::Display for Type {
     }
 }
 
-// TODO: add unit tests to verify the fmt::Display output
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_mapped_type_display() {
+        let constraint = Type::from(TypeKind::Ref(TRef {
+            name: String::from("T"),
+            type_args: None,
+        }));
+        let t = Type::from(TypeKind::MappedType(TMappedType {
+            type_param: TVar {
+                id: 5,
+                constraint: Some(Box::from(constraint)),
+            },
+            optional: None,
+            mutable: None,
+            t: Box::from(Type::from(TypeKind::Keyword(TKeyword::Number))),
+        }));
+
+        assert_eq!(format!("{t}"), "{[t5 in T]: number}");
+    }
+
+    #[test]
+    fn complex_mapped_type_display() {
+        let constraint = Type::from(TypeKind::Ref(TRef {
+            name: String::from("T"),
+            type_args: None,
+        }));
+        let t = Type::from(TypeKind::MappedType(TMappedType {
+            type_param: TVar {
+                id: 5,
+                constraint: Some(Box::from(constraint)),
+            },
+            optional: Some(TMappedTypeChangeProp::Plus),
+            mutable: Some(TMappedTypeChangeProp::Plus),
+            t: Box::from(Type::from(TypeKind::Keyword(TKeyword::Number))),
+        }));
+
+        assert_eq!(format!("{t}"), "{+mut [t5 in T]+?: number}");
+    }
+}

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -635,6 +635,7 @@ pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType
         TypeKind::This => TsType::TsThisType(TsThisType { span: DUMMY_SP }),
         TypeKind::KeyOf(_) => todo!(),
         TypeKind::IndexAccess(_) => todo!(),
+        TypeKind::MappedType(_) => todo!(),
     }
 }
 

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -13,7 +13,7 @@ use crochet_ast::types::{
 use crochet_ast::values::Lit;
 use crochet_infer::{close_over, generalize, normalize, Context, Env, Subst, Substitutable};
 
-use crate::util::{self, replace_alias, replace_aliases};
+use crate::util::{self, replace_aliases_rec};
 
 #[derive(Debug, Clone)]
 pub struct InterfaceCollector {
@@ -186,7 +186,9 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
             let mut type_param_map = HashMap::default();
             type_param_map.insert(type_param.name.sym.to_string(), tvar.clone());
 
-            let type_ann = replace_alias(&type_ann, &type_param_map, ctx)?;
+            // HACK: We call replace_aliases_rec directly here otherwise we'd
+            // get back a generic type that we'd have to instantiate immediately.
+            let type_ann = replace_aliases_rec(&type_ann, &type_param_map);
             let t = Type::from(TypeKind::MappedType(TMappedType {
                 type_param: tvar,
                 optional: match optional {

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -211,7 +211,6 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                 },
                 t: Box::from(type_ann),
             }));
-            println!("MappedType = {t}");
             Ok(t)
         }
         TsType::TsLitType(lit) => match &lit.lit {
@@ -396,22 +395,14 @@ fn infer_ts_type_element(elem: &TsTypeElement, ctx: &Context) -> Result<TObjElem
 }
 
 fn infer_type_alias_decl(decl: &TsTypeAliasDecl, ctx: &Context) -> Result<Type, String> {
-    let name = decl.id.sym.to_string();
-    println!("inferring type decl: {name}");
     let t = infer_ts_type_ann(&decl.type_ann, ctx)?;
 
     // If there are any type params, they will be replaced and the returned type
     // be of kind, TypeKind::Generic.
-    if name == "Partial" {
-        println!("before replace_aliases: {t:#?}");
-    }
     let t = match &decl.type_params {
         Some(type_param_decl) => util::replace_aliases(&t, type_param_decl, ctx)?,
         None => t,
     };
-    if name == "Partial" {
-        println!("after replace_aliases: {t:#?}");
-    }
 
     let empty_s = Subst::default();
     Ok(close_over(&empty_s, &t, ctx))

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use swc_ecma_ast::*;
 
 use crochet_ast::types::{
-    self as types, TCallable, TFnParam, TGeneric, TIndexAccess, TObjElem, TObject, TVar, Type,
-    TypeKind,
+    self as types, TCallable, TFnParam, TGeneric, TIndexAccess, TMappedType, TObjElem, TObject,
+    TVar, Type, TypeKind,
 };
 use crochet_infer::{get_type_params, set_type_params, Context, Subst, Substitutable};
 
@@ -43,6 +43,8 @@ pub fn replace_aliases(
     Ok(replace_aliases_rec(&t, &type_param_map))
 }
 
+// TODO: update this to use Visitor from crochet_infer, which should probably
+// be moved into the crochet_ast crate.
 // TODO: rename this replace_refs_rec
 fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
     let kind = match &t.kind {
@@ -161,6 +163,10 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                 index: Box::from(replace_aliases_rec(index, map)),
             })
         }
+        TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
+            t: Box::from(replace_aliases_rec(&mapped.t, map)),
+            ..mapped.to_owned()
+        }),
     };
 
     Type {

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -11,6 +11,8 @@ use crochet_infer::{get_type_params, set_type_params, Context, Subst, Substituta
 use crate::parse_dts::infer_ts_type_ann;
 
 // TODO: rename this replace_refs
+// TODO: use the same technique we use in infer_type_ann.rs, as this stands, it
+// doesn't handle type param shadowing.
 pub fn replace_aliases(
     t: &Type,
     type_param_decl: &TsTypeParamDecl,
@@ -125,8 +127,6 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                         })
                     }
                     TObjElem::Prop(prop) => {
-                        println!("replacing prop.t");
-                        println!("prop.t = {:#}", prop.t);
                         let t = replace_aliases_rec(&prop.t, map);
                         TObjElem::Prop(types::TProp {
                             t,

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -41,6 +41,19 @@ pub fn replace_aliases(
         })
         .collect::<Result<HashMap<String, TVar>, String>>()?;
 
+    // QUESTION: Do we need to call `set_type_params` before calling `replace_aliases_rec`
+    let t = set_type_params(t, &type_params);
+    Ok(replace_aliases_rec(&t, &type_param_map))
+}
+
+pub fn replace_alias(
+    t: &Type,
+    type_param_map: &HashMap<String, TVar>,
+    ctx: &Context,
+) -> Result<Type, String> {
+    let mut type_params: Vec<TVar> = vec![];
+
+    // QUESTION: Do we need to call `set_type_params` before calling `replace_aliases_rec`
     let t = set_type_params(t, &type_params);
     Ok(replace_aliases_rec(&t, &type_param_map))
 }
@@ -48,38 +61,53 @@ pub fn replace_aliases(
 // TODO: update this to use Visitor from crochet_infer, which should probably
 // be moved into the crochet_ast crate.
 // TODO: rename this replace_refs_rec
-fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
+fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, TVar>) -> Type {
     let kind = match &t.kind {
         TypeKind::Generic(TGeneric { t, type_params }) => {
             // TODO: create a new `map` that adds in `type_params`
             TypeKind::Generic(TGeneric {
-                t: Box::from(replace_aliases_rec(t, map)),
+                t: Box::from(replace_aliases_rec(t, type_param_map)),
                 type_params: type_params.to_owned(),
             })
         }
-        TypeKind::Var(_) => return t.to_owned(),
+        TypeKind::Var(tvar) => match &tvar.constraint {
+            Some(constraint) => TypeKind::Var(TVar {
+                constraint: Some(Box::from(replace_aliases_rec(constraint, type_param_map))),
+                ..tvar.to_owned()
+            }),
+            None => t.kind.to_owned(),
+        },
         TypeKind::App(types::TApp { args, ret }) => TypeKind::App(types::TApp {
-            args: args.iter().map(|t| replace_aliases_rec(t, map)).collect(),
-            ret: Box::from(replace_aliases_rec(ret, map)),
+            args: args
+                .iter()
+                .map(|t| replace_aliases_rec(t, type_param_map))
+                .collect(),
+            ret: Box::from(replace_aliases_rec(ret, type_param_map)),
         }),
         TypeKind::Lam(types::TLam { params, ret }) => TypeKind::Lam(types::TLam {
             params: params
                 .iter()
                 .map(|param| TFnParam {
-                    t: replace_aliases_rec(&param.t, map),
+                    t: replace_aliases_rec(&param.t, type_param_map),
                     ..param.to_owned()
                 })
                 .collect(),
-            ret: Box::from(replace_aliases_rec(ret, map)),
+            ret: Box::from(replace_aliases_rec(ret, type_param_map)),
         }),
         TypeKind::Lit(_) => return t.to_owned(),
         TypeKind::Keyword(_) => return t.to_owned(),
-        TypeKind::Union(types) => {
-            TypeKind::Union(types.iter().map(|t| replace_aliases_rec(t, map)).collect())
-        }
-        TypeKind::Intersection(types) => {
-            TypeKind::Intersection(types.iter().map(|t| replace_aliases_rec(t, map)).collect())
-        }
+        TypeKind::Union(types) => TypeKind::Union(
+            types
+                .iter()
+                .map(|t| replace_aliases_rec(t, type_param_map))
+                .collect(),
+        ),
+        TypeKind::Intersection(types) => TypeKind::Intersection(
+            types
+                .iter()
+                .map(|t| replace_aliases_rec(t, type_param_map))
+                .collect(),
+        ),
         TypeKind::Object(obj) => {
             let elems: Vec<TObjElem> = obj
                 .elems
@@ -90,11 +118,11 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                             .params
                             .iter()
                             .map(|t| TFnParam {
-                                t: replace_aliases_rec(&t.t, map),
+                                t: replace_aliases_rec(&t.t, type_param_map),
                                 ..t.to_owned()
                             })
                             .collect();
-                        let ret = replace_aliases_rec(lam.ret.as_ref(), map);
+                        let ret = replace_aliases_rec(lam.ret.as_ref(), type_param_map);
 
                         TObjElem::Call(TCallable {
                             params,
@@ -107,11 +135,11 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                             .params
                             .iter()
                             .map(|t| TFnParam {
-                                t: replace_aliases_rec(&t.t, map),
+                                t: replace_aliases_rec(&t.t, type_param_map),
                                 ..t.to_owned()
                             })
                             .collect();
-                        let ret = replace_aliases_rec(lam.ret.as_ref(), map);
+                        let ret = replace_aliases_rec(lam.ret.as_ref(), type_param_map);
 
                         TObjElem::Constructor(TCallable {
                             params,
@@ -120,14 +148,14 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                         })
                     }
                     TObjElem::Index(index) => {
-                        let t = replace_aliases_rec(&index.t, map);
+                        let t = replace_aliases_rec(&index.t, type_param_map);
                         TObjElem::Index(types::TIndex {
                             t,
                             ..index.to_owned()
                         })
                     }
                     TObjElem::Prop(prop) => {
-                        let t = replace_aliases_rec(&prop.t, map);
+                        let t = replace_aliases_rec(&prop.t, type_param_map);
                         TObjElem::Prop(types::TProp {
                             t,
                             ..prop.to_owned()
@@ -137,7 +165,7 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
                 .collect();
             TypeKind::Object(TObject { elems })
         }
-        TypeKind::Ref(alias) => match map.get(&alias.name) {
+        TypeKind::Ref(alias) => match type_param_map.get(&alias.name) {
             Some(tv) => {
                 return Type {
                     kind: TypeKind::Var(tv.to_owned()),
@@ -150,23 +178,34 @@ fn replace_aliases_rec(t: &Type, map: &HashMap<String, TVar>) -> Type {
             }
             None => return t.to_owned(),
         },
-        TypeKind::Tuple(types) => {
-            TypeKind::Tuple(types.iter().map(|t| replace_aliases_rec(t, map)).collect())
-        }
-        TypeKind::Array(t) => TypeKind::Array(Box::from(replace_aliases_rec(t, map))),
-        TypeKind::Rest(t) => TypeKind::Rest(Box::from(replace_aliases_rec(t, map))),
+        TypeKind::Tuple(types) => TypeKind::Tuple(
+            types
+                .iter()
+                .map(|t| replace_aliases_rec(t, type_param_map))
+                .collect(),
+        ),
+        TypeKind::Array(t) => TypeKind::Array(Box::from(replace_aliases_rec(t, type_param_map))),
+        TypeKind::Rest(t) => TypeKind::Rest(Box::from(replace_aliases_rec(t, type_param_map))),
         TypeKind::This => TypeKind::This,
-        TypeKind::KeyOf(t) => TypeKind::KeyOf(Box::from(replace_aliases_rec(t, map))),
+        TypeKind::KeyOf(t) => TypeKind::KeyOf(Box::from(replace_aliases_rec(t, type_param_map))),
         TypeKind::IndexAccess(TIndexAccess { object, index }) => {
             TypeKind::IndexAccess(TIndexAccess {
-                object: Box::from(replace_aliases_rec(object, map)),
-                index: Box::from(replace_aliases_rec(index, map)),
+                object: Box::from(replace_aliases_rec(object, type_param_map)),
+                index: Box::from(replace_aliases_rec(index, type_param_map)),
             })
         }
-        TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
-            t: Box::from(replace_aliases_rec(&mapped.t, map)),
-            ..mapped.to_owned()
-        }),
+        TypeKind::MappedType(mapped) => {
+            TypeKind::MappedType(TMappedType {
+                t: Box::from(replace_aliases_rec(&mapped.t, type_param_map)),
+                type_param: TVar {
+                    id: mapped.type_param.id,
+                    constraint: mapped.type_param.constraint.as_ref().map(|constraint| {
+                        Box::from(replace_aliases_rec(constraint, type_param_map))
+                    }),
+                },
+                ..mapped.to_owned()
+            })
+        }
     };
 
     Type {

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -46,22 +46,11 @@ pub fn replace_aliases(
     Ok(replace_aliases_rec(&t, &type_param_map))
 }
 
-pub fn replace_alias(
-    t: &Type,
-    type_param_map: &HashMap<String, TVar>,
-    ctx: &Context,
-) -> Result<Type, String> {
-    let mut type_params: Vec<TVar> = vec![];
-
-    // QUESTION: Do we need to call `set_type_params` before calling `replace_aliases_rec`
-    let t = set_type_params(t, &type_params);
-    Ok(replace_aliases_rec(&t, &type_param_map))
-}
-
 // TODO: update this to use Visitor from crochet_infer, which should probably
 // be moved into the crochet_ast crate.
 // TODO: rename this replace_refs_rec
-fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, TVar>) -> Type {
+// NOTE: This is only used externall by replace_aliases_rec.
+pub fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, TVar>) -> Type {
     let kind = match &t.kind {
         TypeKind::Generic(TGeneric { t, type_params }) => {
             // TODO: create a new `map` that adds in `type_params`

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -490,3 +490,15 @@ fn infer_pick() {
     let result = format!("{}", t);
     assert_eq!(result, "{a: number, b?: string}");
 }
+
+#[test]
+fn infer_prog_using_partial() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+    type PartialObj = Partial<Obj>;
+
+    let partial_obj: PartialObj = {b: "hello"};
+    "#;
+
+    infer_prog(src);
+}

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -399,9 +399,9 @@ fn merging_generic_interfaces() {
 }
 
 #[test]
-fn infer_mapped_types() {
+fn infer_partial() {
     let src = r#"
-    type Obj = {a: number, b: string, c: boolean};
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type PartialObj = Partial<Obj>;
     "#;
     let (_, ctx) = infer_prog(src);
@@ -409,5 +409,22 @@ fn infer_mapped_types() {
     let t = compute_mapped_type(&t, &ctx).unwrap();
 
     let result = format!("{}", t);
-    assert_eq!(result, "{a: Obj[\"a\"], b: Obj[\"b\"], c: Obj[\"c\"]}");
+    assert_eq!(
+        result,
+        "{a?: number, b?: string, mut c?: boolean, mut d?: number}"
+    );
+}
+
+#[test]
+fn infer_readonly() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+    type ReadonlyObj = Readonly<Obj>;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
+    let t = compute_mapped_type(&t, &ctx).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(result, "{a: number, b?: string, c: boolean, d?: number}");
 }

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -416,6 +416,23 @@ fn infer_partial() {
 }
 
 #[test]
+fn infer_required() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+    type RequiredObj = Required<Obj>;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("RequiredObj", false).unwrap();
+    let t = compute_mapped_type(&t, &ctx).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(
+        result,
+        "{a: number, b: string, mut c: boolean, mut d: number}"
+    );
+}
+
+#[test]
 fn infer_readonly() {
     let src = r#"
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
@@ -427,6 +444,37 @@ fn infer_readonly() {
 
     let result = format!("{}", t);
     assert_eq!(result, "{a: number, b?: string, c: boolean, d?: number}");
+}
+
+#[test]
+fn infer_readonly_with_indexer_only() {
+    let src = r#"
+    type Obj = {[key: string]: boolean};
+    type ReadonlyObj = Readonly<Obj>;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
+    let t = compute_mapped_type(&t, &ctx).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(result, "{[key: string]: boolean}");
+}
+
+#[test]
+fn infer_readonly_with_indexer_and_other_properties() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number, [key: number]: boolean};
+    type ReadonlyObj = Readonly<Obj>;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
+    let t = compute_mapped_type(&t, &ctx).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(
+        result,
+        "{[key: number]: boolean, a: number, b?: string, c: boolean, d?: number}"
+    );
 }
 
 #[test]

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -428,3 +428,17 @@ fn infer_readonly() {
     let result = format!("{}", t);
     assert_eq!(result, "{a: number, b?: string, c: boolean, d?: number}");
 }
+
+#[test]
+fn infer_pick() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+    type PickObj = Pick<Obj, "a" | "b">;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("PickObj", false).unwrap();
+    let t = compute_mapped_type(&t, &ctx).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(result, "{a: number, b?: string}");
+}

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -215,11 +215,7 @@ impl Context {
                         .collect()
                     }
                 };
-                println!("subs: {subs:#?}");
-                println!("before subs: {t:#?}");
-                let t = t.apply(&subs);
-                println!("after subs: {t:#?}");
-                return Ok(t);
+                return Ok(t.apply(&subs));
             }
         }
         Err(Report::new(TypeError::CantFindIdent(name.to_owned()))

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -180,7 +180,6 @@ impl Context {
         for scope in self.scopes.iter().rev() {
             if let Some(t) = scope.types.get(name) {
                 let type_params = get_type_params(t);
-                println!("type_params = {type_params:#?}");
 
                 // Replaces qualifiers in the type with the corresponding type params
                 // from the alias type.
@@ -188,8 +187,6 @@ impl Context {
                 let subs: Subst = match &alias.type_args {
                     Some(type_params) => {
                         if type_params.len() != type_params.len() {
-                            println!("type = {t}");
-                            println!("type_params = {type_params:#?}");
                             return Err(Report::new(TypeError::TypeInstantiationFailure)
                                 .attach_printable(
                                     "mismatch between the number of qualifiers and type params",

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -180,6 +180,7 @@ impl Context {
         for scope in self.scopes.iter().rev() {
             if let Some(t) = scope.types.get(name) {
                 let type_params = get_type_params(t);
+                println!("type_params = {type_params:#?}");
 
                 // Replaces qualifiers in the type with the corresponding type params
                 // from the alias type.
@@ -214,8 +215,11 @@ impl Context {
                         .collect()
                     }
                 };
-
-                return Ok(t.apply(&subs));
+                println!("subs: {subs:#?}");
+                println!("before subs: {t:#?}");
+                let t = t.apply(&subs);
+                println!("after subs: {t:#?}");
+                return Ok(t);
             }
         }
         Err(Report::new(TypeError::CantFindIdent(name.to_owned()))

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -88,6 +88,9 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
         TypeKind::IndexAccess(_) => {
             todo!() // We have to evaluate the IndexAccess first
         }
+        TypeKind::MappedType(_) => {
+            todo!() // We have to evaluate the MappedType first
+        }
     }
 }
 

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -5,6 +5,7 @@ mod infer_fn_param;
 mod infer_pattern;
 mod infer_type_ann;
 mod key_of;
+mod mapped_type;
 mod substitutable;
 mod type_error;
 mod unify;

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -18,6 +18,7 @@ pub mod infer;
 
 pub use context::*;
 pub use infer::*;
+pub use mapped_type::compute_mapped_type;
 pub use substitutable::{Subst, Substitutable};
 pub use type_error::TypeError;
 pub use util::{close_over, generalize, get_type_params, normalize, set_type_params};

--- a/crates/crochet_infer/src/mapped_type.rs
+++ b/crates/crochet_infer/src/mapped_type.rs
@@ -1,5 +1,6 @@
 use crochet_ast::types::{
-    BindingIdent, TFnParam, TIndex, TObjElem, TObject, TPat, TProp, Type, TypeKind,
+    BindingIdent, TFnParam, TIndex, TIndexAccess, TMappedType, TObjElem, TObject, TPat, TProp,
+    Type, TypeKind,
 };
 use error_stack::{Report, Result};
 
@@ -8,78 +9,193 @@ use crate::key_of::key_of;
 use crate::type_error::TypeError;
 use crate::visitor::Visitor;
 
+// unwraps `t` recursively until it finds an object type or something that is
+// definitely not an object type
+// TODO: update `infer_property_type` to use this helper function
+fn unwrap_obj_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
+    let t = match &t.kind {
+        TypeKind::Var(_) => todo!(),
+        TypeKind::App(_) => todo!(),
+        TypeKind::Lam(_) => todo!(),
+        TypeKind::Lit(_) => todo!(), // TODO: lookup Number, String, Boolean in Context
+        TypeKind::Keyword(_) => todo!(), // TODO: lookup Number, String, Boolean in Context
+        TypeKind::Union(_) => todo!(),
+        TypeKind::Intersection(_) => todo!(),
+        TypeKind::Object(_) => t.to_owned(),
+        TypeKind::Ref(alias) => unwrap_obj_type(&ctx.lookup_ref_and_instantiate(alias)?, ctx)?,
+        TypeKind::Tuple(_) => todo!(), // TODO: lookup Array in Context
+        TypeKind::Array(_) => todo!(), // TODO: lookup Array in Context
+        TypeKind::Rest(_) => todo!(),
+        TypeKind::This => todo!(),
+        TypeKind::KeyOf(_) => todo!(),
+        TypeKind::IndexAccess(_) => todo!(),
+        TypeKind::MappedType(_) => todo!(),
+        TypeKind::Generic(_) => todo!(),
+    };
+    Ok(t)
+}
+
+fn get_obj_type_from_mapped_type(mapped: &TMappedType, ctx: &Context) -> Result<Type, TypeError> {
+    // TODO:
+    // - check if mapped.type_param.constraint is a keyof type
+    // - if not, look at the constraint's provenence to see it was a keyof type
+    // - as a last resort, look at mapped.t to see if it's an indexed access type
+    if let Some(constraint) = &mapped.type_param.constraint {
+        if let TypeKind::KeyOf(t) = &constraint.kind {
+            return unwrap_obj_type(t.as_ref(), ctx);
+        }
+
+        // TODO: look at constraint.provenence to see if it's a keyof type
+    } else if let TypeKind::IndexAccess(access) = &mapped.t.kind {
+        return unwrap_obj_type(access.object.as_ref(), ctx);
+    }
+
+    Err(Report::new(TypeError::Unhandled))
+}
+
+fn get_prop(obj: &TObject, key: &str) -> Result<TProp, TypeError> {
+    for elem in &obj.elems {
+        if let TObjElem::Prop(prop) = elem {
+            if prop.name == key {
+                return Ok(prop.to_owned());
+            }
+        }
+    }
+
+    Err(Report::new(TypeError::MissingKey(key.to_owned())))
+}
+
+fn computed_indexed_access(access: &TIndexAccess, ctx: &Context) -> Result<Type, TypeError> {
+    let obj = unwrap_obj_type(access.object.as_ref(), ctx)?;
+    let index = access.index.as_ref();
+
+    let key = match &index.kind {
+        TypeKind::Lit(lit) => match lit {
+            crochet_ast::types::TLit::Num(num) => num,
+            crochet_ast::types::TLit::Bool(_) => todo!(),
+            crochet_ast::types::TLit::Str(str) => str,
+        },
+        _ => {
+            return Err(Report::new(TypeError::InvalidIndex(
+                access.object.to_owned(),
+                access.index.to_owned(),
+            )));
+        }
+    };
+
+    if let TypeKind::Object(obj) = &obj.kind {
+        let prop = get_prop(obj, key)?;
+        return Ok(prop.t);
+    }
+
+    Err(Report::new(TypeError::Unhandled))
+}
+
+fn get_prop_by_name(elems: &[TObjElem], name: &str) -> Result<TProp, TypeError> {
+    for elem in elems {
+        match elem {
+            TObjElem::Call(_) => (),
+            TObjElem::Constructor(_) => (),
+            TObjElem::Index(_) => (),
+            TObjElem::Prop(prop) => {
+                if prop.name == name {
+                    return Ok(prop.to_owned());
+                }
+            }
+        }
+    }
+
+    Err(Report::new(TypeError::MissingKey(name.to_owned())))
+}
+
 pub fn compute_mapped_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
-    println!("computed_mapped_type: t = {t:#?}");
     match &t.kind {
         TypeKind::Ref(alias) => {
             let t = ctx.lookup_ref_and_instantiate(alias)?;
             compute_mapped_type(&t, ctx)
         }
         TypeKind::MappedType(mapped) => {
-            // TODO:
-            // - compute the keys to map over
-            // - compute the value of each key (may require computing indexed access)
-            // - create a new object type from those (key, value) pairs
             let constraint = mapped.type_param.constraint.as_ref().unwrap();
             let keys = key_of(constraint, ctx)?;
+            let obj = get_obj_type_from_mapped_type(mapped, ctx)?;
 
-            // keys is assumed to be union type of indexers
+            let elems = match &obj.kind {
+                TypeKind::Object(TObject { elems }) => elems.to_owned(),
+                _ => vec![],
+            };
+
+            // keys is either a union of all the prop keys/indexer types or
+            // is a single prop key/indexer type.
             if let TypeKind::Union(keys) = keys.kind {
                 let elems = keys
                     .iter()
                     .map(|key| {
                         let mut value = mapped.t.clone();
 
-                        // TODO: check why kind of type `value` is, if it's a indexed
-                        // type, we can get its object type.
-                        // Alternatively, we could also look at the constraint to see
-                        // if it's a keyof and then get the original object type that
-                        // way.
-                        // What about MyPick<>:
-                        // type Pick<T, K extends keyof T> = {
-                        //     [P in K]: string;
-                        // };
-                        // When we do Pick<Point, "x" | "z"> we replace `K` with
-                        // "x" | "z" and thus lose the fact that those were keys of T
-                        //
-                        // I think what we probably want to do in that case, is replace
-                        // Pick alias with its definition before checking the args, e.g.
-                        // { [P in K extends keyof T]: string;}
-                        // Admittedly it's kind of edge case so maybe we can get away
-                        // with looking for `keyof` of `T[P]` types
-
                         // if key is a:
                         // - number, string, or symbol then create an indexer
                         // - literal of those types then create a normal property
                         replace_tvar(&mut value, &mapped.type_param.id, key);
 
-                        // TODO: actually do the lookup
-                        if let TypeKind::IndexAccess(access) = &value.kind {
-                            println!("access = {access:#?}");
-                        }
+                        let value = match &value.kind {
+                            TypeKind::IndexAccess(access) => computed_indexed_access(access, ctx)?,
+                            _ => value.as_ref().to_owned(),
+                        };
 
                         match &key.kind {
                             TypeKind::Lit(lit) => match lit {
-                                crochet_ast::types::TLit::Num(num) => Ok(TObjElem::Prop(TProp {
-                                    name: num.to_owned(),
-                                    // How do we maintain the optionality of each property
-                                    // when we aren't setting it explicitly
-                                    optional: false, // TODO
-                                    mutable: false,  // TODO
-                                    t: value.as_ref().to_owned(),
-                                })),
+                                crochet_ast::types::TLit::Num(name) => {
+                                    let prop = get_prop_by_name(&elems, name)?;
+                                    let optional = match &mapped.optional {
+                                        Some(change) => match change {
+                                            crochet_ast::types::TMappedTypeChangeProp::Plus => true,
+                                            crochet_ast::types::TMappedTypeChangeProp::Minus => false,
+                                        },
+                                        None => prop.optional,
+                                    };
+                                    let mutable = match &mapped.mutable {
+                                        Some(change) => match change {
+                                            crochet_ast::types::TMappedTypeChangeProp::Plus => true,
+                                            crochet_ast::types::TMappedTypeChangeProp::Minus => false,
+                                        },
+                                        None => prop.mutable,
+                                    };
+                                    Ok(TObjElem::Prop(TProp {
+                                        name: name.to_owned(),
+                                        optional,
+                                        mutable,
+                                        t: value,
+                                    }))
+                                }
                                 crochet_ast::types::TLit::Bool(_) => {
                                     Err(Report::new(TypeError::Unhandled))
                                 }
-                                crochet_ast::types::TLit::Str(str) => Ok(TObjElem::Prop(TProp {
-                                    name: str.to_owned(),
-                                    // How do we maintain the optionality of each property
-                                    // when we aren't setting it explicitly
-                                    optional: false, // TODO
-                                    mutable: false,  // TODO
-                                    t: value.as_ref().to_owned(),
-                                })),
+                                crochet_ast::types::TLit::Str(name) => {
+                                    let prop = get_prop_by_name(&elems, name)?;
+                                    let optional = match &mapped.optional {
+                                        Some(change) => match change {
+                                            crochet_ast::types::TMappedTypeChangeProp::Plus => true,
+                                            crochet_ast::types::TMappedTypeChangeProp::Minus => false,
+                                        },
+                                        None => prop.optional,
+                                    };
+                                    let mutable = match &mapped.mutable {
+                                        Some(change) => match change {
+                                            crochet_ast::types::TMappedTypeChangeProp::Plus => true,
+                                            crochet_ast::types::TMappedTypeChangeProp::Minus => false,
+                                        },
+                                        None => prop.mutable,
+                                    };
+                                    Ok(TObjElem::Prop(TProp {
+                                        name: name.to_owned(),
+                                        optional,
+                                        mutable,
+                                        t: value,
+                                    }))
+                                }
                             },
+                            // TODO: get indexer(s), you can mix symbol + number
+                            // OR symbol + string, but not number + string.
                             TypeKind::Keyword(_) => Ok(TObjElem::Index(TIndex {
                                 key: TFnParam {
                                     pat: TPat::Ident(BindingIdent {
@@ -92,7 +208,7 @@ pub fn compute_mapped_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
                                 // How do we maintain the optionality of each property
                                 // when we aren't setting it explicitly
                                 mutable: false, // TODO
-                                t: value.as_ref().to_owned(),
+                                t: value,
                             })),
                             _ => Err(Report::new(TypeError::Unhandled)),
                         }
@@ -144,17 +260,4 @@ impl Visitor for ReplaceVisitor {
 fn replace_tvar(t: &mut Type, search_id: &i32, rep: &Type) {
     let mut rep_visitor = ReplaceVisitor::new(search_id, rep);
     rep_visitor.visit_children(t);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::infer;
-    use crochet_parser::*;
-
-    fn infer_prog(input: &str) -> Context {
-        let mut prog = parse(input).unwrap();
-        let mut ctx: Context = Context::default();
-        infer::infer_prog(&mut prog, &mut ctx).unwrap()
-    }
 }

--- a/crates/crochet_infer/src/mapped_type.rs
+++ b/crates/crochet_infer/src/mapped_type.rs
@@ -1,82 +1,118 @@
 use crochet_ast::types::{
-    BindingIdent, TFnParam, TIndex, TMappedType, TObjElem, TObject, TPat, TProp, Type, TypeKind,
+    BindingIdent, TFnParam, TIndex, TObjElem, TObject, TPat, TProp, Type, TypeKind,
 };
 use error_stack::{Report, Result};
 
 use crate::context::Context;
+use crate::key_of::key_of;
 use crate::type_error::TypeError;
 use crate::visitor::Visitor;
 
-pub fn compute_mapped_type(mapped: &TMappedType, ctx: &Context) -> Result<Type, TypeError> {
-    // TODO:
-    // - compute the keys to map over
-    // - compute the value of each key (may require computing indexed access)
-    // - create a new object type from those (key, value) pairs
-    let constraint = mapped.type_param.constraint.as_ref().unwrap();
+pub fn compute_mapped_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
+    println!("computed_mapped_type: t = {t:#?}");
+    match &t.kind {
+        TypeKind::Ref(alias) => {
+            let t = ctx.lookup_ref_and_instantiate(alias)?;
+            compute_mapped_type(&t, ctx)
+        }
+        TypeKind::MappedType(mapped) => {
+            // TODO:
+            // - compute the keys to map over
+            // - compute the value of each key (may require computing indexed access)
+            // - create a new object type from those (key, value) pairs
+            let constraint = mapped.type_param.constraint.as_ref().unwrap();
+            let keys = key_of(constraint, ctx)?;
 
-    // keys is assumed to be union type of indexers
-    if let TypeKind::Union(keys) = &constraint.kind {
-        let elems = keys
-            .iter()
-            .map(|key| {
-                let mut value = mapped.t.clone();
+            // keys is assumed to be union type of indexers
+            if let TypeKind::Union(keys) = keys.kind {
+                let elems = keys
+                    .iter()
+                    .map(|key| {
+                        let mut value = mapped.t.clone();
 
-                // TODO: check why kind of type `value` is, if it's a indexed
-                // type, we can get its object type.
+                        // TODO: check why kind of type `value` is, if it's a indexed
+                        // type, we can get its object type.
+                        // Alternatively, we could also look at the constraint to see
+                        // if it's a keyof and then get the original object type that
+                        // way.
+                        // What about MyPick<>:
+                        // type Pick<T, K extends keyof T> = {
+                        //     [P in K]: string;
+                        // };
+                        // When we do Pick<Point, "x" | "z"> we replace `K` with
+                        // "x" | "z" and thus lose the fact that those were keys of T
+                        //
+                        // I think what we probably want to do in that case, is replace
+                        // Pick alias with its definition before checking the args, e.g.
+                        // { [P in K extends keyof T]: string;}
+                        // Admittedly it's kind of edge case so maybe we can get away
+                        // with looking for `keyof` of `T[P]` types
 
-                // if key is a:
-                // - number, string, or symbol then create an indexer
-                // - literal of those types then create a normal property
-                replace_tvar(&mut value, &mapped.type_param.id, key);
+                        // if key is a:
+                        // - number, string, or symbol then create an indexer
+                        // - literal of those types then create a normal property
+                        replace_tvar(&mut value, &mapped.type_param.id, key);
 
-                match &key.kind {
-                    TypeKind::Lit(lit) => match lit {
-                        crochet_ast::types::TLit::Num(num) => Ok(TObjElem::Prop(TProp {
-                            name: num.to_owned(),
-                            // How do we maintain the optionality of each property
-                            // when we aren't setting it explicitly
-                            optional: false, // TODO
-                            mutable: false,  // TODO
-                            t: value.as_ref().to_owned(),
-                        })),
-                        crochet_ast::types::TLit::Bool(_) => Err(Report::new(TypeError::Unhandled)),
-                        crochet_ast::types::TLit::Str(str) => Ok(TObjElem::Prop(TProp {
-                            name: str.to_owned(),
-                            // How do we maintain the optionality of each property
-                            // when we aren't setting it explicitly
-                            optional: false, // TODO
-                            mutable: false,  // TODO
-                            t: value.as_ref().to_owned(),
-                        })),
-                    },
-                    TypeKind::Keyword(_) => Ok(TObjElem::Index(TIndex {
-                        key: TFnParam {
-                            pat: TPat::Ident(BindingIdent {
-                                name: String::from("key"),
+                        // TODO: actually do the lookup
+                        if let TypeKind::IndexAccess(access) = &value.kind {
+                            println!("access = {access:#?}");
+                        }
+
+                        match &key.kind {
+                            TypeKind::Lit(lit) => match lit {
+                                crochet_ast::types::TLit::Num(num) => Ok(TObjElem::Prop(TProp {
+                                    name: num.to_owned(),
+                                    // How do we maintain the optionality of each property
+                                    // when we aren't setting it explicitly
+                                    optional: false, // TODO
+                                    mutable: false,  // TODO
+                                    t: value.as_ref().to_owned(),
+                                })),
+                                crochet_ast::types::TLit::Bool(_) => {
+                                    Err(Report::new(TypeError::Unhandled))
+                                }
+                                crochet_ast::types::TLit::Str(str) => Ok(TObjElem::Prop(TProp {
+                                    name: str.to_owned(),
+                                    // How do we maintain the optionality of each property
+                                    // when we aren't setting it explicitly
+                                    optional: false, // TODO
+                                    mutable: false,  // TODO
+                                    t: value.as_ref().to_owned(),
+                                })),
+                            },
+                            TypeKind::Keyword(_) => Ok(TObjElem::Index(TIndex {
+                                key: TFnParam {
+                                    pat: TPat::Ident(BindingIdent {
+                                        name: String::from("key"),
+                                        mutable: false, // TODO
+                                    }),
+                                    t: key.to_owned(),
+                                    optional: false, // TODO
+                                },
+                                // How do we maintain the optionality of each property
+                                // when we aren't setting it explicitly
                                 mutable: false, // TODO
-                            }),
-                            t: key.to_owned(),
-                            optional: false, // TODO
-                        },
-                        // How do we maintain the optionality of each property
-                        // when we aren't setting it explicitly
-                        mutable: false, // TODO
-                        t: value.as_ref().to_owned(),
-                    })),
-                    _ => Err(Report::new(TypeError::Unhandled)),
-                }
-            })
-            .collect::<Result<Vec<_>, TypeError>>()?;
+                                t: value.as_ref().to_owned(),
+                            })),
+                            _ => Err(Report::new(TypeError::Unhandled)),
+                        }
+                    })
+                    .collect::<Result<Vec<_>, TypeError>>()?;
 
-        let t = Type {
-            kind: TypeKind::Object(TObject { elems }),
-            mutable: false,
-            provenance: None, // TODO: fill this in
-        };
+                let t = Type {
+                    kind: TypeKind::Object(TObject { elems }),
+                    mutable: false,
+                    provenance: None, // TODO: fill this in
+                };
 
-        Ok(t)
-    } else {
-        Err(Report::new(TypeError::Unhandled))
+                Ok(t)
+            } else {
+                // TODO: handle there being only a single key, create a helper
+                // function for getting the keys as a vector.
+                Err(Report::new(TypeError::Unhandled))
+            }
+        }
+        _ => Err(Report::new(TypeError::Unhandled)),
     }
 }
 

--- a/crates/crochet_infer/src/mapped_type.rs
+++ b/crates/crochet_infer/src/mapped_type.rs
@@ -1,0 +1,124 @@
+use crochet_ast::types::{
+    BindingIdent, TFnParam, TIndex, TMappedType, TObjElem, TObject, TPat, TProp, Type, TypeKind,
+};
+use error_stack::{Report, Result};
+
+use crate::context::Context;
+use crate::type_error::TypeError;
+use crate::visitor::Visitor;
+
+pub fn compute_mapped_type(mapped: &TMappedType, ctx: &Context) -> Result<Type, TypeError> {
+    // TODO:
+    // - compute the keys to map over
+    // - compute the value of each key (may require computing indexed access)
+    // - create a new object type from those (key, value) pairs
+    let constraint = mapped.type_param.constraint.as_ref().unwrap();
+
+    // keys is assumed to be union type of indexers
+    if let TypeKind::Union(keys) = &constraint.kind {
+        let elems = keys
+            .iter()
+            .map(|key| {
+                let mut value = mapped.t.clone();
+
+                // TODO: check why kind of type `value` is, if it's a indexed
+                // type, we can get its object type.
+
+                // if key is a:
+                // - number, string, or symbol then create an indexer
+                // - literal of those types then create a normal property
+                replace_tvar(&mut value, &mapped.type_param.id, key);
+
+                match &key.kind {
+                    TypeKind::Lit(lit) => match lit {
+                        crochet_ast::types::TLit::Num(num) => Ok(TObjElem::Prop(TProp {
+                            name: num.to_owned(),
+                            // How do we maintain the optionality of each property
+                            // when we aren't setting it explicitly
+                            optional: false, // TODO
+                            mutable: false,  // TODO
+                            t: value.as_ref().to_owned(),
+                        })),
+                        crochet_ast::types::TLit::Bool(_) => Err(Report::new(TypeError::Unhandled)),
+                        crochet_ast::types::TLit::Str(str) => Ok(TObjElem::Prop(TProp {
+                            name: str.to_owned(),
+                            // How do we maintain the optionality of each property
+                            // when we aren't setting it explicitly
+                            optional: false, // TODO
+                            mutable: false,  // TODO
+                            t: value.as_ref().to_owned(),
+                        })),
+                    },
+                    TypeKind::Keyword(_) => Ok(TObjElem::Index(TIndex {
+                        key: TFnParam {
+                            pat: TPat::Ident(BindingIdent {
+                                name: String::from("key"),
+                                mutable: false, // TODO
+                            }),
+                            t: key.to_owned(),
+                            optional: false, // TODO
+                        },
+                        // How do we maintain the optionality of each property
+                        // when we aren't setting it explicitly
+                        mutable: false, // TODO
+                        t: value.as_ref().to_owned(),
+                    })),
+                    _ => Err(Report::new(TypeError::Unhandled)),
+                }
+            })
+            .collect::<Result<Vec<_>, TypeError>>()?;
+
+        let t = Type {
+            kind: TypeKind::Object(TObject { elems }),
+            mutable: false,
+            provenance: None, // TODO: fill this in
+        };
+
+        Ok(t)
+    } else {
+        Err(Report::new(TypeError::Unhandled))
+    }
+}
+
+struct ReplaceVisitor {
+    search_id: i32,
+    rep: Type,
+}
+
+impl ReplaceVisitor {
+    fn new(search_id: &i32, rep: &Type) -> Self {
+        ReplaceVisitor {
+            search_id: *search_id,
+            rep: rep.to_owned(),
+        }
+    }
+}
+
+impl Visitor for ReplaceVisitor {
+    fn visit_type(&mut self, t: &mut Type) {
+        if let TypeKind::Var(tvar) = &t.kind {
+            if tvar.id == self.search_id {
+                t.kind = self.rep.kind.to_owned();
+                t.mutable = self.rep.mutable;
+            }
+        }
+    }
+}
+
+fn replace_tvar(t: &mut Type, search_id: &i32, rep: &Type) {
+    let mut rep_visitor = ReplaceVisitor::new(search_id, rep);
+    rep_visitor.visit_children(t);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infer;
+    use crochet_parser::*;
+
+    fn infer_prog(input: &str) -> Context {
+        let mut prog = parse(input).unwrap();
+        let mut ctx: Context = Context::default();
+        infer::infer_prog(&mut prog, &mut ctx).unwrap()
+    }
+}

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -87,9 +87,10 @@ impl Substitutable for Type {
                     index: Box::from(index.apply(sub)),
                 })
             }
-            TypeKind::MappedType(TMappedType { .. }) => {
-                todo!()
-            }
+            TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
+                t: Box::from(mapped.t.apply(sub)),
+                ..mapped.to_owned()
+            }),
         };
         norm_type(Type {
             kind,
@@ -132,8 +133,15 @@ impl Substitutable for Type {
                 result
             }
             // What does it mean to be a free variable?
-            TypeKind::MappedType(TMappedType { .. }) => {
-                todo!()
+            TypeKind::MappedType(TMappedType { type_param, t, .. }) => {
+                // TODO: get free variables in the value and the key and take
+                // the set difference of them.
+                let mut result = t.ftv();
+                if let Some(index) = result.iter().position(|tv| tv == type_param) {
+                    result.remove(index);
+                }
+                // TODO: warn that the type param doesn't appear in the `t`
+                result
             }
         }
     }

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -89,6 +89,14 @@ impl Substitutable for Type {
             }
             TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
                 t: Box::from(mapped.t.apply(sub)),
+                type_param: TVar {
+                    id: mapped.type_param.id,
+                    constraint: mapped
+                        .type_param
+                        .constraint
+                        .as_ref()
+                        .map(|constraint| Box::from(constraint.apply(sub))),
+                },
                 ..mapped.to_owned()
             }),
         };

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -87,6 +87,9 @@ impl Substitutable for Type {
                     index: Box::from(index.apply(sub)),
                 })
             }
+            TypeKind::MappedType(TMappedType { .. }) => {
+                todo!()
+            }
         };
         norm_type(Type {
             kind,
@@ -127,6 +130,10 @@ impl Substitutable for Type {
                 let mut result = object.ftv();
                 result.append(&mut index.ftv());
                 result
+            }
+            // What does it mean to be a free variable?
+            TypeKind::MappedType(TMappedType { .. }) => {
+                todo!()
             }
         }
     }

--- a/crates/crochet_infer/src/type_error.rs
+++ b/crates/crochet_infer/src/type_error.rs
@@ -8,7 +8,7 @@ use crochet_ast::values::{Assign, Statement};
 pub enum TypeError {
     UnificationError(Box<Type>, Box<Type>),
     UnificationIsUndecidable,
-    Unhandled,
+    Unhandled, // TODO: rename to unspecified
     InfiniteType,
     PrimitivesCantBeMutable(Box<Type>),
     TuplesCantBeMutable(Box<Type>),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -8,6 +8,7 @@ use types::TKeyword;
 
 use crate::context::Context;
 use crate::key_of::key_of;
+use crate::mapped_type::compute_mapped_type;
 use crate::substitutable::{Subst, Substitutable};
 use crate::type_error::TypeError;
 use crate::unify_mut::unify_mut;
@@ -612,6 +613,14 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, TypeError> {
         (TypeKind::Ref(alias), _) => {
             let alias_t = ctx.lookup_ref_and_instantiate(alias)?;
             unify(&alias_t, t2, ctx)
+        }
+        (_, TypeKind::MappedType(_)) => {
+            let mapped_t = compute_mapped_type(t2, ctx)?;
+            unify(t1, &mapped_t, ctx)
+        }
+        (TypeKind::MappedType(_), _) => {
+            let mapped_t = compute_mapped_type(t1, ctx)?;
+            unify(&mapped_t, t2, ctx)
         }
         (TypeKind::Array(_), TypeKind::Rest(rest_arg)) => unify(t1, rest_arg.as_ref(), ctx),
         (TypeKind::Tuple(_), TypeKind::Rest(rest_arg)) => unify(t1, rest_arg.as_ref(), ctx),

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -199,6 +199,10 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                     index: Box::from(norm_type(index, mapping, _ctx)),
                 })
             }
+            TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
+                t: Box::from(norm_type(&mapped.t, mapping, _ctx)),
+                ..mapped.to_owned()
+            }),
         };
 
         Type {

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -77,12 +77,20 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                         .collect(),
                 })
             }
-            TypeKind::Var(tv) => match mapping.get(&tv.id) {
-                Some(t) => return t.to_owned(),
-                // If `id` doesn't exist in `mapping` we return the original type variable.
-                // In this situation, it should appear in some other list of qualifiers.
-                None => return t.to_owned(),
-            },
+            TypeKind::Var(tv) => {
+                match mapping.get(&tv.id) {
+                    Some(t) => return t.to_owned(),
+                    // If `id` doesn't exist in `mapping` we return the original type variable.
+                    // In this situation, it should appear in some other list of qualifiers.
+                    None => TypeKind::Var(TVar {
+                        id: tv.id,
+                        constraint: tv
+                            .constraint
+                            .as_ref()
+                            .map(|constraint| Box::from(norm_type(constraint, mapping, _ctx))),
+                    }),
+                }
+            }
             TypeKind::App(app) => {
                 let args: Vec<_> = app
                     .args
@@ -201,6 +209,14 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
             }
             TypeKind::MappedType(mapped) => TypeKind::MappedType(TMappedType {
                 t: Box::from(norm_type(&mapped.t, mapping, _ctx)),
+                type_param: TVar {
+                    id: mapped.type_param.id,
+                    constraint: mapped
+                        .type_param
+                        .constraint
+                        .as_ref()
+                        .map(|constraint| Box::from(norm_type(constraint, mapping, _ctx))),
+                },
                 ..mapped.to_owned()
             }),
         };

--- a/crates/crochet_infer/src/visitor.rs
+++ b/crates/crochet_infer/src/visitor.rs
@@ -37,6 +37,9 @@ pub trait Visitor {
                 self.visit_children(&mut access.object);
                 self.visit_children(&mut access.index);
             }
+            TypeKind::MappedType(mapped) => {
+                self.visit_children(&mut mapped.t);
+            }
             TypeKind::Generic(gen) => {
                 self.visit_children(&mut gen.t);
             }

--- a/crates/crochet_infer/src/visitor.rs
+++ b/crates/crochet_infer/src/visitor.rs
@@ -25,7 +25,11 @@ pub trait Visitor {
                 types.iter_mut().for_each(|t| self.visit_children(t));
             }
             TypeKind::Object(_) => todo!(),
-            TypeKind::Ref(_) => todo!(),
+            TypeKind::Ref(alias) => {
+                if let Some(type_args) = &mut alias.type_args {
+                    type_args.iter_mut().for_each(|t| self.visit_children(t));
+                }
+            }
             TypeKind::Tuple(types) => {
                 types.iter_mut().for_each(|t| self.visit_children(t));
             }


### PR DESCRIPTION
TODO:
- [x] close over the type inferred from parsing .d.ts files
- [x] update crochet_infer to:
  - [x] compute the actual type from a mapped type (similar to what we do for `keyof`  types)
  - [x] so that mapped types can be unified with other types
- ~update parser to handle mapped types in the source code~ I'm going to do this in a separate PR since most of the code to implement this will be largely unrelated to what's in this PR which is already quite large.
- [x] write unit tests and fixture tests