### PR TITLE
Make the conditional_type have right-to-left precendence in grammar.js

### DIFF
--- a/crates/crochet/tests/pass/conditional_types.crochet
+++ b/crates/crochet/tests/pass/conditional_types.crochet
@@ -1,4 +1,8 @@
-type GetTypeName<T extends number | string> = T extends number ? "number" : "string";
+type GetTypeName<T extends boolean| number | string> = 
+    T extends boolean ? "boolean" : 
+    T extends number ? "number" : 
+    "string";
 
-let a: GetTypeName<5> = "number";
-let b: GetTypeName<"hello"> = "string";
+let a: GetTypeName<true> = "boolean";
+let b: GetTypeName<5> = "number";
+let c: GetTypeName<"hello"> = "string";

--- a/crates/crochet/tests/pass/conditional_types.d.ts
+++ b/crates/crochet/tests/pass/conditional_types.d.ts
@@ -1,3 +1,4 @@
-declare type GetTypeName<A extends number | string> = A extends number ? "number" : "string";
-export declare const a: GetTypeName<5>;
-export declare const b: GetTypeName<"hello">;
+declare type GetTypeName<A extends boolean | number | string> = A extends boolean ? "boolean" : A extends number ? "number" : "string";
+export declare const a: GetTypeName<true>;
+export declare const b: GetTypeName<5>;
+export declare const c: GetTypeName<"hello">;

--- a/crates/crochet/tests/pass/conditional_types.js
+++ b/crates/crochet/tests/pass/conditional_types.js
@@ -1,3 +1,4 @@
 ;
-export const a = "number";
-export const b = "string";
+export const a = "boolean";
+export const b = "number";
+export const c = "string";

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3018,4 +3018,20 @@ mod tests {
         "#;
         infer_prog(src);
     }
+
+    #[test]
+    fn nested_conditional_types() {
+        let src = r#"
+        type GetTypeName<T extends boolean| number | string> = 
+            T extends boolean ? "boolean" : 
+            T extends number ? "number" : 
+            "string";
+
+        let a: GetTypeName<true> = "boolean";
+        let b: GetTypeName<5> = "number";
+        let c: GetTypeName<"hello"> = "string";
+        "#;
+
+        infer_prog(src);
+    }
 }

--- a/crates/tree_sitter_crochet/corpus/tsx/types.txt
+++ b/crates/tree_sitter_crochet/corpus/tsx/types.txt
@@ -1506,25 +1506,25 @@ type T<X> = T extends { x: infer X } ? X : never;
           (type_annotation
             (type_identifier))))
       (conditional_type
+        (type_identifier)
+        (type_identifier)
+        (type_identifier)
         (conditional_type
           (type_identifier)
+          (function_type
+            (formal_parameters
+              (required_parameter
+                (binding_identifier
+                  (identifier))
+                (type_annotation
+                  (type_identifier))))
+            (conditional_type
+              (type_identifier)
+              (type_identifier)
+              (type_identifier)
+              (type_identifier)))
           (type_identifier)
-          (type_identifier)
-          (type_identifier))
-        (function_type
-          (formal_parameters
-            (required_parameter
-              (binding_identifier
-                (identifier))
-              (type_annotation
-                (type_identifier))))
-          (conditional_type
-            (type_identifier)
-            (type_identifier)
-            (type_identifier)
-            (type_identifier)))
-        (type_identifier)
-        (type_identifier))))
+          (type_identifier)))))
   (type_alias_declaration
     (type_identifier)
     (type_parameters

--- a/crates/tree_sitter_crochet/grammar.js
+++ b/crates/tree_sitter_crochet/grammar.js
@@ -137,6 +137,19 @@ module.exports = grammar(tsx, {
       return prec.left(seq(...members));
     },
 
+    conditional_type: ($) =>
+      prec.right(
+        seq(
+          field("left", $._type),
+          "extends",
+          field("right", $._type),
+          "?",
+          field("consequence", $._type),
+          ":",
+          field("alternative", $._type)
+        )
+      ),
+
     expression: ($, prev) => {
       // Removes ternary expression
       const choices = prev.members.filter(


### PR DESCRIPTION
This PR fixes #383.
