### PR TITLE
Conditional types

### DIFF
--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -88,6 +88,14 @@ pub enum TMappedTypeChangeProp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TConditionalType {
+    pub check_type: Box<Type>,
+    pub extends_type: Box<Type>,
+    pub true_type: Box<Type>,
+    pub false_type: Box<Type>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TypeKind {
     Var(TVar),
     App(TApp),
@@ -107,6 +115,7 @@ pub enum TypeKind {
     KeyOf(Box<Type>),
     IndexAccess(TIndexAccess),
     MappedType(TMappedType),
+    ConditionalType(TConditionalType),
     // Query, // use for typed holes
 
     // We encapsulate type polymorphism in a wrapper type instead of a separate
@@ -218,6 +227,17 @@ impl fmt::Display for Type {
                 }
 
                 write!(f, ": {t}}}")
+            }
+            TypeKind::ConditionalType(TConditionalType {
+                check_type,
+                extends_type,
+                true_type,
+                false_type,
+            }) => {
+                write!(
+                    f,
+                    "{check_type} extends {extends_type} ? {true_type} : {false_type}"
+                )
             }
         }
     }

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -637,6 +637,7 @@ pub fn build_type(t: &Type, type_params: Option<Box<TsTypeParamDecl>>) -> TsType
         TypeKind::KeyOf(_) => todo!(),
         TypeKind::IndexAccess(_) => todo!(),
         TypeKind::MappedType(_) => todo!(),
+        TypeKind::ConditionalType(_) => todo!(),
     }
 }
 

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use swc_ecma_ast::*;
 
 use crochet_ast::types::{
-    self as types, TCallable, TFnParam, TGeneric, TIndexAccess, TMappedType, TObjElem, TObject,
-    TVar, Type, TypeKind,
+    self as types, TCallable, TConditionalType, TFnParam, TGeneric, TIndexAccess, TMappedType,
+    TObjElem, TObject, TVar, Type, TypeKind,
 };
 use crochet_infer::{get_type_params, set_type_params, Context, Subst, Substitutable};
 
@@ -195,6 +195,17 @@ pub fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, TVar>) -> 
                 ..mapped.to_owned()
             })
         }
+        TypeKind::ConditionalType(TConditionalType {
+            check_type,
+            extends_type,
+            true_type,
+            false_type,
+        }) => TypeKind::ConditionalType(TConditionalType {
+            check_type: Box::from(replace_aliases_rec(check_type, type_param_map)),
+            extends_type: Box::from(replace_aliases_rec(extends_type, type_param_map)),
+            true_type: Box::from(replace_aliases_rec(true_type, type_param_map)),
+            false_type: Box::from(replace_aliases_rec(false_type, type_param_map)),
+        }),
     };
 
     Type {

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -536,3 +536,23 @@ fn infer_exclude() {
 
     assert_eq!(result, "\"c\"");
 }
+
+// TODO: fix this test case, we want to fully expand this type alias
+#[test]
+#[ignore]
+fn infer_omit() {
+    let src = r#"
+    type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
+    type T1 = Omit<Obj, "b" | "c">;
+    "#;
+    let (_, ctx) = infer_prog(src);
+    let t = ctx.lookup_type("T1", false).unwrap();
+
+    let result = format!("{}", t);
+    assert_eq!(result, "Omit<Obj, \"b\" | \"c\">");
+
+    let t = compute_conditional_type(&t, &ctx).unwrap();
+    let result = format!("{}", t);
+
+    assert_eq!(result, "{a: number; mut d?: number}");
+}

--- a/crates/crochet_infer/src/conditional_type.rs
+++ b/crates/crochet_infer/src/conditional_type.rs
@@ -1,0 +1,30 @@
+use crochet_ast::types::{TConditionalType, Type, TypeKind};
+use error_stack::{Report, Result};
+
+use crate::context::Context;
+use crate::type_error::TypeError;
+use crate::unify::unify;
+
+pub fn compute_conditional_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
+    match &t.kind {
+        TypeKind::Ref(alias) => {
+            // When conditional types act on a generic type, they become
+            // distributive when given a union type.
+            ctx.lookup_ref_and_instantiate(alias)
+        }
+        TypeKind::ConditionalType(TConditionalType {
+            check_type,
+            extends_type,
+            true_type,
+            false_type,
+        }) => {
+            let t = match unify(check_type, extends_type, ctx) {
+                Ok(_) => true_type,
+                Err(_) => false_type,
+            };
+
+            Ok(t.as_ref().to_owned())
+        }
+        _ => Err(Report::new(TypeError::Unhandled)),
+    }
+}

--- a/crates/crochet_infer/src/key_of.rs
+++ b/crates/crochet_infer/src/key_of.rs
@@ -14,6 +14,8 @@ const NEVER_TYPE: Type = Type {
 };
 
 // TODO: try to dedupe with infer_property_type()
+// TODO: use unwrap_obj_type to get an object type first before computing all
+// of its keys.
 pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
     match &t.kind {
         TypeKind::Generic(TGeneric { t, type_params: _ }) => key_of(t, ctx),
@@ -90,6 +92,9 @@ pub fn key_of(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
         }
         TypeKind::MappedType(_) => {
             todo!() // We have to evaluate the MappedType first
+        }
+        TypeKind::ConditionalType(_) => {
+            todo!() // We have to evaluate the ConditionalType first
         }
     }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -1,4 +1,5 @@
 mod assump;
+mod conditional_type;
 mod context;
 mod infer_expr;
 mod infer_fn_param;
@@ -16,6 +17,7 @@ mod visitor;
 
 pub mod infer;
 
+pub use conditional_type::compute_conditional_type;
 pub use context::*;
 pub use infer::*;
 pub use mapped_type::compute_mapped_type;

--- a/crates/crochet_infer/src/mapped_type.rs
+++ b/crates/crochet_infer/src/mapped_type.rs
@@ -30,6 +30,7 @@ fn unwrap_obj_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
         TypeKind::KeyOf(_) => todo!(),
         TypeKind::IndexAccess(_) => todo!(),
         TypeKind::MappedType(_) => todo!(),
+        TypeKind::ConditionalType(_) => todo!(),
         TypeKind::Generic(_) => todo!(),
     };
     Ok(t)

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -99,6 +99,17 @@ impl Substitutable for Type {
                 },
                 ..mapped.to_owned()
             }),
+            TypeKind::ConditionalType(TConditionalType {
+                check_type,
+                extends_type,
+                true_type,
+                false_type,
+            }) => TypeKind::ConditionalType(TConditionalType {
+                check_type: Box::from(check_type.apply(sub)),
+                extends_type: Box::from(extends_type.apply(sub)),
+                true_type: Box::from(true_type.apply(sub)),
+                false_type: Box::from(false_type.apply(sub)),
+            }),
         };
         norm_type(Type {
             kind,
@@ -149,6 +160,19 @@ impl Substitutable for Type {
                     result.remove(index);
                 }
                 // TODO: warn that the type param doesn't appear in the `t`
+                result
+            }
+            TypeKind::ConditionalType(TConditionalType {
+                check_type,
+                extends_type,
+                true_type,
+                false_type,
+            }) => {
+                let mut result = vec![];
+                result.append(&mut check_type.ftv());
+                result.append(&mut extends_type.ftv());
+                result.append(&mut true_type.ftv());
+                result.append(&mut false_type.ftv());
                 result
             }
         }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -677,7 +677,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, TypeError> {
         }
     };
     if result.is_err() {
-        println!("Can't unify {t1:#?} with {t2:#?}");
+        println!("Can't unify {t1} with {t2}");
     }
     result
 }

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -335,7 +335,7 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
     }
 }
 
-fn flatten_types(t: &Type) -> Vec<Type> {
+pub fn flatten_types(t: &Type) -> Vec<Type> {
     match &t.kind {
         TypeKind::Union(types) => types.iter().flat_map(flatten_types).collect(),
         _ => vec![t.to_owned()],
@@ -346,6 +346,7 @@ pub fn union_types(t1: &Type, t2: &Type) -> Type {
     union_many_types(&[t1.to_owned(), t2.to_owned()])
 }
 
+// TODO: remove any extraneous 'never' types
 pub fn union_many_types(ts: &[Type]) -> Type {
     let types: Vec<_> = ts.iter().flat_map(flatten_types).collect();
 
@@ -385,12 +386,16 @@ pub fn union_many_types(ts: &[Type]) -> Type {
         .chain(lit_types.iter())
         .chain(other_types.iter())
         .cloned()
+        .filter(|t| match &t.kind {
+            TypeKind::Keyword(keyword) => !matches!(keyword, TKeyword::Never),
+            _ => true,
+        })
         .collect();
 
-    if types.len() > 1 {
-        Type::from(TypeKind::Union(types))
-    } else {
-        types[0].clone()
+    match types.len() {
+        0 => Type::from(TypeKind::Keyword(TKeyword::Never)),
+        1 => types[0].clone(),
+        _ => Type::from(TypeKind::Union(types)),
     }
 }
 
@@ -450,6 +455,13 @@ pub fn get_type_params(t: &Type) -> Vec<TVar> {
     match &t.kind {
         TypeKind::Generic(gen) => gen.type_params.to_owned(),
         _ => vec![],
+    }
+}
+
+pub fn unwrap_generic(t: &Type) -> Type {
+    match &t.kind {
+        TypeKind::Generic(TGeneric { t, .. }) => t.as_ref().to_owned(),
+        _ => t.to_owned(),
     }
 }
 

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -219,6 +219,17 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                 },
                 ..mapped.to_owned()
             }),
+            TypeKind::ConditionalType(TConditionalType {
+                check_type,
+                extends_type,
+                true_type,
+                false_type,
+            }) => TypeKind::ConditionalType(TConditionalType {
+                check_type: Box::from(norm_type(check_type, mapping, _ctx)),
+                extends_type: Box::from(norm_type(extends_type, mapping, _ctx)),
+                true_type: Box::from(norm_type(true_type, mapping, _ctx)),
+                false_type: Box::from(norm_type(false_type, mapping, _ctx)),
+            }),
         };
 
         Type {

--- a/crates/crochet_infer/src/visitor.rs
+++ b/crates/crochet_infer/src/visitor.rs
@@ -44,6 +44,17 @@ pub trait Visitor {
             TypeKind::MappedType(mapped) => {
                 self.visit_children(&mut mapped.t);
             }
+            TypeKind::ConditionalType(TConditionalType {
+                check_type,
+                extends_type,
+                true_type,
+                false_type,
+            }) => {
+                self.visit_children(check_type);
+                self.visit_children(extends_type);
+                self.visit_children(true_type);
+                self.visit_children(false_type);
+            }
             TypeKind::Generic(gen) => {
                 self.visit_children(&mut gen.t);
             }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1424,11 +1424,20 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> Result<TypeAnn, ParseE
         "template_literal_type" => todo!(),
         "intersection_type" => {
             let mut cursor = node.walk();
-            let types = node
-                .named_children(&mut cursor)
-                .into_iter()
-                .map(|t| parse_type_ann(&t, src))
-                .collect::<Result<Vec<_>, ParseError>>()?;
+            let mut types: Vec<TypeAnn> = vec![];
+
+            for t in node.named_children(&mut cursor) {
+                let t = parse_type_ann(&t, src)?;
+                match &t.kind {
+                    TypeAnnKind::Intersection(intersection) => {
+                        types.extend(intersection.types.to_owned());
+                    }
+                    _ => {
+                        types.push(t);
+                    }
+                }
+            }
+
             TypeAnnKind::Intersection(IntersectionType {
                 span: node.byte_range(),
                 types,
@@ -1436,11 +1445,20 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> Result<TypeAnn, ParseE
         }
         "union_type" => {
             let mut cursor = node.walk();
-            let types = node
-                .named_children(&mut cursor)
-                .into_iter()
-                .map(|t| parse_type_ann(&t, src))
-                .collect::<Result<Vec<_>, ParseError>>()?;
+            let mut types: Vec<TypeAnn> = vec![];
+
+            for t in node.named_children(&mut cursor) {
+                let t = parse_type_ann(&t, src)?;
+                match &t.kind {
+                    TypeAnnKind::Union(union) => {
+                        types.extend(union.types.to_owned());
+                    }
+                    _ => {
+                        types.push(t);
+                    }
+                }
+            }
+
             TypeAnnKind::Union(UnionType {
                 span: node.byte_range(),
                 types,

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-8.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__types-8.snap
@@ -18,81 +18,70 @@ Ok(
                             span: 33..119,
                             types: [
                                 TypeAnn {
-                                    kind: Union(
-                                        UnionType {
-                                            span: 33..76,
-                                            types: [
-                                                TypeAnn {
-                                                    kind: Object(
-                                                        ObjectType {
-                                                            span: 35..76,
-                                                            elems: [
-                                                                Prop(
-                                                                    TProp {
-                                                                        span: 36..53,
-                                                                        name: "type",
-                                                                        optional: false,
-                                                                        mutable: false,
-                                                                        type_ann: TypeAnn {
-                                                                            kind: Lit(
-                                                                                Str(
-                                                                                    Str {
-                                                                                        span: 42..53,
-                                                                                        value: "mousedown",
-                                                                                    },
-                                                                                ),
-                                                                            ),
-                                                                            span: 42..53,
-                                                                            inferred_type: None,
-                                                                        },
+                                    kind: Object(
+                                        ObjectType {
+                                            span: 35..76,
+                                            elems: [
+                                                Prop(
+                                                    TProp {
+                                                        span: 36..53,
+                                                        name: "type",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: TypeAnn {
+                                                            kind: Lit(
+                                                                Str(
+                                                                    Str {
+                                                                        span: 42..53,
+                                                                        value: "mousedown",
                                                                     },
                                                                 ),
-                                                                Prop(
-                                                                    TProp {
-                                                                        span: 55..64,
-                                                                        name: "x",
-                                                                        optional: false,
-                                                                        mutable: false,
-                                                                        type_ann: TypeAnn {
-                                                                            kind: Keyword(
-                                                                                KeywordType {
-                                                                                    span: 58..64,
-                                                                                    keyword: Number,
-                                                                                },
-                                                                            ),
-                                                                            span: 58..64,
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                                Prop(
-                                                                    TProp {
-                                                                        span: 66..75,
-                                                                        name: "y",
-                                                                        optional: false,
-                                                                        mutable: false,
-                                                                        type_ann: TypeAnn {
-                                                                            kind: Keyword(
-                                                                                KeywordType {
-                                                                                    span: 69..75,
-                                                                                    keyword: Number,
-                                                                                },
-                                                                            ),
-                                                                            span: 69..75,
-                                                                            inferred_type: None,
-                                                                        },
-                                                                    },
-                                                                ),
-                                                            ],
+                                                            ),
+                                                            span: 42..53,
+                                                            inferred_type: None,
                                                         },
-                                                    ),
-                                                    span: 35..76,
-                                                    inferred_type: None,
-                                                },
+                                                    },
+                                                ),
+                                                Prop(
+                                                    TProp {
+                                                        span: 55..64,
+                                                        name: "x",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    span: 58..64,
+                                                                    keyword: Number,
+                                                                },
+                                                            ),
+                                                            span: 58..64,
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
+                                                Prop(
+                                                    TProp {
+                                                        span: 66..75,
+                                                        name: "y",
+                                                        optional: false,
+                                                        mutable: false,
+                                                        type_ann: TypeAnn {
+                                                            kind: Keyword(
+                                                                KeywordType {
+                                                                    span: 69..75,
+                                                                    keyword: Number,
+                                                                },
+                                                            ),
+                                                            span: 69..75,
+                                                            inferred_type: None,
+                                                        },
+                                                    },
+                                                ),
                                             ],
                                         },
                                     ),
-                                    span: 33..76,
+                                    span: 35..76,
                                     inferred_type: None,
                                 },
                                 TypeAnn {


### PR DESCRIPTION
TODO:
- ~automatically determine which type param is being used as the `check_type`~
- ~more test cases (including nested conditional types)~

I'm going to tackle these in a followup PR once I have a more generate `expand_type` function that interleaves `key_of`, `compute_mapped_type`, and `compute_conditional_type`.
