### PR TITLE
Add support for 'new' expressions

### DIFF
--- a/crates/crochet/tests/pass/new_expressions.crochet
+++ b/crates/crochet/tests/pass/new_expressions.crochet
@@ -1,0 +1,2 @@
+let numbers = new Array(1, 2, 3);
+let letters = new Array("a", "b", "c");

--- a/crates/crochet/tests/pass/new_expressions.d.ts
+++ b/crates/crochet/tests/pass/new_expressions.d.ts
@@ -1,0 +1,2 @@
+export declare const letters: "a" | "b" | "c"[];
+export declare const numbers: 1 | 2 | 3[];

--- a/crates/crochet/tests/pass/new_expressions.js
+++ b/crates/crochet/tests/pass/new_expressions.js
@@ -1,0 +1,2 @@
+export const numbers = new Array(1, 2, 3);
+export const letters = new Array("a", "b", "c");

--- a/crates/crochet_ast/src/types/keyword.rs
+++ b/crates/crochet_ast/src/types/keyword.rs
@@ -10,6 +10,7 @@ pub enum TKeyword {
     Symbol,
     Undefined,
     Never,
+    Object,
 }
 
 impl fmt::Display for TKeyword {
@@ -22,6 +23,7 @@ impl fmt::Display for TKeyword {
             TKeyword::Symbol => write!(f, "symbol"),
             TKeyword::Undefined => write!(f, "undefined"),
             TKeyword::Never => write!(f, "never"),
+            TKeyword::Object => write!(f, "object"),
         }
     }
 }

--- a/crates/crochet_ast/src/types/provenance.rs
+++ b/crates/crochet_ast/src/types/provenance.rs
@@ -1,4 +1,4 @@
-use crate::types::Type;
+use crate::types::{TObjElem, Type};
 use crate::values::{Expr, Pattern, Span, TypeAnn};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6,6 +6,7 @@ pub enum Provenance {
     Expr(Box<Expr>),
     Pattern(Box<Pattern>),
     Type(Box<Type>),
+    TObjElem(Box<TObjElem>),
     TypeAnn(Box<TypeAnn>),
 }
 
@@ -26,6 +27,7 @@ impl Provenance {
                 Some(prov) => prov.get_span(),
                 None => None,
             },
+            Provenance::TObjElem(_) => None, // TODO: add provenance to TObjElem
             Provenance::TypeAnn(type_ann) => Some(type_ann.span.to_owned()),
         }
     }
@@ -46,6 +48,7 @@ impl Provenance {
                 Some(prov) => prov.get_expr(),
                 None => None,
             },
+            Provenance::TObjElem(_) => None,
             Provenance::TypeAnn(_) => None,
         }
     }

--- a/crates/crochet_ast/src/values/expr.rs
+++ b/crates/crochet_ast/src/values/expr.rs
@@ -262,8 +262,15 @@ pub struct Arm {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct New {
+    pub expr: Box<Expr>, // should resolve to an object with a constructor signature
+    pub args: Vec<ExprOrSpread>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExprKind {
     App(App),
+    New(New), // like App but for calling constructors to create a new instance
     Fix(Fix),
     Ident(Ident),
     IfElse(IfElse),

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -382,6 +382,7 @@ pub fn build_type(t: &Type, type_params: &Option<Box<TsTypeParamDecl>>) -> TsTyp
                 types::TKeyword::Symbol => TsKeywordTypeKind::TsSymbolKeyword,
                 types::TKeyword::Undefined => TsKeywordTypeKind::TsUndefinedKeyword,
                 types::TKeyword::Never => TsKeywordTypeKind::TsNeverKeyword,
+                types::TKeyword::Object => TsKeywordTypeKind::TsObjectKeyword,
             };
 
             TsType::TsKeywordType(TsKeywordType {

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -650,10 +650,5 @@ pub fn parse_dts(d_ts_source: &str) -> Result<Context, Error> {
 
     module.visit_with(&mut collector);
 
-    // let values = collector.ctx.scopes.last().unwrap().values.keys();
-    // println!("values = {values:#?}");
-    // let types = collector.ctx.scopes.last().unwrap().types.keys();
-    // println!("types = {types:#?}");
-
     Ok(collector.ctx)
 }

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -42,6 +42,7 @@ pub fn replace_aliases(
         })
         .collect::<Result<HashMap<String, Type>, String>>()?;
 
+    // Why does `type_params` contain different `TVar`s from what's in `type_param_map`?
     for mut param in &mut type_params {
         if let Some(constraint) = &param.constraint {
             param.constraint = Some(Box::from(replace_aliases_rec(

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -591,5 +591,37 @@ fn new_expressions() {
 
     let t = ctx.lookup_value("array").unwrap();
     let result = format!("{}", t);
-    assert_eq!(result, "<t0>mut t0[]");
+    assert_eq!(result, "mut 1 | 2 | 3[]");
+}
+
+#[test]
+fn new_expressions_instantiation_check() {
+    let src = r#"
+    let numbers = new Array(1, 2, 3);
+    let letters = new Array("a", "b", "c");
+    "#;
+
+    let (_, ctx) = infer_prog(src);
+
+    let t = ctx.lookup_value("numbers").unwrap();
+    let result = format!("{}", t);
+    assert_eq!(result, "mut 1 | 2 | 3[]");
+
+    let t = ctx.lookup_value("letters").unwrap();
+    let result = format!("{}", t);
+    assert_eq!(result, r#"mut "a" | "b" | "c"[]"#);
+}
+
+#[test]
+fn rest_fn() {
+    let src = r#"
+    declare let foo: <T>(...items: mut T[]) => string;
+    let result = foo(1, 2, 3);
+    "#;
+
+    let (_, ctx) = infer_prog(src);
+
+    let t = ctx.lookup_value("result").unwrap();
+    let result = format!("{}", t);
+    assert_eq!(result, "string");
 }

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -580,3 +580,16 @@ fn infer_omit() {
 
     assert_eq!(result, "{a: number, mut d?: number}");
 }
+
+#[test]
+fn new_expressions() {
+    let src = r#"
+    let mut array = new Array(1, 2, 3);
+    "#;
+
+    let (_, ctx) = infer_prog(src);
+
+    let t = ctx.lookup_value("array").unwrap();
+    let result = format!("{}", t);
+    assert_eq!(result, "<t0>mut t0[]");
+}

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -584,7 +584,7 @@ fn infer_omit() {
 #[test]
 fn new_expressions() {
     let src = r#"
-    let mut array = new Array(1, 2, 3);
+    let array = new Array(1, 2, 3);
     "#;
 
     let (_, ctx) = infer_prog(src);

--- a/crates/crochet_infer/src/expand_type.rs
+++ b/crates/crochet_infer/src/expand_type.rs
@@ -17,7 +17,6 @@ use crate::util::{
 // `expand_type` is used to expand types that `unify` doesn't know how to unify
 // into something that it does know how to unify.
 pub fn expand_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
-    println!("expand_type t = {t}");
     match &t.kind {
         TypeKind::Var(_) => Ok(t.to_owned()),
         TypeKind::App(_) => Ok(t.to_owned()),
@@ -406,6 +405,15 @@ pub fn get_obj_type(t: &Type, ctx: &Context) -> Result<Type, TypeError> {
                 TKeyword::Boolean => ctx.lookup_type_and_instantiate("Boolean", false)?,
                 TKeyword::String => ctx.lookup_type_and_instantiate("String", false)?,
                 TKeyword::Symbol => ctx.lookup_type_and_instantiate("Symbol", false)?,
+                TKeyword::Object => {
+                    // NOTE: Structural typing allows for extra elems in any object
+                    // so this should be a good equivalent for the `object` keyword.
+                    // There might be an issue with mutable objects since in those
+                    // situations the elements have to match exactly.  This can
+                    // likely be addressed by special-casing unification with `object`
+                    // types.
+                    Type::from(TypeKind::Object(TObject { elems: vec![] }))
+                }
                 // TODO: return TypeError::NotAnObject here
                 TKeyword::Null => return Ok(NEVER_TYPE),
                 TKeyword::Undefined => return Ok(NEVER_TYPE),

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -42,6 +42,7 @@ pub fn unify(t1: &Type, t2: &Type, ctx: &Context) -> Result<Subst, TypeError> {
                 },
                 types::Provenance::Pattern(_) => (),
                 types::Provenance::Type(_) => (),
+                types::Provenance::TObjElem(_) => (),
                 types::Provenance::TypeAnn(_) => (),
             },
             None => (),

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -78,6 +78,13 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
                 update_expr(&mut arg_or_spread.expr, s);
             });
         }
+        ExprKind::New(New { expr, args }) => {
+            update_expr(expr, s);
+            args.iter_mut().for_each(|arg_or_spread| {
+                // TODO: rework args to be less awkward
+                update_expr(&mut arg_or_spread.expr, s);
+            });
+        }
         ExprKind::Fix(Fix { expr }) => {
             update_expr(expr, s);
         }

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__new_expression-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__new_expression-2.snap
@@ -1,0 +1,78 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"new Array(1, 2, 3);\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..19,
+                expr: Expr {
+                    span: 0..18,
+                    kind: New(
+                        New {
+                            expr: Expr {
+                                span: 4..9,
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..9,
+                                        name: "Array",
+                                    },
+                                ),
+                                inferred_type: None,
+                            },
+                            args: [
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 10..11,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 10..11,
+                                                    value: "1",
+                                                },
+                                            ),
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 13..14,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 13..14,
+                                                    value: "2",
+                                                },
+                                            ),
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                },
+                                ExprOrSpread {
+                                    spread: None,
+                                    expr: Expr {
+                                        span: 16..17,
+                                        kind: Lit(
+                                            Num(
+                                                Num {
+                                                    span: 16..17,
+                                                    value: "3",
+                                                },
+                                            ),
+                                        ),
+                                        inferred_type: None,
+                                    },
+                                },
+                            ],
+                        },
+                    ),
+                    inferred_type: None,
+                },
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__new_expression.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__new_expression.snap
@@ -1,0 +1,32 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"new Array();\")"
+---
+Ok(
+    Program {
+        body: [
+            Expr {
+                span: 0..12,
+                expr: Expr {
+                    span: 0..11,
+                    kind: New(
+                        New {
+                            expr: Expr {
+                                span: 4..9,
+                                kind: Ident(
+                                    Ident {
+                                        span: 4..9,
+                                        name: "Array",
+                                    },
+                                ),
+                                inferred_type: None,
+                            },
+                            args: [],
+                        },
+                    ),
+                    inferred_type: None,
+                },
+            },
+        ],
+    },
+)


### PR DESCRIPTION
TODO:
- [x] if there are multiple constructor signatures, pick the best one
- [x] handle type params properly by instantiating new type variables
- [x] handle type references properly by creating type variables for them