### PR TITLE
Use grcov to generate lcov report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
 
+      - name: Install grcov
+        run: rustup component add llvm-tools-preview
+
       - name: Test
         run: CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,38 +126,43 @@ jobs:
         with:
           command: test
 
-  # coverage:
-  #   name: Coverage
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Setup Nodejs and npm
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
-  #         cache: "yarn"
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "yarn"
 
-  #     - name: Install node_modules
-  #       run: yarn install --frozen-lockfile
+      - name: Install node_modules
+        run: yarn install --frozen-lockfile
 
-  #     - name: Cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
 
-  #     - name: Run cargo-tarpaulin
-  #       uses: actions-rs/tarpaulin@v0.1
-  #       with:
-  #         version: "0.20.0"
-  #         args: "--exclude-files *_test.rs -- --test-threads 1"
+      - name: Test
+        run: CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test
 
-  #     - name: Upload to codecov.io
-  #       uses: codecov/codecov-action@v3
+      - name: Create Folder
+        run: mkdir -p target/coverage
+
+      - name: Generate lcov
+        run: grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/tests.lcov
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          directory: target/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "**.crochet"
       - "**.js"
       - "**.rs"
+      - ".github/workflows/ci.yml"
 
 jobs:
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-coverage
 
       - name: Install grcov
+        run: cargo install grcov
+
+      - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
       - name: Test


### PR DESCRIPTION
This PR is based on https://blog.rng0.io/how-to-do-code-coverage-in-rust, but opts not to use `xtask`.