### PR TITLE
Remove all uses of error-stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,17 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +168,6 @@ dependencies = [
  "crochet_dts",
  "crochet_infer",
  "crochet_parser",
- "error-stack",
  "insta",
  "pretty_assertions",
  "strip-ansi-escapes",
@@ -208,7 +196,6 @@ dependencies = [
  "crochet_dts",
  "crochet_infer",
  "crochet_parser",
- "error-stack",
  "insta",
  "pretty_assertions",
  "tree-sitter",
@@ -242,7 +229,6 @@ dependencies = [
  "crochet_infer",
  "crochet_parser",
  "defaultmap",
- "error-stack",
  "insta",
  "memoize",
  "swc_atoms",
@@ -261,7 +247,6 @@ dependencies = [
  "crochet_ast",
  "crochet_parser",
  "defaultmap",
- "error-stack",
  "insta",
  "itertools",
 ]
@@ -271,7 +256,6 @@ name = "crochet_parser"
 version = "0.1.0"
 dependencies = [
  "crochet_ast",
- "error-stack",
  "insta",
  "itertools",
  "pretty_assertions",
@@ -401,17 +385,6 @@ dependencies = [
  "proc-macro2",
  "swc_macros_common",
  "syn",
-]
-
-[[package]]
-name = "error-stack"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d224e04b2d93d974c08e375dac9b8d1a513846e44c6666450a57b1ed963f9"
-dependencies = [
- "anyhow",
- "owo-colors",
- "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -549,12 +522,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
@@ -769,15 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-dependencies = [
- "supports-color",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,16 +947,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver 1.0.14",
+ "semver",
 ]
 
 [[package]]
@@ -1027,12 +976,6 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "semver-parser"
@@ -1122,7 +1065,7 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "regex",
- "rustc_version 0.2.3",
+ "rustc_version",
  "serde",
  "serde_json",
  "url",
@@ -1193,16 +1136,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "supports-color"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
-dependencies = [
- "atty",
- "is_ci",
-]
 
 [[package]]
 name = "swc_atoms"

--- a/crates/crochet/Cargo.toml
+++ b/crates/crochet/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ariadne = "0.1.5"
-error-stack = "0.2.4"
 tree-sitter = "0.20.8"
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 crochet_codegen = { version = "0.1.0", path = "../crochet_codegen" }

--- a/crates/crochet/src/compile_error.rs
+++ b/crates/crochet/src/compile_error.rs
@@ -1,13 +1,16 @@
-use error_stack::Context;
 use std::fmt;
 
+use crochet_infer::TypeError;
+use crochet_parser::ParseError;
+
 #[derive(Debug, PartialEq, Eq)]
-pub struct CompileError;
+pub enum CompileError {
+    TypeError(Vec<TypeError>),
+    ParseError(ParseError),
+}
 
 impl fmt::Display for CompileError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "CompileError")
     }
 }
-
-impl Context for CompileError {}

--- a/crates/crochet_cli/Cargo.toml
+++ b/crates/crochet_cli/Cargo.toml
@@ -15,6 +15,5 @@ crochet_parser = { version = "0.1.0", path = "../crochet_parser" }
 tree_sitter_crochet = { version = "0.1.0", path = "../tree_sitter_crochet" }
 
 [dev-dependencies]
-error-stack = "0.2.4"
 insta = "1.13.0"
 pretty_assertions = "1.2.1"

--- a/crates/crochet_cli/tests/integration_test.rs
+++ b/crates/crochet_cli/tests/integration_test.rs
@@ -19,7 +19,17 @@ fn infer(input: &str) -> String {
         }
         _ => Err(vec![TypeError::Unspecified]),
     };
-    format!("{}", result.unwrap())
+    match result {
+        Ok(t) => t.to_string(),
+        Err(error) => {
+            let message = error
+                .iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            panic!("{message}");
+        }
+    }
 }
 
 fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
@@ -33,9 +43,18 @@ fn infer_prog(src: &str) -> (Program, crochet_infer::Context) {
     };
     // println!("prog = {:#?}", &prog);
     let mut ctx = crochet_infer::Context::default();
-    let ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
-    (prog, ctx)
+    match crochet_infer::infer_prog(&mut prog, &mut ctx) {
+        Ok(ctx) => (prog, ctx),
+        Err(error) => {
+            let message = error
+                .iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            panic!("{message}");
+        }
+    }
 }
 
 fn infer_prog_with_type_error(src: &str) -> Vec<String> {
@@ -98,13 +117,13 @@ fn infer_let_fn_with_param_types() {
 }
 
 #[test]
-#[should_panic = "Can't unify string with number"]
+#[should_panic = "TypeError::UnificationError: string, number"]
 fn infer_fn_with_incorrect_param_types() {
     infer("(a: string, b: boolean) => a + b;");
 }
 
 #[test]
-#[should_panic = "Can't unify string with number"]
+#[should_panic = "TypeError::UnificationError: string, number"]
 fn infer_let_fn_with_incorrect_param_types() {
     let src = "let add = (a: string, b: boolean) => a + b;";
     infer_prog(src);
@@ -471,8 +490,6 @@ fn infer_let_decl_with_incorrect_type_ann() {
     assert_eq!(
         error_messages,
         vec![
-            "Unification failure",
-            "Location",
             // Ideally we'd want the error message to be something like:
             // "can't assign '10' to 'string'"
             "TypeError::UnificationError: 10, string"
@@ -538,7 +555,7 @@ fn calling_a_fn_with_an_obj_subtype() {
 }
 
 #[test]
-#[should_panic = "Unification failure"]
+#[should_panic = "TypeError::UnificationError: {x: 5}, {x: number, y: number}"]
 fn calling_a_fn_with_an_obj_missing_a_property() {
     let src = r#"
     declare let mag: (p: {x: number, y: number}) => number;
@@ -584,16 +601,12 @@ fn infer_tuple_with_type_annotation_and_incorrect_element() {
 
     assert_eq!(
         error_messages,
-        vec![
-            "Unification failure",
-            "Location",
-            "TypeError::UnificationError: 3, boolean"
-        ]
+        vec!["TypeError::UnificationError: 3, boolean"]
     );
 }
 
 #[test]
-#[should_panic = "not enough elements to unpack"]
+#[should_panic = "TypeError::NotEnoughElementsToUnpack"]
 fn infer_tuple_with_not_enough_elements() {
     let src = r#"let tuple: [number, string, boolean] = [1, "two"];"#;
     infer_prog(src);
@@ -799,10 +812,7 @@ fn infer_function_overloading_with_incorrect_args() {
     "#;
     let error_messages = infer_prog_with_type_error(src);
 
-    assert_eq!(
-        error_messages,
-        vec!["Location", "TypeError::NoValidOverload"]
-    );
+    assert_eq!(error_messages, vec!["TypeError::NoValidOverload"]);
 }
 
 #[test]
@@ -1160,7 +1170,7 @@ fn infer_destructure_tuple() {
 }
 
 #[test]
-#[should_panic = "not enough elements to unpack"]
+#[should_panic = "TypeError::NotEnoughElementsToUnpack"]
 fn infer_destructure_tuple_too_many_identifiers() {
     let src = r#"
     let [a, b, c] = ["hello", 5];
@@ -1221,7 +1231,7 @@ fn infer_jsx() {
 }
 
 #[test]
-#[should_panic = "Unification failure"]
+#[should_panic = r#"TypeError::UnificationError: "hello", number,TypeError::UnificationError: "world", number"#]
 fn incorrect_args() {
     let src = r#"
     let add = (a, b) => a + b;
@@ -1367,7 +1377,7 @@ fn codegen_if_let_with_rename() {
 }
 
 #[test]
-#[should_panic = "Unification failure"]
+#[should_panic = r#"TypeError::UnificationError: "hello", number"#]
 fn infer_if_let_with_type_error() {
     let src = r#"
     let p = {x: "hello", y: "world"};

--- a/crates/crochet_dts/Cargo.toml
+++ b/crates/crochet_dts/Cargo.toml
@@ -17,6 +17,5 @@ crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 crochet_infer = { version = "0.1.0", path = "../crochet_infer" }
 
 [dev-dependencies]
-error-stack = "0.2.4"
 insta = "1.13.0"
 crochet_parser = { version = "0.1.0", path = "../crochet_parser" }

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -1,38 +1,12 @@
-use error_stack::Report;
 use std::fs;
 
 use crochet_ast::values::Program;
 use crochet_dts::parse_dts::*;
-use crochet_infer::expand_type;
+use crochet_infer::{expand_type, TypeError};
 use crochet_parser::parse;
 
-use core::{any::TypeId, panic::Location};
-use error_stack::{AttachmentKind, FrameKind};
-
-pub fn messages<E>(report: &Report<E>) -> Vec<String> {
-    report
-        .frames()
-        .map(|frame| match frame.kind() {
-            FrameKind::Context(context) => context.to_string(),
-            FrameKind::Attachment(AttachmentKind::Printable(attachment)) => attachment.to_string(),
-            FrameKind::Attachment(AttachmentKind::Opaque(_)) => {
-                #[cfg(all(rust_1_65, feature = "std"))]
-                if frame.type_id() == TypeId::of::<Backtrace>() {
-                    return String::from("Backtrace");
-                }
-                #[cfg(feature = "spantrace")]
-                if frame.type_id() == TypeId::of::<SpanTrace>() {
-                    return String::from("SpanTrace");
-                }
-                if frame.type_id() == TypeId::of::<Location>() {
-                    String::from("Location")
-                } else {
-                    String::from("opaque")
-                }
-            }
-            FrameKind::Attachment(_) => panic!("attachment was not covered"),
-        })
-        .collect()
+pub fn messages(report: &[TypeError]) -> Vec<String> {
+    report.iter().map(|error| error.to_string()).collect()
 }
 
 static LIB_ES5_D_TS: &str = "../../node_modules/typescript/lib/lib.es5.d.ts";

--- a/crates/crochet_infer/Cargo.toml
+++ b/crates/crochet_infer/Cargo.toml
@@ -10,7 +10,6 @@ ariadne = "0.1.5"
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 array_tool = "1.0.3"
 defaultmap = "0.5.0"
-error-stack = "0.2.4"
 itertools = "0.10.3"
 
 [dev-dependencies]

--- a/crates/crochet_infer/src/infer_fn_param.rs
+++ b/crates/crochet_infer/src/infer_fn_param.rs
@@ -1,4 +1,3 @@
-use error_stack::Result;
 use std::collections::HashMap;
 
 use crochet_ast::types::{self as types, TFnParam, TKeyword, TPat, Type, TypeKind};
@@ -16,7 +15,7 @@ pub fn infer_fn_param(
     param: &mut EFnParam,
     ctx: &mut Context,
     type_param_map: &HashMap<String, Type>,
-) -> Result<(Subst, Assump, TFnParam), TypeError> {
+) -> Result<(Subst, Assump, TFnParam), Vec<TypeError>> {
     // Keeps track of all of the variables the need to be introduced by this pattern.
     // let mut new_vars: Assump = Assump::default();
 

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -26,39 +26,12 @@ pub use util::{
 
 #[cfg(test)]
 mod tests {
-    use core::{any::TypeId, panic::Location};
     use crochet_parser::*;
-    use error_stack::Report;
-    use error_stack::{AttachmentKind, FrameKind};
 
     use super::*;
 
-    pub fn messages<E>(report: &Report<E>) -> Vec<String> {
-        report
-            .frames()
-            .map(|frame| match frame.kind() {
-                FrameKind::Context(context) => context.to_string(),
-                FrameKind::Attachment(AttachmentKind::Printable(attachment)) => {
-                    attachment.to_string()
-                }
-                FrameKind::Attachment(AttachmentKind::Opaque(_)) => {
-                    #[cfg(all(rust_1_65, feature = "std"))]
-                    if frame.type_id() == TypeId::of::<Backtrace>() {
-                        return String::from("Backtrace");
-                    }
-                    #[cfg(feature = "spantrace")]
-                    if frame.type_id() == TypeId::of::<SpanTrace>() {
-                        return String::from("SpanTrace");
-                    }
-                    if frame.type_id() == TypeId::of::<Location>() {
-                        String::from("Location")
-                    } else {
-                        String::from("opaque")
-                    }
-                }
-                FrameKind::Attachment(_) => panic!("attachment was not covered"),
-            })
-            .collect()
+    pub fn messages(report: &[TypeError]) -> Vec<String> {
+        report.iter().map(|error| error.to_string()).collect()
     }
 
     fn infer(input: &str) -> String {

--- a/crates/crochet_infer/src/type_error.rs
+++ b/crates/crochet_infer/src/type_error.rs
@@ -1,4 +1,3 @@
-use error_stack::Context;
 use std::fmt;
 
 use crochet_ast::types::Type;
@@ -133,5 +132,3 @@ impl fmt::Display for TypeError {
         }
     }
 }
-
-impl Context for TypeError {}

--- a/crates/crochet_infer/src/unify_mut.rs
+++ b/crates/crochet_infer/src/unify_mut.rs
@@ -1,19 +1,17 @@
 use crochet_ast::types::Type;
-use error_stack::{Report, Result};
 
 use crate::context::Context;
 use crate::substitutable::Subst;
 use crate::type_error::TypeError;
 
-pub fn unify_mut(t1: &Type, t2: &Type, _ctx: &Context) -> Result<Subst, TypeError> {
+pub fn unify_mut(t1: &Type, t2: &Type, _ctx: &Context) -> Result<Subst, Vec<TypeError>> {
     if t1 == t2 {
         println!("unify_mut: {t1} == {t2}");
         Ok(Subst::new())
     } else {
-        Err(Report::new(TypeError::UnificationError(
+        Err(vec![TypeError::UnificationError(
             Box::from(t1.to_owned()),
             Box::from(t2.to_owned()),
-        ))
-        .attach_printable(format!("Couldn't unify {t1} and {t2}")))
+        )])
     }
 }

--- a/crates/crochet_parser/Cargo.toml
+++ b/crates/crochet_parser/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
-error-stack = "0.2.4"
 itertools = "0.10.3"
 tree-sitter = "0.20.8"
 tree_sitter_crochet = { version = "0.1.0", path = "../tree_sitter_crochet" }

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -1972,7 +1972,10 @@ mod tests {
         match parse("(...a, ...b) => true") {
             Ok(_) => panic!("expected test parse() to return an error"),
             Err(report) => {
-                assert_eq!(messages(&report), "ParseError");
+                assert_eq!(
+                    messages(&report),
+                    "ParseError: failed to parse: '(...a, ...b) => true'"
+                );
             }
         }
     }

--- a/crates/crochet_parser/src/parse_error.rs
+++ b/crates/crochet_parser/src/parse_error.rs
@@ -1,13 +1,29 @@
-use error_stack::Context;
 use std::fmt;
 
+// TODO: turn this into an enum so that we can report different kinds of parse
+// errors
 #[derive(Debug, PartialEq, Eq)]
-pub struct ParseError;
+pub struct ParseError {
+    pub message: String,
+}
 
 impl fmt::Display for ParseError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "ParseError")
+        let Self { message } = self;
+        write!(fmt, "ParseError: {message}")
     }
 }
 
-impl Context for ParseError {}
+impl From<&str> for ParseError {
+    fn from(message: &str) -> Self {
+        ParseError {
+            message: message.to_owned(),
+        }
+    }
+}
+
+impl From<String> for ParseError {
+    fn from(message: String) -> Self {
+        ParseError { message }
+    }
+}


### PR DESCRIPTION
The reason for this is that error-stack doesn't support cyclic data types b/c they aren't thread safe.  Additionally, we're going to need to change error handling quite significantly if we want to support reporting warnings or allowing unification to continuing after reporting errors with function call param/args mismatches.

TODO:
- [x] fix all of the failing tests