### PR TITLE
Add support for 'infer' type

### DIFF
--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -35,6 +35,7 @@ impl fmt::Display for TRef {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TObject {
     pub elems: Vec<TObjElem>,
+    pub is_interface: bool, // Used for `interface` types and classes
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -97,6 +97,11 @@ pub struct TConditionalType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TInferType {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TypeKind {
     Var(TVar),
     App(TApp),
@@ -118,6 +123,7 @@ pub enum TypeKind {
     IndexAccess(TIndexAccess),
     MappedType(TMappedType),
     ConditionalType(TConditionalType),
+    InferType(TInferType),
     // Query, // use for typed holes
 }
 
@@ -234,6 +240,7 @@ impl fmt::Display for Type {
                     "{check_type} extends {extends_type} ? {true_type} : {false_type}"
                 )
             }
+            TypeKind::InferType(TInferType { name }) => write!(f, "infer {name}"),
         }
     }
 }

--- a/crates/crochet_ast/src/values/keyword.rs
+++ b/crates/crochet_ast/src/values/keyword.rs
@@ -11,6 +11,7 @@ pub enum Keyword {
     Self_, // self is a replacement for this
     Symbol,
     Undefined,
+    Never,
 }
 
 impl fmt::Display for Keyword {
@@ -23,6 +24,7 @@ impl fmt::Display for Keyword {
             Keyword::Self_ => write!(f, "self"),
             Keyword::Symbol => write!(f, "symbol"),
             Keyword::Undefined => write!(f, "undefined"),
+            Keyword::Never => write!(f, "never"),
         }
     }
 }
@@ -38,6 +40,7 @@ impl From<Keyword> for Type {
                 Keyword::Symbol => TKeyword::Symbol,
                 Keyword::Undefined => TKeyword::Undefined,
                 Keyword::Self_ => TKeyword::Self_,
+                Keyword::Never => TKeyword::Never,
             }),
             provenance: None,
             mutable: false,

--- a/crates/crochet_ast/src/values/type_ann.rs
+++ b/crates/crochet_ast/src/values/type_ann.rs
@@ -147,6 +147,11 @@ pub struct MutableType {
     pub type_ann: Box<TypeAnn>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InferType {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeAnnKind {
     Lam(LamType),
@@ -164,6 +169,7 @@ pub enum TypeAnnKind {
     Mapped(MappedType),
     Conditional(ConditionalType),
     Mutable(MutableType),
+    Infer(InferType),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/crochet_codegen/src/d_ts.rs
+++ b/crates/crochet_codegen/src/d_ts.rs
@@ -8,8 +8,8 @@ use swc_ecma_ast::*;
 use swc_ecma_codegen::*;
 
 use crochet_ast::types::{
-    TConditionalType, TFnParam, TGetter, TIndexAccess, TMappedType, TObjElem, TObject, TPat,
-    TPropKey, TSetter, TVar, Type, TypeKind, TypeParam,
+    TConditionalType, TFnParam, TGetter, TIndexAccess, TInferType, TMappedType, TObjElem, TObject,
+    TPat, TPropKey, TSetter, TVar, Type, TypeKind, TypeParam,
 };
 use crochet_ast::{types, values};
 use crochet_infer::{immutable_obj_type, Context};
@@ -593,6 +593,21 @@ pub fn build_type(t: &Type, type_params: &Option<Box<TsTypeParamDecl>>, ctx: &Co
             extends_type: Box::from(build_type(extends_type.as_ref(), type_params, ctx)),
             true_type: Box::from(build_type(true_type.as_ref(), type_params, ctx)),
             false_type: Box::from(build_type(false_type.as_ref(), type_params, ctx)),
+        }),
+        TypeKind::InferType(TInferType { name }) => TsType::TsInferType(TsInferType {
+            span: DUMMY_SP,
+            type_param: TsTypeParam {
+                span: DUMMY_SP,
+                name: Ident {
+                    span: DUMMY_SP,
+                    sym: JsWord::from(name.to_string()),
+                    optional: false,
+                },
+                is_in: false,
+                is_out: false,
+                constraint: None,
+                default: None,
+            },
         }),
     }
 }

--- a/crates/crochet_dts/src/parse_dts.rs
+++ b/crates/crochet_dts/src/parse_dts.rs
@@ -160,7 +160,10 @@ pub fn infer_ts_type_ann(type_ann: &TsType, ctx: &Context) -> Result<Type, Strin
                 })
                 .collect();
 
-            let t = Type::from(TypeKind::Object(TObject { elems }));
+            let t = Type::from(TypeKind::Object(TObject {
+                elems,
+                is_interface: false,
+            }));
 
             Ok(t)
         }
@@ -656,7 +659,10 @@ fn infer_interface_decl(
         })
         .collect();
 
-    let t = Type::from(TypeKind::Object(TObject { elems }));
+    let t = Type::from(TypeKind::Object(TObject {
+        elems,
+        is_interface: false,
+    }));
 
     let type_params = match &decl.type_params {
         Some(type_params) => type_params

--- a/crates/crochet_dts/src/util.rs
+++ b/crates/crochet_dts/src/util.rs
@@ -166,7 +166,14 @@ pub fn merge_schemes(old_scheme: &Scheme, new_scheme: &Scheme) -> Scheme {
                 elems.push(elem.to_owned());
             }
 
-            Type::from(TypeKind::Object(TObject { elems }))
+            Type::from(TypeKind::Object(TObject {
+                elems,
+                // NOTE: This function is called from the code parsing interfaces
+                // so this should always be true.
+                // TODO: add a check to make sure since we shouldn't be trying to
+                // merge things that aren't interfaces.
+                is_interface: true,
+            }))
         }
         (_, _) => todo!(),
     };
@@ -193,7 +200,10 @@ mod tests {
             is_mutating: false,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Method(TMethod {
@@ -204,7 +214,10 @@ mod tests {
             is_mutating: false,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -225,7 +238,10 @@ mod tests {
             is_mutating: true,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Method(TMethod {
@@ -236,7 +252,10 @@ mod tests {
             is_mutating: true,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -257,7 +276,10 @@ mod tests {
             is_mutating: true,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Method(TMethod {
@@ -268,7 +290,10 @@ mod tests {
             is_mutating: false,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -286,7 +311,10 @@ mod tests {
             is_mutating: false,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Method(TMethod {
@@ -297,7 +325,10 @@ mod tests {
             is_mutating: true,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -316,7 +347,10 @@ mod tests {
             mutable: true,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Index(TIndex {
@@ -328,7 +362,10 @@ mod tests {
             mutable: false,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -350,7 +387,10 @@ mod tests {
             mutable: false,
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Index(TIndex {
@@ -362,7 +402,10 @@ mod tests {
             mutable: true,
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -381,7 +424,10 @@ mod tests {
             type_params: vec![],
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Call(TCallable {
@@ -390,7 +436,10 @@ mod tests {
             type_params: vec![],
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 
@@ -406,7 +455,10 @@ mod tests {
             type_params: vec![],
         })];
         let old_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: old_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: old_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
         let new_elems = vec![TObjElem::Constructor(TCallable {
@@ -415,7 +467,10 @@ mod tests {
             type_params: vec![],
         })];
         let new_scheme = Scheme {
-            t: Box::from(Type::from(TypeKind::Object(TObject { elems: new_elems }))),
+            t: Box::from(Type::from(TypeKind::Object(TObject {
+                elems: new_elems,
+                is_interface: true,
+            }))),
             type_params: vec![],
         };
 

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -382,9 +382,9 @@ fn infer_partial() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type PartialObj = Partial<Obj>;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("PartialObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(
@@ -399,9 +399,9 @@ fn infer_required() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type RequiredObj = Required<Obj>;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("RequiredObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(
@@ -416,9 +416,9 @@ fn infer_readonly() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type ReadonlyObj = Readonly<Obj>;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "{a: number, b?: string, c: boolean, d?: number}");
@@ -430,9 +430,9 @@ fn infer_readonly_with_indexer_only() {
     type Obj = {[key: string]: boolean};
     type ReadonlyObj = Readonly<Obj>;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "{[key: string]: boolean}");
@@ -444,9 +444,9 @@ fn infer_readonly_with_indexer_and_other_properties() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number, [key: number]: boolean};
     type ReadonlyObj = Readonly<Obj>;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("ReadonlyObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(
@@ -461,9 +461,9 @@ fn infer_pick() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type PickObj = Pick<Obj, "a" | "b">;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("PickObj", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "{a: number, b?: string}");
@@ -505,13 +505,13 @@ fn infer_exclude() {
     let src = r#"
     type T1 = Exclude<"a" | "b" | "c", "a" | "b">;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("T1", false).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "Exclude<\"a\" | \"b\" | \"c\", \"a\" | \"b\">");
 
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
     let result = format!("{}", t);
 
     assert_eq!(result, "\"c\"");
@@ -535,10 +535,10 @@ fn infer_out_of_order_exclude() {
             panic!("Error parsing expression");
         }
     };
-    let ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
+    let mut ctx = crochet_infer::infer_prog(&mut prog, &mut ctx).unwrap();
 
     let t = ctx.lookup_type("T1", false).unwrap();
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
     let result = format!("{}", t);
     assert_eq!(result, "\"c\"");
 }
@@ -549,13 +549,13 @@ fn infer_omit() {
     type Obj = {a: number, b?: string, mut c: boolean, mut d?: number};
     type T1 = Omit<Obj, "b" | "c">;
     "#;
-    let (_, ctx) = infer_prog(src);
+    let (_, mut ctx) = infer_prog(src);
     let t = ctx.lookup_type("T1", false).unwrap();
 
     let result = format!("{}", t);
     assert_eq!(result, "Omit<Obj, \"b\" | \"c\">");
 
-    let t = expand_type(&t, &ctx).unwrap();
+    let t = expand_type(&t, &mut ctx).unwrap();
     let result = format!("{}", t);
 
     assert_eq!(result, "{a: number, mut d?: number}");

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -89,6 +89,8 @@ impl Context {
         current_scope.values.insert(name, b);
     }
 
+    // TODO: determine if we need to generalize the inserted type everywhere
+    // this is being called.
     pub fn insert_type(&mut self, name: String, t: Type) {
         let current_scope = self.scopes.last_mut().unwrap();
         let scheme = generalize(&current_scope.types, &t);

--- a/crates/crochet_infer/src/expand_type.rs
+++ b/crates/crochet_infer/src/expand_type.rs
@@ -67,7 +67,7 @@ pub fn expand_type(t: &Type, ctx: &mut Context) -> Result<Type, Vec<TypeError>> 
     }
 }
 
-fn expand_alias_type(alias: &TRef, ctx: &mut Context) -> Result<Type, Vec<TypeError>> {
+pub fn expand_alias_type(alias: &TRef, ctx: &mut Context) -> Result<Type, Vec<TypeError>> {
     let name = &alias.name;
     let scheme = ctx.lookup_scheme(name)?;
 

--- a/crates/crochet_infer/src/expand_type.rs
+++ b/crates/crochet_infer/src/expand_type.rs
@@ -32,6 +32,10 @@ pub fn expand_type(t: &Type, ctx: &Context) -> Result<Type, Vec<TypeError>> {
         TypeKind::IndexAccess(access) => expand_index_access(access, ctx),
         TypeKind::MappedType(mapped) => expand_mapped_type(mapped, ctx),
         TypeKind::ConditionalType(cond) => expand_conditional_type(cond, ctx),
+        TypeKind::InferType(_infer) => {
+            // TODO: add a type binding to the current context
+            Ok(t.to_owned())
+        }
     }
 }
 
@@ -118,11 +122,18 @@ fn expand_conditional_type(cond: &TConditionalType, ctx: &Context) -> Result<Typ
     } = cond;
 
     let mut check_type = check_type.clone();
+
+    // TODO: make `ctx` a mutable reference
+    // ctx.push_scope(false);
+
     let mut extends_type = extends_type.clone();
     let t = match unify(&mut check_type, &mut extends_type, ctx) {
         Ok(_) => true_type,
         Err(_) => false_type,
     };
+
+    // ctx.pop_scope();
+
     expand_type(t.as_ref(), ctx)
 }
 
@@ -530,6 +541,9 @@ pub fn get_obj_type(t: &'_ Type, ctx: &Context) -> Result<Type, Vec<TypeError>> 
         }
         TypeKind::ConditionalType(_) => {
             todo!() // We have to evaluate the ConditionalType first
+        }
+        TypeKind::InferType(_) => {
+            todo!() // ?
         }
     }
 }

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -22,7 +22,10 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
         mutable: false,
         t: Type::from(Lit::str(String::from("Promise"), 0..0, DUMMY_LOC)),
     })];
-    let promise_type = Type::from(TypeKind::Object(TObject { elems }));
+    let promise_type = Type::from(TypeKind::Object(TObject {
+        elems,
+        is_interface: true,
+    }));
     ctx.insert_type(String::from("Promise"), promise_type);
     // TODO: replace with Class type once it exists
     // We use {_name: "JSXElement"} to differentiate it from other
@@ -33,7 +36,10 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
         mutable: false,
         t: Type::from(Lit::str(String::from("JSXElement"), 0..0, DUMMY_LOC)),
     })];
-    let jsx_element_type = Type::from(TypeKind::Object(TObject { elems }));
+    let jsx_element_type = Type::from(TypeKind::Object(TObject {
+        elems,
+        is_interface: true,
+    }));
     ctx.insert_type(String::from("JSXElement"), jsx_element_type);
 
     // We push a scope here so that it's easy to differentiate globals from

--- a/crates/crochet_infer/src/infer_class.rs
+++ b/crates/crochet_infer/src/infer_class.rs
@@ -259,10 +259,12 @@ pub fn infer_class(ctx: &mut Context, class: &mut Class) -> Result<(Subst, Type)
 
     let statics_t = Type::from(TypeKind::Object(TObject {
         elems: statics_elems,
+        is_interface: false,
     }));
 
     let instance_t = Type::from(TypeKind::Object(TObject {
         elems: mut_instance_elems,
+        is_interface: true,
     }));
 
     let empty_env = Env::default();

--- a/crates/crochet_infer/src/infer_expr.rs
+++ b/crates/crochet_infer/src/infer_expr.rs
@@ -87,7 +87,11 @@ pub fn infer_expr(
             }
 
             let mut results = vec![];
-            if let TypeKind::Object(TObject { elems }) = t.kind {
+            if let TypeKind::Object(TObject {
+                elems,
+                is_interface: _,
+            }) = t.kind
+            {
                 for elem in elems {
                     if let TObjElem::Constructor(callable) = &elem {
                         let mut ret_type = ctx.fresh_var();
@@ -284,7 +288,10 @@ pub fn infer_expr(
                         }));
 
                         let mut call_type = Type::from(TypeKind::App(types::TApp {
-                            args: vec![Type::from(TypeKind::Object(TObject { elems }))],
+                            args: vec![Type::from(TypeKind::Object(TObject {
+                                elems,
+                                is_interface: false,
+                            }))],
                             ret: Box::from(ret_type.clone()),
                         }));
 
@@ -553,10 +560,16 @@ pub fn infer_expr(
 
             let s = compose_many_subs(&ss);
             let t = if spread_types.is_empty() {
-                Type::from(TypeKind::Object(TObject { elems }))
+                Type::from(TypeKind::Object(TObject {
+                    elems,
+                    is_interface: false,
+                }))
             } else {
                 let mut all_types = spread_types;
-                all_types.push(Type::from(TypeKind::Object(TObject { elems })));
+                all_types.push(Type::from(TypeKind::Object(TObject {
+                    elems,
+                    is_interface: false,
+                })));
                 simplify_intersection(&all_types)
             };
 

--- a/crates/crochet_infer/src/infer_pattern.rs
+++ b/crates/crochet_infer/src/infer_pattern.rs
@@ -199,7 +199,10 @@ fn infer_pattern_rec(
                 }
             }
 
-            let obj_type = Type::from(TypeKind::Object(TObject { elems }));
+            let obj_type = Type::from(TypeKind::Object(TObject {
+                elems,
+                is_interface: false,
+            }));
 
             match rest_opt_ty {
                 // TODO: Replace this with a proper Rest/Spread type

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -151,7 +151,10 @@ fn infer_type_ann_rec(
             }
 
             let s = compose_many_subs(&ss);
-            let t = Type::from(TypeKind::Object(TObject { elems }));
+            let t = Type::from(TypeKind::Object(TObject {
+                elems,
+                is_interface: false,
+            }));
             type_ann.inferred_type = Some(t.clone());
             Ok((s, t))
         }

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 
 use crochet_ast::types::{
     self as types, Provenance, TConditionalType, TFnParam, TIndex, TIndexAccess, TIndexKey,
-    TMappedType, TObjElem, TObject, TProp, TPropKey, TVar, Type, TypeKind,
+    TInferType, TMappedType, TObjElem, TObject, TProp, TPropKey, TVar, Type, TypeKind,
 };
 use crochet_ast::values::*;
 
@@ -274,6 +274,14 @@ fn infer_type_ann_rec(
 
             t.mutable = true;
             type_ann.inferred_type = Some(t.clone());
+            Ok((s, t))
+        }
+        TypeAnnKind::Infer(InferType { name }) => {
+            let t = Type::from(TypeKind::InferType(TInferType {
+                name: name.to_owned(),
+            }));
+            let s = Subst::new();
+
             Ok((s, t))
         }
         TypeAnnKind::IndexedAccess(IndexedAccessType {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3197,37 +3197,4 @@ mod tests {
 
         infer_prog(src);
     }
-
-    #[test]
-    fn infer_infer_type() {
-        let src = r#"
-        type Array<T> = {[key: number]: T};
-        type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
-        // type GetReturnType<Type> = Type extends (...args: never[]) => infer Return
-        //     ? Return
-        //     : never;
-
-        type NumberArray = Array<number>;
-        type NumberItem = Flatten<NumberArray>;
-        let num: NumberItem = 5;
-
-        type StringArray = Array<string>;
-        type StringItem = Flatten<StringArray>;
-        let str: StringItem = "hello";
-        "#;
-
-        let ctx = infer_prog(src);
-
-        let flatten = ctx.lookup_scheme("Flatten").unwrap();
-        assert_eq!(
-            format!("{flatten}"),
-            "<A>A extends Array<infer Item> ? Item : A"
-        );
-
-        // let get_return = ctx.lookup_scheme("GetReturnType").unwrap();
-        // assert_eq!(
-        //     format!("{get_return}"),
-        //     "<A>A extends (...args: never[]) => infer Return ? Return : never"
-        // );
-    }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3201,10 +3201,19 @@ mod tests {
     #[test]
     fn infer_infer_type() {
         let src = r#"
+        type Array<T> = {[key: number]: T};
         type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
-        type GetReturnType<Type> = Type extends (...args: never[]) => infer Return
-            ? Return
-            : never;
+        // type GetReturnType<Type> = Type extends (...args: never[]) => infer Return
+        //     ? Return
+        //     : never;
+
+        type NumberArray = Array<number>;
+        type NumberItem = Flatten<NumberArray>;
+        let num: NumberItem = 5;
+
+        type StringArray = Array<string>;
+        type StringItem = Flatten<StringArray>;
+        let str: StringItem = "hello";
         "#;
 
         let ctx = infer_prog(src);
@@ -3215,10 +3224,10 @@ mod tests {
             "<A>A extends Array<infer Item> ? Item : A"
         );
 
-        let get_return = ctx.lookup_scheme("GetReturnType").unwrap();
-        assert_eq!(
-            format!("{get_return}"),
-            "<A>A extends (...args: never[]) => infer Return ? Return : never"
-        );
+        // let get_return = ctx.lookup_scheme("GetReturnType").unwrap();
+        // assert_eq!(
+        //     format!("{get_return}"),
+        //     "<A>A extends (...args: never[]) => infer Return ? Return : never"
+        // );
     }
 }

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3197,4 +3197,28 @@ mod tests {
 
         infer_prog(src);
     }
+
+    #[test]
+    fn infer_infer_type() {
+        let src = r#"
+        type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
+        type GetReturnType<Type> = Type extends (...args: never[]) => infer Return
+            ? Return
+            : never;
+        "#;
+
+        let ctx = infer_prog(src);
+
+        let flatten = ctx.lookup_scheme("Flatten").unwrap();
+        assert_eq!(
+            format!("{flatten}"),
+            "<A>A extends Array<infer Item> ? Item : A"
+        );
+
+        let get_return = ctx.lookup_scheme("GetReturnType").unwrap();
+        assert_eq!(
+            format!("{get_return}"),
+            "<A>A extends (...args: never[]) => infer Return ? Return : never"
+        );
+    }
 }

--- a/crates/crochet_infer/src/scheme.rs
+++ b/crates/crochet_infer/src/scheme.rs
@@ -165,6 +165,7 @@ mod tests {
                     t: ctx.fresh_var(),
                 }),
             ],
+            is_interface: false,
         }));
 
         let env = Env::new();
@@ -193,6 +194,7 @@ mod tests {
                     t: tv,
                 }),
             ],
+            is_interface: false,
         }));
 
         let env = Env::new();
@@ -218,6 +220,7 @@ mod tests {
                     t: Type::from(TypeKind::Keyword(TKeyword::String)),
                 }),
             ],
+            is_interface: false,
         }));
 
         let env = Env::new();
@@ -312,6 +315,7 @@ mod tests {
                     t: Type::from(TypeKind::Keyword(TKeyword::String)),
                 }),
             ],
+            is_interface: false,
         }));
 
         let sc = Scheme {
@@ -348,6 +352,7 @@ mod tests {
                     })),
                 }),
             ],
+            is_interface: false,
         }));
 
         let sc = Scheme {
@@ -395,6 +400,7 @@ mod tests {
                     })),
                 }),
             ],
+            is_interface: false,
         }));
 
         let sc = Scheme {
@@ -435,6 +441,7 @@ mod tests {
                     })),
                 }),
             ],
+            is_interface: false,
         }));
 
         let sc = Scheme {

--- a/crates/crochet_infer/src/snapshots/crochet_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
+++ b/crates/crochet_infer/src/snapshots/crochet_infer__scheme__tests__instantiate_scheme_with_constrained_type_param.snap
@@ -53,6 +53,7 @@ Type {
                     },
                 ),
             ],
+            is_interface: false,
         },
     ),
     mutable: false,

--- a/crates/crochet_infer/src/substitutable.rs
+++ b/crates/crochet_infer/src/substitutable.rs
@@ -87,6 +87,7 @@ impl Substitutable for Type {
                 true_type.apply(sub);
                 false_type.apply(sub);
             }
+            TypeKind::InferType(_) => (),
         };
 
         norm_type(self)
@@ -148,6 +149,7 @@ impl Substitutable for Type {
                 result.append(&mut false_type.ftv());
                 result
             }
+            TypeKind::InferType(_) => vec![],
         }
     }
 }

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -16,7 +16,7 @@ use crate::unify_mut::unify_mut;
 use crate::util::*;
 
 // Returns Ok(substitions) if t2 admits all values from t1 and an Err() otherwise.
-pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &Context) -> Result<Subst, Vec<TypeError>> {
+pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, Vec<TypeError>> {
     // All binding must be done first
     match (&mut t1.kind, &mut t2.kind) {
         // If both are type variables...
@@ -730,7 +730,7 @@ fn bind(
     tv: &mut TVar,
     t: &mut Type,
     rel: Relation,
-    ctx: &Context,
+    ctx: &mut Context,
 ) -> Result<Subst, Vec<TypeError>> {
     // | t == TVar a     = return nullSubst
     // | occursCheck a t = throwError $ InfiniteType a t
@@ -829,26 +829,26 @@ mod tests {
 
     #[test]
     fn literals_are_subtypes_of_corresponding_keywords() -> Result<(), Vec<TypeError>> {
-        let ctx = Context::default();
+        let mut ctx = Context::default();
 
         let result = unify(
             &mut Type::from(num("5")),
             &mut Type::from(TypeKind::Keyword(TKeyword::Number)),
-            &ctx,
+            &mut ctx,
         )?;
         assert_eq!(result, Subst::default());
 
         let result = unify(
             &mut Type::from(str("hello")),
             &mut Type::from(TypeKind::Keyword(TKeyword::String)),
-            &ctx,
+            &mut ctx,
         )?;
         assert_eq!(result, Subst::default());
 
         let result = unify(
             &mut Type::from(bool(&true)),
             &mut Type::from(TypeKind::Keyword(TKeyword::Boolean)),
-            &ctx,
+            &mut ctx,
         )?;
         assert_eq!(result, Subst::default());
 
@@ -857,7 +857,7 @@ mod tests {
 
     #[test]
     fn object_subtypes() -> Result<(), Vec<TypeError>> {
-        let ctx = Context::default();
+        let mut ctx = Context::default();
 
         let elems = vec![
             types::TObjElem::Prop(types::TProp {
@@ -906,7 +906,7 @@ mod tests {
         ];
         let mut t2 = Type::from(TypeKind::Object(TObject { elems }));
 
-        let result = unify(&mut t1, &mut t2, &ctx)?;
+        let result = unify(&mut t1, &mut t2, &mut ctx)?;
         assert_eq!(result, Subst::default());
 
         Ok(())

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -580,14 +580,20 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, V
                         });
 
                     let s1 = unify(
-                        &mut Type::from(TypeKind::Object(TObject { elems: obj_elems })),
+                        &mut Type::from(TypeKind::Object(TObject {
+                            elems: obj_elems,
+                            is_interface: false,
+                        })),
                         obj_type,
                         ctx,
                     )?;
 
                     let rest_type = rest_types.get_mut(0).unwrap();
                     let s2 = unify(
-                        &mut Type::from(TypeKind::Object(TObject { elems: rest_elems })),
+                        &mut Type::from(TypeKind::Object(TObject {
+                            elems: rest_elems,
+                            is_interface: false,
+                        })),
                         rest_type,
                         ctx,
                     )?;
@@ -634,14 +640,20 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, V
 
                     let s_obj = unify(
                         obj_type,
-                        &mut Type::from(TypeKind::Object(TObject { elems: obj_elems })),
+                        &mut Type::from(TypeKind::Object(TObject {
+                            elems: obj_elems,
+                            is_interface: false,
+                        })),
                         ctx,
                     )?;
 
                     let rest_type = rest_types.get_mut(0).unwrap();
                     let s_rest = unify(
                         rest_type,
-                        &mut Type::from(TypeKind::Object(TObject { elems: rest_elems })),
+                        &mut Type::from(TypeKind::Object(TObject {
+                            elems: rest_elems,
+                            is_interface: false,
+                        })),
                         ctx,
                     )?;
 
@@ -652,20 +664,6 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, V
             }
         }
         (TypeKind::Ref(alias1), TypeKind::Ref(alias2)) => {
-            // If `alias1` points to another TypeKind::Ref(_), unwrap that ref.
-            if let Ok(mut t) = ctx.lookup_type(&alias1.name, false) {
-                if let TypeKind::Ref(_) = &t.kind {
-                    return unify(&mut t, t2, ctx);
-                }
-            }
-
-            // If `alias2` points to another TypeKind::Ref(_), unwrap that ref.
-            if let Ok(mut t) = ctx.lookup_type(&alias2.name, false) {
-                if let TypeKind::Ref(_) = &t.kind {
-                    return unify(t1, &mut t, ctx);
-                }
-            }
-
             if alias1.name == alias2.name {
                 eprintln!("unifying aliases {alias1} with {alias2}");
                 match (&mut alias1.type_args, &mut alias2.type_args) {
@@ -897,7 +895,10 @@ mod tests {
                 t: Type::from(TypeKind::Keyword(TKeyword::String)),
             }),
         ];
-        let mut t1 = Type::from(TypeKind::Object(TObject { elems }));
+        let mut t1 = Type::from(TypeKind::Object(TObject {
+            elems,
+            is_interface: false,
+        }));
 
         let elems = vec![
             types::TObjElem::Prop(types::TProp {
@@ -921,7 +922,10 @@ mod tests {
                 t: Type::from(TypeKind::Keyword(TKeyword::String)),
             }),
         ];
-        let mut t2 = Type::from(TypeKind::Object(TObject { elems }));
+        let mut t2 = Type::from(TypeKind::Object(TObject {
+            elems,
+            is_interface: false,
+        }));
 
         let result = unify(&mut t1, &mut t2, &mut ctx)?;
         assert_eq!(result, Subst::default());

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -358,6 +358,10 @@ pub fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
             update_type_ann(consequent, s);
             update_type_ann(alternate, s);
         }
+        // NOTE: "infer" types have no type annotation to update.  Their sole
+        // purpose is to introduce a type binding which is scoped to the containing
+        // conditional type.
+        TypeAnnKind::Infer(_) => (),
     }
 }
 

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -208,7 +208,10 @@ pub fn normalize(t: &Type, ctx: &Context) -> Type {
                         TObjElem::Setter(_) => todo!(),
                     })
                     .collect();
-                TypeKind::Object(TObject { elems })
+                TypeKind::Object(TObject {
+                    elems,
+                    is_interface: obj.is_interface,
+                })
             }
             TypeKind::Ref(TRef { name, type_args }) => {
                 let type_args = type_args
@@ -351,7 +354,10 @@ pub fn simplify_intersection(in_types: &[Type]) -> Type {
     let mut out_types = vec![];
     out_types.append(&mut not_obj_types);
     if !elems.is_empty() {
-        out_types.push(Type::from(TypeKind::Object(TObject { elems })));
+        out_types.push(Type::from(TypeKind::Object(TObject {
+            elems,
+            is_interface: false,
+        })));
     }
     // TODO: figure out a consistent way to sort types
     // out_types.sort_by_key(|t| t.id); // ensure a stable order
@@ -645,7 +651,10 @@ pub fn replace_aliases_rec(t: &Type, type_param_map: &HashMap<String, Type>) -> 
                     }
                 })
                 .collect();
-            TypeKind::Object(TObject { elems })
+            TypeKind::Object(TObject {
+                elems,
+                is_interface: obj.is_interface,
+            })
         }
         TypeKind::Ref(alias) => match type_param_map.get(&alias.name) {
             Some(t) => {
@@ -774,7 +783,10 @@ pub fn immutable_obj_type(obj: &TObject) -> Option<TObject> {
         .collect();
 
     if changed {
-        Some(TObject { elems })
+        Some(TObject {
+            elems,
+            is_interface: obj.is_interface,
+        })
     } else {
         None
     }

--- a/crates/crochet_infer/src/visitor.rs
+++ b/crates/crochet_infer/src/visitor.rs
@@ -5,7 +5,7 @@ pub trait Visitor {
 
     fn visit_children(&mut self, t: &mut Type) {
         match &mut t.kind {
-            TypeKind::Var(_) => (), // no children
+            TypeKind::Var(_) => (), // leaf node
             TypeKind::App(app) => {
                 app.args.iter_mut().for_each(|arg| self.visit_children(arg));
                 self.visit_children(app.ret.as_mut());
@@ -30,8 +30,8 @@ pub trait Visitor {
                     .for_each(|TFnParam { t, .. }| self.visit_children(t));
                 self.visit_children(lam.ret.as_mut());
             }
-            TypeKind::Lit(_) => (),     // no children
-            TypeKind::Keyword(_) => (), // no children
+            TypeKind::Lit(_) => (),     // leaf node
+            TypeKind::Keyword(_) => (), // leaf node
             TypeKind::Union(types) => {
                 types.iter_mut().for_each(|t| self.visit_children(t));
             }
@@ -49,7 +49,7 @@ pub trait Visitor {
             }
             TypeKind::Array(t) => self.visit_children(t),
             TypeKind::Rest(t) => self.visit_children(t),
-            TypeKind::This => (), // no children
+            TypeKind::This => (), // leaf node
             TypeKind::KeyOf(t) => self.visit_children(t),
             TypeKind::IndexAccess(access) => {
                 self.visit_children(&mut access.object);
@@ -69,6 +69,7 @@ pub trait Visitor {
                 self.visit_children(true_type);
                 self.visit_children(false_type);
             }
+            TypeKind::InferType(_) => (), // leaf node
         }
 
         self.visit_type(t);

--- a/crates/crochet_infer/src/visitor.rs
+++ b/crates/crochet_infer/src/visitor.rs
@@ -1,5 +1,6 @@
 use crochet_ast::types::*;
 
+// TODO: rename this to VisitorMut and create a non-mutable Visitor
 pub trait Visitor {
     fn visit_type(&mut self, t: &mut Type);
 

--- a/crates/crochet_lsp/src/semantic_tokens.rs
+++ b/crates/crochet_lsp/src/semantic_tokens.rs
@@ -129,6 +129,7 @@ impl Visitor for SemanticTokenVisitor {
             crochet_ast::values::TypeAnnKind::IndexedAccess(_) => None,
             crochet_ast::values::TypeAnnKind::Mapped(_) => None,
             crochet_ast::values::TypeAnnKind::Conditional(_) => None,
+            crochet_ast::values::TypeAnnKind::Infer(_) => None,
             // TODO: figure out how to get the SourceLocation for just the `mut`
             // modifier
             crochet_ast::values::TypeAnnKind::Mutable(_) => None,

--- a/crates/crochet_lsp/src/visitor.rs
+++ b/crates/crochet_lsp/src/visitor.rs
@@ -104,25 +104,26 @@ pub trait Visitor {
         self.visit_type_ann(type_ann);
 
         match &mut type_ann.kind {
-            TypeAnnKind::Lam(_) => (),
-            TypeAnnKind::Lit(_) => (),
-            TypeAnnKind::Keyword(_) => (),
-            TypeAnnKind::Object(_) => (),
-            TypeAnnKind::TypeRef(_) => (),
-            TypeAnnKind::Union(_) => (),
-            TypeAnnKind::Intersection(_) => (),
+            TypeAnnKind::Lam(_) => (),          // TODO: visit
+            TypeAnnKind::Lit(_) => (),          // leaf node
+            TypeAnnKind::Keyword(_) => (),      // leaf node
+            TypeAnnKind::Object(_) => (),       // TODO: visit
+            TypeAnnKind::TypeRef(_) => (),      // leaf node
+            TypeAnnKind::Union(_) => (),        // TODO: visit
+            TypeAnnKind::Intersection(_) => (), // TODO: visit
             TypeAnnKind::Tuple(TupleType { types }) => {
                 types.iter_mut().for_each(|t| self._visit_type_ann(t))
             }
             TypeAnnKind::Array(ArrayType { elem_type }) => {
                 self._visit_type_ann(elem_type);
             }
-            TypeAnnKind::KeyOf(_) => (),
-            TypeAnnKind::Query(_) => (),
-            TypeAnnKind::IndexedAccess(_) => (),
-            TypeAnnKind::Mapped(_) => (),
-            TypeAnnKind::Conditional(_) => (),
-            TypeAnnKind::Mutable(_) => (),
+            TypeAnnKind::KeyOf(_) => (),         // TODO: visit
+            TypeAnnKind::Query(_) => (),         // leaf node
+            TypeAnnKind::IndexedAccess(_) => (), // TODO: visit
+            TypeAnnKind::Mapped(_) => (),        // ?
+            TypeAnnKind::Conditional(_) => (),   // TODO: visit
+            TypeAnnKind::Mutable(_) => (),       // TODO: visit
+            TypeAnnKind::Infer(_) => (),         // leaf node
         }
     }
 

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__conditional_types-2.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__conditional_types-2.snap
@@ -1,0 +1,181 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(\"type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;\")"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        column: 66,
+                    },
+                },
+                span: 0..66,
+                declare: false,
+                id: Ident {
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 0,
+                            column: 5,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 12,
+                        },
+                    },
+                    span: 5..12,
+                    name: "Flatten",
+                },
+                type_ann: TypeAnn {
+                    kind: Conditional(
+                        ConditionalType {
+                            check_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Type",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 21,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 25,
+                                    },
+                                },
+                                span: 21..25,
+                                inferred_type: None,
+                            },
+                            extends_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Array",
+                                        type_args: Some(
+                                            [
+                                                TypeAnn {
+                                                    kind: Infer(
+                                                        InferType {
+                                                            name: "Item",
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 40,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 50,
+                                                        },
+                                                    },
+                                                    span: 40..50,
+                                                    inferred_type: None,
+                                                },
+                                            ],
+                                        ),
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 34,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 51,
+                                    },
+                                },
+                                span: 34..51,
+                                inferred_type: None,
+                            },
+                            true_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Item",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 54,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 58,
+                                    },
+                                },
+                                span: 54..58,
+                                inferred_type: None,
+                            },
+                            false_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Type",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 61,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 65,
+                                    },
+                                },
+                                span: 61..65,
+                                inferred_type: None,
+                            },
+                        },
+                    ),
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 0,
+                            column: 21,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 65,
+                        },
+                    },
+                    span: 21..65,
+                    inferred_type: None,
+                },
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 13..17,
+                            name: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 13,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 17,
+                                    },
+                                },
+                                span: 13..17,
+                                name: "Type",
+                            },
+                            constraint: None,
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)

--- a/crates/crochet_parser/src/snapshots/crochet_parser__tests__conditional_types-3.snap
+++ b/crates/crochet_parser/src/snapshots/crochet_parser__tests__conditional_types-3.snap
@@ -1,0 +1,267 @@
+---
+source: crates/crochet_parser/src/lib.rs
+expression: "parse(r#\"type GetReturnType<Type> = Type extends (...args: never[]) => infer Return\n                ? Return\n                : never;\n        \"#)"
+---
+Ok(
+    Program {
+        body: [
+            TypeDecl {
+                loc: SourceLocation {
+                    start: Position {
+                        line: 0,
+                        column: 0,
+                    },
+                    end: Position {
+                        line: 2,
+                        column: 24,
+                    },
+                },
+                span: 0..124,
+                declare: false,
+                id: Ident {
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 0,
+                            column: 5,
+                        },
+                        end: Position {
+                            line: 0,
+                            column: 18,
+                        },
+                    },
+                    span: 5..18,
+                    name: "GetReturnType",
+                },
+                type_ann: TypeAnn {
+                    kind: Conditional(
+                        ConditionalType {
+                            check_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Type",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 27,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 31,
+                                    },
+                                },
+                                span: 27..31,
+                                inferred_type: None,
+                            },
+                            extends_type: TypeAnn {
+                                kind: Lam(
+                                    LamType {
+                                        params: [
+                                            TypeAnnFnParam {
+                                                pat: Pattern {
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 41,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 48,
+                                                        },
+                                                    },
+                                                    span: 41..48,
+                                                    kind: Rest(
+                                                        RestPat {
+                                                            arg: Pattern {
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 44,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 48,
+                                                                    },
+                                                                },
+                                                                span: 44..48,
+                                                                kind: Ident(
+                                                                    BindingIdent {
+                                                                        name: "args",
+                                                                        mutable: false,
+                                                                        span: 44..48,
+                                                                        loc: SourceLocation {
+                                                                            start: Position {
+                                                                                line: 0,
+                                                                                column: 44,
+                                                                            },
+                                                                            end: Position {
+                                                                                line: 0,
+                                                                                column: 48,
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ),
+                                                    inferred_type: None,
+                                                },
+                                                type_ann: TypeAnn {
+                                                    kind: Array(
+                                                        ArrayType {
+                                                            elem_type: TypeAnn {
+                                                                kind: Keyword(
+                                                                    KeywordType {
+                                                                        keyword: Never,
+                                                                    },
+                                                                ),
+                                                                loc: SourceLocation {
+                                                                    start: Position {
+                                                                        line: 0,
+                                                                        column: 50,
+                                                                    },
+                                                                    end: Position {
+                                                                        line: 0,
+                                                                        column: 55,
+                                                                    },
+                                                                },
+                                                                span: 50..55,
+                                                                inferred_type: None,
+                                                            },
+                                                        },
+                                                    ),
+                                                    loc: SourceLocation {
+                                                        start: Position {
+                                                            line: 0,
+                                                            column: 50,
+                                                        },
+                                                        end: Position {
+                                                            line: 0,
+                                                            column: 57,
+                                                        },
+                                                    },
+                                                    span: 50..57,
+                                                    inferred_type: None,
+                                                },
+                                                optional: false,
+                                            },
+                                        ],
+                                        ret: TypeAnn {
+                                            kind: Infer(
+                                                InferType {
+                                                    name: "Return",
+                                                },
+                                            ),
+                                            loc: SourceLocation {
+                                                start: Position {
+                                                    line: 0,
+                                                    column: 62,
+                                                },
+                                                end: Position {
+                                                    line: 0,
+                                                    column: 74,
+                                                },
+                                            },
+                                            span: 62..74,
+                                            inferred_type: None,
+                                        },
+                                        type_params: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 40,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 74,
+                                    },
+                                },
+                                span: 40..74,
+                                inferred_type: None,
+                            },
+                            true_type: TypeAnn {
+                                kind: TypeRef(
+                                    TypeRef {
+                                        name: "Return",
+                                        type_args: None,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 1,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 1,
+                                        column: 24,
+                                    },
+                                },
+                                span: 93..99,
+                                inferred_type: None,
+                            },
+                            false_type: TypeAnn {
+                                kind: Keyword(
+                                    KeywordType {
+                                        keyword: Never,
+                                    },
+                                ),
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 2,
+                                        column: 18,
+                                    },
+                                    end: Position {
+                                        line: 2,
+                                        column: 23,
+                                    },
+                                },
+                                span: 118..123,
+                                inferred_type: None,
+                            },
+                        },
+                    ),
+                    loc: SourceLocation {
+                        start: Position {
+                            line: 0,
+                            column: 27,
+                        },
+                        end: Position {
+                            line: 2,
+                            column: 23,
+                        },
+                    },
+                    span: 27..123,
+                    inferred_type: None,
+                },
+                type_params: Some(
+                    [
+                        TypeParam {
+                            span: 19..23,
+                            name: Ident {
+                                loc: SourceLocation {
+                                    start: Position {
+                                        line: 0,
+                                        column: 19,
+                                    },
+                                    end: Position {
+                                        line: 0,
+                                        column: 23,
+                                    },
+                                },
+                                span: 19..23,
+                                name: "Type",
+                            },
+                            constraint: None,
+                            default: None,
+                        },
+                    ],
+                ),
+            },
+        ],
+    },
+)


### PR DESCRIPTION
TODO:
- [x] update unify.rs and expand_type.rs to make `ctx` a mutable reference

It turned out that this wasn't actually the way to implement support for `infer`.
- ~update `expand_conditional_type()` to add a new scope~
- ~update `expand_type` to insert a type binding when handling `TypeKind::InferType`~