### PR TITLE
Fix .d.ts code generation of mutable types

### DIFF
--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -440,6 +440,7 @@ pub fn build_type_params(t: &Type) -> Option<Box<TsTypeParamDecl>> {
 /// `expr` should be the original expression that `t` was inferred
 /// from if it exists.
 pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType {
+    let mutable = t.mutable;
     match &t.kind {
         TypeKind::Generic(TGeneric { t, .. }) => {
             // TODO: combine the return value from the `build_type_params()` call
@@ -605,7 +606,7 @@ pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType
                     .collect(),
             });
 
-            if t.mutable {
+            if mutable {
                 type_ann
             } else {
                 TsType::TsTypeOperator(TsTypeOperator {
@@ -621,7 +622,7 @@ pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType
                 elem_type: Box::from(build_type(t, None)),
             });
 
-            if t.mutable {
+            if mutable {
                 type_ann
             } else {
                 TsType::TsTypeOperator(TsTypeOperator {

--- a/crates/crochet_codegen/tests/codegen_test.rs
+++ b/crates/crochet_codegen/tests/codegen_test.rs
@@ -619,7 +619,6 @@ fn spread_args() {
 }
 
 #[test]
-#[ignore]
 fn mutable_array() {
     let src = r#"
     let arr: mut number[] = [1, 2, 3];
@@ -638,8 +637,6 @@ fn mutable_array() {
     infer_prog(&mut program, &mut ctx).unwrap();
     let result = codegen_d_ts(&program, &ctx);
 
-    let arr = ctx.lookup_value("arr").unwrap();
-    println!("arr = {arr:#?}");
     insta::assert_snapshot!(result, @"export declare const arr: number[];
 ");
 }


### PR DESCRIPTION
We were using the `readonly` modifier for all array and tuple types even when the type as mutable.  This PR fixes that.