### PR TITLE
Boostrap LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crochet_lsp"
+version = "0.1.0"
+dependencies = [
+ "crochet_ast",
+ "crochet_dts",
+ "crochet_infer",
+ "crochet_parser",
+ "lsp-server",
+ "lsp-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "crochet_parser"
 version = "0.1.0"
 dependencies = [
@@ -263,6 +277,25 @@ dependencies = [
  "tree-sitter",
  "tree_sitter_crochet",
  "unescape",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -641,6 +674,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "lsp-server"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70570c1c29cf6654029b8fe201a5507c153f0d85be6f234d471d756bc36775a"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.93.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,11 +925,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -986,18 +1053,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,13 +1073,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1415,13 +1493,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1556,6 +1634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe8d9274f490a36442acb4edfd0c4e473fdfc6a8b5cd32f28a0235761aedbe"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,12 +1655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1664,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/crochet_codegen",
     "crates/crochet_dts",
     "crates/crochet_infer",
+    "crates/crochet_lsp",
     "crates/crochet_parser",
     "crates/tree_sitter_crochet",
 ]

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -149,7 +149,7 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                     match prop {
                         Ok(prop) => Some(prop),
                         Err(msg) => {
-                            println!("Err: {msg}");
+                            eprintln!("Err: {msg}");
                             None
                         }
                     }
@@ -324,7 +324,7 @@ fn infer_fn_params(params: &[TsFnParam], ctx: &Context) -> Result<Vec<TFnParam>,
             }
             TsFnParam::Array(_) => {
                 // TODO: create a tuple pattern
-                println!("skipping TsFnParam::Array(_)");
+                eprintln!("skipping TsFnParam::Array(_)");
                 None
             }
             TsFnParam::Rest(rest) => {
@@ -347,7 +347,7 @@ fn infer_fn_params(params: &[TsFnParam], ctx: &Context) -> Result<Vec<TFnParam>,
             }
             TsFnParam::Object(_) => {
                 // TODO: create an object pattern
-                println!("skipping TsFnParam::Object(_)");
+                eprintln!("skipping TsFnParam::Object(_)");
                 None
             }
         })
@@ -679,7 +679,7 @@ fn infer_interface_decl(decl: &TsInterfaceDecl, ctx: &Context) -> Result<Scheme,
             match prop {
                 Ok(prop) => Some(prop),
                 Err(msg) => {
-                    println!("Err: {msg}");
+                    eprintln!("Err: {msg}");
                     None
                 }
             }
@@ -732,11 +732,11 @@ impl Visit for InterfaceCollector {
         let name = decl.id.sym.to_string();
         match infer_type_alias_decl(decl, &self.ctx) {
             Ok(scheme) => {
-                // println!("inferring: {name} as type: {t}");
+                eprintln!("inferring: {name} as scheme: {scheme}");
                 self.ctx.insert_scheme(name, scheme)
             }
-            Err(_err) => {
-                // println!("couldn't infer {name}, {err:#?}")
+            Err(err) => {
+                eprintln!("couldn't infer {name}, {err:#?}")
             }
         }
     }
@@ -753,7 +753,7 @@ impl Visit for InterfaceCollector {
                     None => self.ctx.insert_scheme(name, scheme),
                 };
             }
-            Err(_) => println!("couldn't infer {name}"),
+            Err(_) => eprintln!("couldn't infer {name}"),
         }
     }
 
@@ -761,7 +761,7 @@ impl Visit for InterfaceCollector {
         match &decl.id {
             TsModuleName::Ident(id) => {
                 let name = id.sym.to_string();
-                println!("module: {name}");
+                eprintln!("module: {name}");
                 self.namespace.push(name);
                 decl.visit_children_with(self);
                 self.namespace.pop();
@@ -820,6 +820,8 @@ pub fn parse_dts(d_ts_source: &str) -> Result<Context, Error> {
         &mut errors,
     )?;
 
+    eprintln!("after parse_file_as_module");
+
     let mut collector = InterfaceCollector {
         ctx: Context::default(),
         comments,
@@ -827,6 +829,8 @@ pub fn parse_dts(d_ts_source: &str) -> Result<Context, Error> {
     };
 
     module.visit_with(&mut collector);
+
+    eprintln!("after visit_with");
 
     Ok(collector.ctx)
 }

--- a/crates/crochet_infer/src/expand_type.rs
+++ b/crates/crochet_infer/src/expand_type.rs
@@ -38,7 +38,7 @@ pub fn expand_type(t: &Type, ctx: &Context) -> Result<Type, Vec<TypeError>> {
 fn expand_alias_type(alias: &TRef, ctx: &Context) -> Result<Type, Vec<TypeError>> {
     let name = &alias.name;
     let scheme = ctx.lookup_scheme(name)?;
-    println!("scheme = {scheme}");
+    eprintln!("scheme = {scheme}");
 
     let type_params = scheme.type_params;
 
@@ -47,7 +47,7 @@ fn expand_alias_type(alias: &TRef, ctx: &Context) -> Result<Type, Vec<TypeError>
     if let Some(type_args) = &alias.type_args {
         if type_args.len() != type_params.len() {
             // TODO: rename this TypeParamTypeArgCountMismatch
-            println!("type_args.len() != type_params.len()");
+            eprintln!("type_args.len() != type_params.len()");
             return Err(vec![TypeError::TypeInstantiationFailure]);
         }
 

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -383,6 +383,9 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), V
             t_params.apply(&s);
             t.apply(&s);
 
+            // TODO: Update the inferred_type on each param to equal the
+            // corresponding type from t_params.
+
             Ok((s, t))
         }
         ExprKind::Let(Let {
@@ -397,7 +400,7 @@ pub fn infer_expr(ctx: &mut Context, expr: &mut Expr) -> Result<(Subst, Type), V
                 let (init_s, init_t) = infer_expr(ctx, init)?;
 
                 if init_t.kind != TypeKind::Keyword(TKeyword::Undefined) {
-                    println!("WARNING: {init_t} was not assigned");
+                    eprintln!("WARNING: {init_t} was not assigned");
                 }
 
                 let (body_s, mut body_t) = infer_expr(ctx, body)?;

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
         let mut prog = match result {
             Ok(prog) => prog,
             Err(err) => {
-                println!("err = {:?}", err);
+                eprintln!("err = {:?}", err);
                 panic!("Error parsing expression");
             }
         };
@@ -2904,7 +2904,7 @@ mod tests {
         match infer::infer_prog(&mut prog, &mut ctx) {
             Ok(_) => panic!("expected an error"),
             Err(report) => {
-                println!("{report:#?}");
+                eprintln!("{report:#?}");
                 let messages = messages(&report);
                 assert_eq!(
                     messages,
@@ -2929,7 +2929,7 @@ mod tests {
         match infer::infer_prog(&mut prog, &mut ctx) {
             Ok(_) => panic!("expected an error"),
             Err(report) => {
-                println!("{report:#?}");
+                eprintln!("{report:#?}");
                 let messages = messages(&report);
                 assert_eq!(
                     messages,

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -175,7 +175,7 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &Context) -> Result<Subst, Vec<T
                 .iter()
                 .filter_map(|elem| match elem {
                     TObjElem::Call(call) => {
-                        println!("handling callable");
+                        eprintln!("handling callable");
                         let lam = Type::from(TypeKind::Lam(TLam {
                             params: call.params.to_owned(),
                             ret: call.ret.to_owned(),
@@ -185,7 +185,7 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &Context) -> Result<Subst, Vec<T
                         } else {
                             instantiate_callable(ctx, call)
                         };
-                        println!("callable instantiated as {t}");
+                        eprintln!("callable instantiated as {t}");
                         Some(t)
                     }
                     TObjElem::Constructor(_) => None,
@@ -712,7 +712,7 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &Context) -> Result<Subst, Vec<T
         }
     };
     if result.is_err() {
-        println!("Can't unify {t1} with {t2}");
+        eprintln!("Can't unify {t1} with {t2}");
     }
     result
 }
@@ -734,7 +734,7 @@ fn bind(
     // | otherwise       = return $ Map.singleton a t
     match &t.kind {
         TypeKind::Var(other_tv) if other_tv == tv => {
-            println!("other_tv = {other_tv:#?}, tv = {tv:#?}");
+            eprintln!("other_tv = {other_tv:#?}, tv = {tv:#?}");
             Ok(Subst::default())
         }
         _ => {

--- a/crates/crochet_infer/src/unify_mut.rs
+++ b/crates/crochet_infer/src/unify_mut.rs
@@ -6,7 +6,7 @@ use crate::type_error::TypeError;
 
 pub fn unify_mut(t1: &Type, t2: &Type, _ctx: &Context) -> Result<Subst, Vec<TypeError>> {
     if t1 == t2 {
-        println!("unify_mut: {t1} == {t2}");
+        eprintln!("unify_mut: {t1} == {t2}");
         Ok(Subst::new())
     } else {
         Err(vec![TypeError::UnificationError(

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -714,6 +714,6 @@ mod tests {
 
         let s = compose_subs(&s2, &s1);
 
-        println!("s = {s:#?}");
+        eprintln!("s = {s:#?}");
     }
 }

--- a/crates/crochet_lsp/Cargo.toml
+++ b/crates/crochet_lsp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "crochet_lsp"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lsp-server = "0.6.0"
+lsp-types = "0.93.2"
+serde = "1.0.152"
+serde_json = "1.0.91"
+crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
+crochet_dts = { version = "0.1.0", path = "../crochet_dts" }
+crochet_infer = { version = "0.1.0", path = "../crochet_infer" }
+crochet_parser = { version = "0.1.0", path = "../crochet_parser" }

--- a/crates/crochet_lsp/src/main.rs
+++ b/crates/crochet_lsp/src/main.rs
@@ -1,0 +1,125 @@
+use std::error::Error;
+use std::fs;
+
+use lsp_server::{Connection, ExtractError, Message, Request, RequestId, Response};
+use lsp_types::{
+    request::HoverRequest, Hover, HoverContents, HoverProviderCapability, InitializeParams,
+    MarkedString, ServerCapabilities,
+};
+
+use crochet_dts::parse_dts::parse_dts;
+use crochet_parser::parse;
+
+static LIB_ES5_D_TS: &str = "../../../node_modules/typescript/lib/lib.es5.d.ts";
+
+fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
+    // Note that  we must have our logging only write out to stderr.
+    eprintln!("starting generic LSP server");
+
+    // Create the transport. Includes the stdio (stdin and stdout) versions but this could
+    // also be implemented to use sockets or HTTP.
+    let (connection, io_threads) = Connection::stdio();
+
+    // Run the server and wait for the two threads to end (typically by trigger LSP Exit event).
+    let server_capabilities = serde_json::to_value(&ServerCapabilities {
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let initialization_params = connection.initialize(server_capabilities)?;
+    main_loop(connection, initialization_params)?;
+    io_threads.join()?;
+
+    // Shut down gracefully.
+    eprintln!("shutting down server");
+    Ok(())
+}
+
+fn main_loop(
+    connection: Connection,
+    params: serde_json::Value,
+    // We use `dyn Error` here b/c we're mixing different APIs when generate
+    // different error structs
+) -> Result<(), Box<dyn Error + Sync + Send>> {
+    let lib = fs::read_to_string(LIB_ES5_D_TS).unwrap();
+    let _params: InitializeParams = serde_json::from_value(params).unwrap();
+
+    eprintln!("starting example main loop");
+    for msg in &connection.receiver {
+        eprintln!("got msg: {msg:?}");
+        match msg {
+            Message::Request(req) => {
+                if connection.handle_shutdown(&req)? {
+                    return Ok(());
+                }
+                eprintln!("got request: {req:?}");
+                match cast::<HoverRequest>(req) {
+                    Ok((id, params)) => {
+                        eprintln!("got hoverRequest request #{id}: {params:?}");
+                        let in_path = params
+                            .text_document_position_params
+                            .text_document
+                            .uri
+                            .to_file_path()
+                            .unwrap(); // TODO: generate a real error if the path doesn't exist
+                        eprintln!("reading {}", in_path.to_string_lossy());
+                        let input = fs::read_to_string(in_path).unwrap();
+                        eprintln!("parsing .d.ts");
+                        let mut ctx = match parse_dts(&lib) {
+                            Ok(ctx) => {
+                                eprintln!("success");
+                                ctx
+                            }
+                            Err(_) => {
+                                eprintln!("error");
+                                panic!("parsing .d.ts file failed");
+                            }
+                        };
+                        eprintln!("parsed lib");
+                        // Update ParseError to implement Error + Sync + Send
+                        let mut prog = parse(&input).unwrap();
+                        eprintln!("parsed input");
+                        // Update TypeError to implement Error + Sync + Send
+                        crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
+                        eprintln!("inferred prog");
+                        // eprintln!("prog = {prog:#?}");
+
+                        let result = Some(Hover {
+                            contents: HoverContents::Scalar(MarkedString::String(String::from(
+                                "Hello, world!",
+                            ))),
+                            range: None,
+                        });
+                        let result = serde_json::to_value(&result).unwrap();
+                        let resp = Response {
+                            id,
+                            result: Some(result),
+                            error: None,
+                        };
+                        connection.sender.send(Message::Response(resp))?;
+                        continue;
+                    }
+                    Err(err @ ExtractError::JsonError { .. }) => panic!("{err:?}"),
+                    Err(ExtractError::MethodMismatch(req)) => req,
+                };
+                // ...
+            }
+            Message::Response(resp) => {
+                eprintln!("got response: {resp:?}");
+            }
+            Message::Notification(not) => {
+                eprintln!("got notification: {not:?}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cast<R>(req: Request) -> Result<(RequestId, R::Params), ExtractError<Request>>
+where
+    R: lsp_types::request::Request,
+    R::Params: serde::de::DeserializeOwned,
+{
+    req.extract(R::METHOD)
+}

--- a/crates/crochet_parser/src/lib.rs
+++ b/crates/crochet_parser/src/lib.rs
@@ -37,7 +37,7 @@ fn log(str: &str) {
 
 #[cfg(target_family = "unix")]
 fn log(str: &str) {
-    println!("{}", str);
+    eprintln!("{}", str);
 }
 
 pub fn parse(src: &str) -> Result<Program, ParseError> {
@@ -1496,7 +1496,7 @@ fn parse_type_ann(node: &tree_sitter::Node, src: &str) -> Result<TypeAnn, ParseE
                 .named_children(&mut cursor)
                 .into_iter()
                 .map(|elem| {
-                    println!("parsing elem: {elem:#?}");
+                    eprintln!("parsing elem: {elem:#?}");
                     parse_type_ann(&elem, src)
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;

--- a/packages/vscode-crochet/package.json
+++ b/packages/vscode-crochet/package.json
@@ -61,6 +61,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
+    "vscode-languageclient": "^8.0.2",
     "web-tree-sitter": "^0.20.7"
   }
 }

--- a/packages/vscode-crochet/yarn.lock
+++ b/packages/vscode-crochet/yarn.lock
@@ -917,7 +917,7 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -1188,7 +1188,7 @@ semver@^5.4.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.3.7:
+semver@^7.3.5, semver@^7.3.7:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -1431,6 +1431,33 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
+
+vscode-languageclient@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz#f1f23ce8c8484aa11e4b7dfb24437d3e59bb61c6"
+  integrity sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==
+  dependencies:
+    minimatch "^3.0.4"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.2"
+
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
+  dependencies:
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
+
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
 web-tree-sitter@^0.20.7:
   version "0.20.7"


### PR DESCRIPTION
This PR implements a very simple LSP that responds to `HoverRequest`s.  As part of the request, it parses the code in the file from the hover request was made from and does type inference.  It responds with a generic "Hello world!" string.  In the future we'll determine the type for the symbol at the given cursor location, but we need #405 before that can happen.

One thing that took me a while to figure out what was that all of the `println!()`s that I had scattered around were interfering with the stdio communication between the LSP server and the client.  This PR changes all of them to be `eprintln!()`s so that their output goes to stderr instead.

I did some profiling and while each request takes about 75~100ms, the majority of the time is taken up by reading/parsing of lib.es5.d.ts.  The parsing/inferring of the rest_param.crochet fixture test file only takes 5ms.