### PR TITLE
Initial implementation of hover to show inferred type in LSP

### DIFF
--- a/crates/crochet_ast/src/values/expr.rs
+++ b/crates/crochet_ast/src/values/expr.rs
@@ -13,6 +13,7 @@ pub struct Program {
 }
 
 // TODO: Update Statement to mimic structure of Expr/ExprKind
+// TODO: Update Statement to have an .inferred_type field like Expr
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
     VarDecl {
@@ -197,6 +198,7 @@ pub struct Tuple {
     pub elems: Vec<ExprOrSpread>,
 }
 
+// TODO: make this a enum instead of a struct
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExprOrSpread {
     pub spread: Option<Span>,

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -15,6 +15,7 @@ use crate::scheme::instantiate_callable;
 use crate::substitutable::{Subst, Substitutable};
 use crate::type_error::TypeError;
 use crate::unify::unify;
+use crate::update::update_pattern;
 use crate::util::*;
 use crate::visitor::Visitor;
 
@@ -691,6 +692,8 @@ fn infer_let(
     for (name, binding) in pa {
         ctx.insert_binding(name.to_owned(), binding.to_owned());
     }
+
+    update_pattern(pat, &s1);
 
     let (s2, t2) = infer_expr(ctx, body)?;
 

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -211,6 +211,7 @@ fn infer_pattern_rec(
     };
     let mut t = result?;
 
+    pat.inferred_type = Some(t.clone());
     t.provenance = Some(Box::from(Provenance::Pattern(Box::from(pat.to_owned()))));
 
     Ok(t)

--- a/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__tests__infer_ident_inside_lam.snap
@@ -45,7 +45,792 @@ Program {
                         },
                     },
                 ),
-                inferred_type: None,
+                inferred_type: Some(
+                    Type {
+                        kind: Lam(
+                            TLam {
+                                params: [
+                                    TFnParam {
+                                        pat: Ident(
+                                            BindingIdent {
+                                                name: "a",
+                                                mutable: false,
+                                            },
+                                        ),
+                                        t: Type {
+                                            kind: Keyword(
+                                                Number,
+                                            ),
+                                            mutable: false,
+                                            provenance: Some(
+                                                Type(
+                                                    Type {
+                                                        kind: Var(
+                                                            TVar {
+                                                                id: 2,
+                                                                constraint: None,
+                                                            },
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Pattern(
+                                                                Pattern {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 11,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 12,
+                                                                        },
+                                                                    },
+                                                                    span: 11..12,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "a",
+                                                                            mutable: false,
+                                                                            span: 11..12,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 11,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 12,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 2,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: None,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                        optional: false,
+                                    },
+                                    TFnParam {
+                                        pat: Ident(
+                                            BindingIdent {
+                                                name: "b",
+                                                mutable: false,
+                                            },
+                                        ),
+                                        t: Type {
+                                            kind: Keyword(
+                                                Number,
+                                            ),
+                                            mutable: false,
+                                            provenance: Some(
+                                                Type(
+                                                    Type {
+                                                        kind: Var(
+                                                            TVar {
+                                                                id: 3,
+                                                                constraint: None,
+                                                            },
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Pattern(
+                                                                Pattern {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 14,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 15,
+                                                                        },
+                                                                    },
+                                                                    span: 14..15,
+                                                                    kind: Ident(
+                                                                        BindingIdent {
+                                                                            name: "b",
+                                                                            mutable: false,
+                                                                            span: 14..15,
+                                                                            loc: SourceLocation {
+                                                                                start: Position {
+                                                                                    line: 0,
+                                                                                    column: 14,
+                                                                                },
+                                                                                end: Position {
+                                                                                    line: 0,
+                                                                                    column: 15,
+                                                                                },
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 3,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: None,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                        optional: false,
+                                    },
+                                ],
+                                ret: Type {
+                                    kind: Keyword(
+                                        Number,
+                                    ),
+                                    mutable: false,
+                                    provenance: Some(
+                                        Expr(
+                                            Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                },
+                                                span: 20..25,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Add,
+                                                        left: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                            },
+                                                            span: 20..21,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 20,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 21,
+                                                                        },
+                                                                    },
+                                                                    span: 20..21,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 2,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        },
+                                                        right: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 24..25,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 24,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 24..25,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 3,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                inferred_type: Some(
+                                                    Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: None,
+                                                    },
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                },
+                            },
+                        ),
+                        mutable: false,
+                        provenance: Some(
+                            Expr(
+                                Expr {
+                                    loc: SourceLocation {
+                                        start: Position {
+                                            line: 0,
+                                            column: 10,
+                                        },
+                                        end: Position {
+                                            line: 0,
+                                            column: 25,
+                                        },
+                                    },
+                                    span: 10..25,
+                                    kind: Lambda(
+                                        Lambda {
+                                            params: [
+                                                EFnParam {
+                                                    pat: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 11,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 12,
+                                                            },
+                                                        },
+                                                        span: 11..12,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "a",
+                                                                mutable: false,
+                                                                span: 11..12,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 11,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 12,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: Some(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 2,
+                                                                        constraint: None,
+                                                                    },
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
+                                                    mutable: false,
+                                                },
+                                                EFnParam {
+                                                    pat: Pattern {
+                                                        loc: SourceLocation {
+                                                            start: Position {
+                                                                line: 0,
+                                                                column: 14,
+                                                            },
+                                                            end: Position {
+                                                                line: 0,
+                                                                column: 15,
+                                                            },
+                                                        },
+                                                        span: 14..15,
+                                                        kind: Ident(
+                                                            BindingIdent {
+                                                                name: "b",
+                                                                mutable: false,
+                                                                span: 14..15,
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 14,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 15,
+                                                                    },
+                                                                },
+                                                            },
+                                                        ),
+                                                        inferred_type: Some(
+                                                            Type {
+                                                                kind: Var(
+                                                                    TVar {
+                                                                        id: 3,
+                                                                        constraint: None,
+                                                                    },
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: None,
+                                                            },
+                                                        ),
+                                                    },
+                                                    type_ann: None,
+                                                    optional: false,
+                                                    mutable: false,
+                                                },
+                                            ],
+                                            body: Expr {
+                                                loc: SourceLocation {
+                                                    start: Position {
+                                                        line: 0,
+                                                        column: 20,
+                                                    },
+                                                    end: Position {
+                                                        line: 0,
+                                                        column: 25,
+                                                    },
+                                                },
+                                                span: 20..25,
+                                                kind: BinaryExpr(
+                                                    BinaryExpr {
+                                                        op: Add,
+                                                        left: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 20,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 21,
+                                                                },
+                                                            },
+                                                            span: 20..21,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 20,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 21,
+                                                                        },
+                                                                    },
+                                                                    span: 20..21,
+                                                                    name: "a",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 2,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        },
+                                                        right: Expr {
+                                                            loc: SourceLocation {
+                                                                start: Position {
+                                                                    line: 0,
+                                                                    column: 24,
+                                                                },
+                                                                end: Position {
+                                                                    line: 0,
+                                                                    column: 25,
+                                                                },
+                                                            },
+                                                            span: 24..25,
+                                                            kind: Ident(
+                                                                Ident {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 24,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 24..25,
+                                                                    name: "b",
+                                                                },
+                                                            ),
+                                                            inferred_type: Some(
+                                                                Type {
+                                                                    kind: Var(
+                                                                        TVar {
+                                                                            id: 3,
+                                                                            constraint: None,
+                                                                        },
+                                                                    ),
+                                                                    mutable: false,
+                                                                    provenance: None,
+                                                                },
+                                                            ),
+                                                        },
+                                                    },
+                                                ),
+                                                inferred_type: Some(
+                                                    Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: None,
+                                                    },
+                                                ),
+                                            },
+                                            is_async: false,
+                                            return_type: None,
+                                            type_params: None,
+                                        },
+                                    ),
+                                    inferred_type: Some(
+                                        Type {
+                                            kind: Lam(
+                                                TLam {
+                                                    params: [
+                                                        TFnParam {
+                                                            pat: Ident(
+                                                                BindingIdent {
+                                                                    name: "a",
+                                                                    mutable: false,
+                                                                },
+                                                            ),
+                                                            t: Type {
+                                                                kind: Keyword(
+                                                                    Number,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: Some(
+                                                                    Type(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 2,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: Some(
+                                                                                Pattern(
+                                                                                    Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 11,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 12,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 11..12,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "a",
+                                                                                                mutable: false,
+                                                                                                span: 11..12,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 11,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 12,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: Some(
+                                                                                            Type {
+                                                                                                kind: Var(
+                                                                                                    TVar {
+                                                                                                        id: 2,
+                                                                                                        constraint: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                                mutable: false,
+                                                                                                provenance: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                            optional: false,
+                                                        },
+                                                        TFnParam {
+                                                            pat: Ident(
+                                                                BindingIdent {
+                                                                    name: "b",
+                                                                    mutable: false,
+                                                                },
+                                                            ),
+                                                            t: Type {
+                                                                kind: Keyword(
+                                                                    Number,
+                                                                ),
+                                                                mutable: false,
+                                                                provenance: Some(
+                                                                    Type(
+                                                                        Type {
+                                                                            kind: Var(
+                                                                                TVar {
+                                                                                    id: 3,
+                                                                                    constraint: None,
+                                                                                },
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: Some(
+                                                                                Pattern(
+                                                                                    Pattern {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 14,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 15,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 14..15,
+                                                                                        kind: Ident(
+                                                                                            BindingIdent {
+                                                                                                name: "b",
+                                                                                                mutable: false,
+                                                                                                span: 14..15,
+                                                                                                loc: SourceLocation {
+                                                                                                    start: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 14,
+                                                                                                    },
+                                                                                                    end: Position {
+                                                                                                        line: 0,
+                                                                                                        column: 15,
+                                                                                                    },
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        inferred_type: Some(
+                                                                                            Type {
+                                                                                                kind: Var(
+                                                                                                    TVar {
+                                                                                                        id: 3,
+                                                                                                        constraint: None,
+                                                                                                    },
+                                                                                                ),
+                                                                                                mutable: false,
+                                                                                                provenance: None,
+                                                                                            },
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                ),
+                                                            },
+                                                            optional: false,
+                                                        },
+                                                    ],
+                                                    ret: Type {
+                                                        kind: Keyword(
+                                                            Number,
+                                                        ),
+                                                        mutable: false,
+                                                        provenance: Some(
+                                                            Expr(
+                                                                Expr {
+                                                                    loc: SourceLocation {
+                                                                        start: Position {
+                                                                            line: 0,
+                                                                            column: 20,
+                                                                        },
+                                                                        end: Position {
+                                                                            line: 0,
+                                                                            column: 25,
+                                                                        },
+                                                                    },
+                                                                    span: 20..25,
+                                                                    kind: BinaryExpr(
+                                                                        BinaryExpr {
+                                                                            op: Add,
+                                                                            left: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 20,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 21,
+                                                                                    },
+                                                                                },
+                                                                                span: 20..21,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 20,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 21,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 20..21,
+                                                                                        name: "a",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: Some(
+                                                                                    Type {
+                                                                                        kind: Var(
+                                                                                            TVar {
+                                                                                                id: 2,
+                                                                                                constraint: None,
+                                                                                            },
+                                                                                        ),
+                                                                                        mutable: false,
+                                                                                        provenance: None,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                            right: Expr {
+                                                                                loc: SourceLocation {
+                                                                                    start: Position {
+                                                                                        line: 0,
+                                                                                        column: 24,
+                                                                                    },
+                                                                                    end: Position {
+                                                                                        line: 0,
+                                                                                        column: 25,
+                                                                                    },
+                                                                                },
+                                                                                span: 24..25,
+                                                                                kind: Ident(
+                                                                                    Ident {
+                                                                                        loc: SourceLocation {
+                                                                                            start: Position {
+                                                                                                line: 0,
+                                                                                                column: 24,
+                                                                                            },
+                                                                                            end: Position {
+                                                                                                line: 0,
+                                                                                                column: 25,
+                                                                                            },
+                                                                                        },
+                                                                                        span: 24..25,
+                                                                                        name: "b",
+                                                                                    },
+                                                                                ),
+                                                                                inferred_type: Some(
+                                                                                    Type {
+                                                                                        kind: Var(
+                                                                                            TVar {
+                                                                                                id: 3,
+                                                                                                constraint: None,
+                                                                                            },
+                                                                                        ),
+                                                                                        mutable: false,
+                                                                                        provenance: None,
+                                                                                    },
+                                                                                ),
+                                                                            },
+                                                                        },
+                                                                    ),
+                                                                    inferred_type: Some(
+                                                                        Type {
+                                                                            kind: Keyword(
+                                                                                Number,
+                                                                            ),
+                                                                            mutable: false,
+                                                                            provenance: None,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            mutable: false,
+                                            provenance: None,
+                                        },
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
             },
             type_ann: None,
             init: Some(
@@ -94,7 +879,18 @@ Program {
                                                 },
                                             },
                                         ),
-                                        inferred_type: None,
+                                        inferred_type: Some(
+                                            Type {
+                                                kind: Var(
+                                                    TVar {
+                                                        id: 2,
+                                                        constraint: None,
+                                                    },
+                                                ),
+                                                mutable: false,
+                                                provenance: None,
+                                            },
+                                        ),
                                     },
                                     type_ann: None,
                                     optional: false,
@@ -130,7 +926,18 @@ Program {
                                                 },
                                             },
                                         ),
-                                        inferred_type: None,
+                                        inferred_type: Some(
+                                            Type {
+                                                kind: Var(
+                                                    TVar {
+                                                        id: 3,
+                                                        constraint: None,
+                                                    },
+                                                ),
+                                                mutable: false,
+                                                provenance: None,
+                                            },
+                                        ),
                                     },
                                     type_ann: None,
                                     optional: false,
@@ -329,7 +1136,18 @@ Program {
                                                                                 },
                                                                             },
                                                                         ),
-                                                                        inferred_type: None,
+                                                                        inferred_type: Some(
+                                                                            Type {
+                                                                                kind: Var(
+                                                                                    TVar {
+                                                                                        id: 2,
+                                                                                        constraint: None,
+                                                                                    },
+                                                                                ),
+                                                                                mutable: false,
+                                                                                provenance: None,
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
                                                             ),
@@ -392,7 +1210,18 @@ Program {
                                                                                 },
                                                                             },
                                                                         ),
-                                                                        inferred_type: None,
+                                                                        inferred_type: Some(
+                                                                            Type {
+                                                                                kind: Var(
+                                                                                    TVar {
+                                                                                        id: 3,
+                                                                                        constraint: None,
+                                                                                    },
+                                                                                ),
+                                                                                mutable: false,
+                                                                                provenance: None,
+                                                                            },
+                                                                        ),
                                                                     },
                                                                 ),
                                                             ),

--- a/crates/crochet_lsp/src/main.rs
+++ b/crates/crochet_lsp/src/main.rs
@@ -55,6 +55,8 @@ fn main_loop(
     // We use `dyn Error` here b/c we're mixing different APIs when generate
     // different error structs
 ) -> Result<(), Box<dyn Error + Sync + Send>> {
+    // TODO: store the content of LIB_ES5_D_TS in the file cache as well.
+    // We need to figure out how to generate a Url from the &str.
     let lib = fs::read_to_string(LIB_ES5_D_TS).unwrap();
     let _params: InitializeParams = serde_json::from_value(params).unwrap();
 
@@ -67,16 +69,17 @@ fn main_loop(
                 if connection.handle_shutdown(&req)? {
                     return Ok(());
                 }
+
                 eprintln!("got request: {req:?}");
                 match req.method.as_str() {
                     "textDocument/hover" => {
                         let (id, params) = cast_req::<HoverRequest>(req)?;
                         handle_hover_request(&connection, &lib, &file_cache, id, params)?;
+
                         continue;
                     }
-                    _ => {
-                        // log unrecognized method
-                        todo!()
+                    method => {
+                        eprintln!("Unhandled request method: {method}");
                     }
                 }
             }
@@ -115,9 +118,8 @@ fn main_loop(
 
                         continue;
                     }
-                    _ => {
-                        // log unrecognized method
-                        todo!()
+                    method => {
+                        eprintln!("Unhandled notification method: {method}");
                     }
                 }
             }

--- a/crates/crochet_lsp/src/main.rs
+++ b/crates/crochet_lsp/src/main.rs
@@ -3,13 +3,20 @@ use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use lsp_server::{Connection, ExtractError, Message, Request, RequestId, Response};
+use lsp_types::HoverParams;
 use lsp_types::{
     request::HoverRequest, Hover, HoverContents, HoverProviderCapability, InitializeParams,
     MarkedString, ServerCapabilities,
 };
 
+use crochet_ast::types::Type;
+use crochet_ast::values::{Position, Program, SourceLocation};
 use crochet_dts::parse_dts::parse_dts;
 use crochet_parser::parse;
+
+mod visitor;
+
+use visitor::Visitor;
 
 static LIB_ES5_D_TS: &str = "../../../node_modules/typescript/lib/lib.es5.d.ts";
 
@@ -57,58 +64,7 @@ fn main_loop(
                 eprintln!("got request: {req:?}");
                 match cast::<HoverRequest>(req) {
                     Ok((id, params)) => {
-                        eprintln!("got hoverRequest request #{id}: {params:?}");
-                        eprintln!("parsing .d.ts");
-                        // NOTE: This is slow so we'll want to do this once once
-                        // on startup and re-use the results.
-                        let mut ctx = match parse_dts(&lib) {
-                            Ok(ctx) => {
-                                eprintln!("success");
-                                ctx
-                            }
-                            Err(_) => {
-                                eprintln!("error");
-                                panic!("parsing .d.ts file failed");
-                            }
-                        };
-
-                        let start = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards");
-                        let in_path = params
-                            .text_document_position_params
-                            .text_document
-                            .uri
-                            .to_file_path()
-                            .unwrap(); // TODO: generate a real error if the path doesn't exist
-                        eprintln!("reading {}", in_path.to_string_lossy());
-                        let input = fs::read_to_string(in_path).unwrap();
-                        // Update ParseError to implement Error + Sync + Send
-                        eprintln!("parsing input");
-                        let mut prog = parse(&input).unwrap();
-                        // Update TypeError to implement Error + Sync + Send
-                        eprintln!("inferring types");
-                        crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
-                        // eprintln!("prog = {prog:#?}");
-                        let end = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards");
-                        let elapsed = end - start;
-                        eprintln!("request took {}ms", elapsed.as_millis());
-
-                        let result = Some(Hover {
-                            contents: HoverContents::Scalar(MarkedString::String(String::from(
-                                "Hello, world!",
-                            ))),
-                            range: None,
-                        });
-                        let result = serde_json::to_value(&result).unwrap();
-                        let resp = Response {
-                            id,
-                            result: Some(result),
-                            error: None,
-                        };
-                        connection.sender.send(Message::Response(resp))?;
+                        handle_hover_request(&connection, &lib, id, params)?;
                         continue;
                     }
                     Err(err @ ExtractError::JsonError { .. }) => panic!("{err:?}"),
@@ -125,6 +81,146 @@ fn main_loop(
         }
     }
     Ok(())
+}
+
+fn handle_hover_request(
+    connection: &Connection,
+    lib: &str,
+    id: RequestId,
+    params: HoverParams,
+) -> Result<(), Box<dyn Error + Sync + Send>> {
+    eprintln!("Handling HoverRequest");
+
+    // NOTE: This is slow so we'll want to do this once once
+    // on startup and re-use the results.
+    eprintln!("parsing .d.ts");
+    let mut ctx = match parse_dts(lib) {
+        Ok(ctx) => {
+            eprintln!("success");
+            ctx
+        }
+        Err(_) => {
+            eprintln!("error");
+            panic!("parsing .d.ts file failed");
+        }
+    };
+
+    let start = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+
+    let in_path = params
+        .text_document_position_params
+        .text_document
+        .uri
+        .to_file_path()
+        .unwrap(); // TODO: generate a real error if the path doesn't exist
+
+    eprintln!("reading {}", in_path.to_string_lossy());
+    let input = fs::read_to_string(in_path).unwrap();
+
+    // Update ParseError to implement Error + Sync + Send
+    eprintln!("parsing input");
+    let mut prog = parse(&input).unwrap();
+
+    // Update TypeError to implement Error + Sync + Send
+    eprintln!("inferring types");
+    crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
+
+    let end = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    let elapsed = end - start;
+    eprintln!("request took {}ms", elapsed.as_millis());
+
+    // TODO: create a From impl to convert from one Position to another.
+    let cursor_loc = Position {
+        line: params.text_document_position_params.position.line,
+        column: params.text_document_position_params.position.character,
+    };
+
+    let message = match get_type_at_location(&mut prog, &cursor_loc) {
+        Some(t) => t.to_string(),
+        None => String::from("no type info"),
+    };
+
+    let result = Some(Hover {
+        contents: HoverContents::Scalar(MarkedString::String(message)),
+        range: None,
+    });
+    let resp = Response {
+        id,
+        result: Some(serde_json::to_value(&result).unwrap()),
+        error: None,
+    };
+    connection.sender.send(Message::Response(resp))?;
+
+    Ok(())
+}
+
+struct GetTypeVisitor {
+    cursor_pos: Position,
+    t: Option<Type>,
+}
+
+fn is_pos_in_source_loc(pos: &Position, src_loc: &SourceLocation) -> bool {
+    let is_after_start = pos.line > src_loc.start.line
+        || (pos.line == src_loc.start.line && pos.column >= src_loc.start.column);
+    let is_before_end = pos.line < src_loc.end.line
+        || (pos.line == src_loc.end.line && pos.column < src_loc.end.column);
+
+    is_after_start && is_before_end
+}
+
+// TODO: use is_pos_in_source_loc to terminate certain branches of the visitor
+impl Visitor for GetTypeVisitor {
+    fn visit_program(&mut self, _: &crochet_ast::values::Program) {
+        eprintln!("visit_program");
+        // Do nothing b/c Program doesn't have an .inferred_type field
+    }
+
+    fn visit_statement(&mut self, _stmt: &crochet_ast::values::Statement) {
+        eprintln!("visit_program");
+        // Do nothing b/c Statement doesn't have an .inferred_type field (yet)
+    }
+
+    fn visit_pattern(&mut self, pat: &crochet_ast::values::Pattern) {
+        if is_pos_in_source_loc(&self.cursor_pos, &pat.loc) {
+            if let Some(t) = &pat.inferred_type {
+                self.t = Some(t.to_owned())
+            }
+        }
+    }
+
+    fn visit_type_ann(&mut self, type_ann: &crochet_ast::values::TypeAnn) {
+        if is_pos_in_source_loc(&self.cursor_pos, &type_ann.loc) {
+            if let Some(t) = &type_ann.inferred_type {
+                self.t = Some(t.to_owned())
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &crochet_ast::values::Expr) {
+        eprintln!(
+            "visit_expr - start, line {} col {} - end, line {} col {}",
+            expr.loc.start.line, expr.loc.start.column, expr.loc.end.line, expr.loc.end.column
+        );
+        if is_pos_in_source_loc(&self.cursor_pos, &expr.loc) {
+            if let Some(t) = &expr.inferred_type {
+                self.t = Some(t.to_owned())
+            }
+        }
+    }
+}
+
+fn get_type_at_location(program: &mut Program, cursor_pos: &Position) -> Option<Type> {
+    let mut visitor = GetTypeVisitor {
+        cursor_pos: cursor_pos.to_owned(),
+        t: None,
+    };
+    visitor.visit(program);
+
+    visitor.t
 }
 
 fn cast<R>(req: Request) -> Result<(RequestId, R::Params), ExtractError<Request>>

--- a/crates/crochet_lsp/src/main.rs
+++ b/crates/crochet_lsp/src/main.rs
@@ -201,10 +201,6 @@ impl Visitor for GetTypeVisitor {
     }
 
     fn visit_expr(&mut self, expr: &crochet_ast::values::Expr) {
-        eprintln!(
-            "visit_expr - start, line {} col {} - end, line {} col {}",
-            expr.loc.start.line, expr.loc.start.column, expr.loc.end.line, expr.loc.end.column
-        );
         if is_pos_in_source_loc(&self.cursor_pos, &expr.loc) {
             if let Some(t) = &expr.inferred_type {
                 self.t = Some(t.to_owned())

--- a/crates/crochet_lsp/src/visitor.rs
+++ b/crates/crochet_lsp/src/visitor.rs
@@ -1,0 +1,165 @@
+use crochet_ast::values::*;
+
+pub trait Visitor {
+    fn visit_program(&mut self, prog: &Program);
+    fn visit_statement(&mut self, stmt: &Statement);
+    fn visit_pattern(&mut self, pat: &Pattern);
+    fn visit_type_ann(&mut self, type_ann: &TypeAnn);
+    fn visit_expr(&mut self, expr: &Expr);
+
+    // This is the main entry point
+    fn visit(&mut self, prog: &mut Program) {
+        self.visit_program(prog);
+
+        prog.body
+            .iter_mut()
+            .for_each(|stmt| self._visit_statement(stmt));
+    }
+
+    fn _visit_statement(&mut self, stmt: &mut Statement) {
+        self.visit_statement(stmt);
+
+        match stmt {
+            Statement::VarDecl {
+                pattern,
+                type_ann,
+                init,
+                ..
+            } => {
+                self._visit_pattern(pattern);
+                if let Some(type_ann) = type_ann {
+                    self._visit_type_ann(type_ann);
+                }
+                if let Some(init) = init {
+                    self._visit_expr(init);
+                }
+            }
+            Statement::TypeDecl {
+                type_ann,
+                type_params: _, // TODO
+                ..
+            } => {
+                self._visit_type_ann(type_ann);
+            }
+            Statement::Expr { expr, .. } => {
+                self._visit_expr(expr);
+            }
+        }
+    }
+
+    fn _visit_pattern(&mut self, pat: &mut Pattern) {
+        self.visit_pattern(pat);
+
+        // TODO: traverse children
+    }
+
+    fn _visit_type_ann(&mut self, type_ann: &mut TypeAnn) {
+        self.visit_type_ann(type_ann);
+
+        // TODO: traverse children
+    }
+
+    fn _visit_expr(&mut self, expr: &mut Expr) {
+        self.visit_expr(expr);
+
+        match &mut expr.kind {
+            ExprKind::App(App { lam, args }) => {
+                self._visit_expr(lam);
+                args.iter_mut()
+                    .for_each(|arg| self._visit_expr(&mut arg.expr));
+            }
+            ExprKind::New(_) => todo!(),
+            ExprKind::Fix(_) => todo!(),
+            ExprKind::Ident(_) => (), // leaf node
+            ExprKind::IfElse(IfElse {
+                cond,
+                consequent,
+                alternate,
+            }) => {
+                self._visit_expr(cond);
+                self._visit_expr(consequent);
+                if let Some(alternate) = alternate {
+                    self._visit_expr(alternate);
+                }
+            }
+            ExprKind::JSXElement(_) => todo!(),
+            ExprKind::Lambda(Lambda {
+                params,
+                body,
+                return_type,
+                type_params: _, // TODO
+                ..
+            }) => {
+                params.iter_mut().for_each(|param| {
+                    // TODO: add visit_fn_param() method
+                    let EFnParam { pat, type_ann, .. } = param;
+                    self._visit_pattern(pat);
+                    if let Some(type_ann) = type_ann {
+                        self._visit_type_ann(type_ann);
+                    }
+                });
+                if let Some(return_type) = return_type {
+                    self._visit_type_ann(return_type);
+                }
+                // TODO: revisit how we store the body in the AST, maybe we can
+                // defer converting it to `let-in` until later in the process.
+                // The problem with the `let-in` form is that it results in a
+                // of nesting that we could do with out.
+                self._visit_expr(body);
+            }
+            ExprKind::Let(Let {
+                pattern,
+                type_ann,
+                init,
+                body,
+            }) => {
+                if let Some(pattern) = pattern {
+                    self._visit_pattern(pattern);
+                }
+                if let Some(type_ann) = type_ann {
+                    self._visit_type_ann(type_ann);
+                }
+                self._visit_expr(init);
+                self._visit_expr(body);
+            }
+            ExprKind::Assign(Assign { left, right, .. }) => {
+                self._visit_expr(left);
+                self._visit_expr(right);
+            }
+            ExprKind::LetExpr(_) => todo!(),
+            ExprKind::Lit(_) => (),     // leaf node
+            ExprKind::Keyword(_) => (), // leaf node
+            ExprKind::BinaryExpr(BinaryExpr { left, right, .. }) => {
+                self._visit_expr(left);
+                self._visit_expr(right);
+            }
+            ExprKind::UnaryExpr(UnaryExpr { arg, .. }) => {
+                self._visit_expr(arg);
+            }
+            ExprKind::Obj(Obj { props }) => {
+                props.iter_mut().for_each(|prop| match prop {
+                    PropOrSpread::Spread(_) => todo!(),
+                    PropOrSpread::Prop(prop) => match prop.as_mut() {
+                        Prop::Shorthand(_) => todo!(),
+                        Prop::KeyValue(KeyValueProp { key: _, value }) => {
+                            self._visit_expr(value);
+                        }
+                    },
+                });
+            }
+            ExprKind::Await(Await { expr }) => {
+                self._visit_expr(expr);
+            }
+            ExprKind::Tuple(Tuple { elems }) => {
+                elems
+                    .iter_mut()
+                    .for_each(|elem| self._visit_expr(&mut elem.expr));
+            }
+            ExprKind::Member(_) => todo!(),
+            ExprKind::Empty => (), // leaf node
+            ExprKind::TemplateLiteral(_) => todo!(),
+            ExprKind::TaggedTemplateLiteral(_) => todo!(),
+            ExprKind::Match(_) => todo!(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary:
TODO:
- [x] add `inferred_type` field to top-level decls (it turns out I just need to specify the `inferred_type` field when inferring patterns)
- [x] get the current version of the code being analyzed which hasn't been saved yet

<img width="638" alt="Capture d’écran, le 2022-12-31 à 23 11 14" src="https://user-images.githubusercontent.com/1044413/210161472-c3b137b9-382c-42d5-80c4-99ce6a584901.png">

I'll write some unit tests in a separate PR since this will likely require some refactoring and I'd like to get the current changes landed.

## Test Plan:
- press F5 to run the VSCode extension in a new instance of VSCode
- open a few different .crochet files
- hover over different things in each file, see the types displayed
- making some edits without saving
- hover over the new code, see the types displayed