### PR TITLE
Infer new-expressions as immutable

### DIFF
--- a/crates/crochet/tests/pass/new_expressions.d.ts
+++ b/crates/crochet/tests/pass/new_expressions.d.ts
@@ -1,2 +1,2 @@
-export declare const letters: "a" | "b" | "c"[];
-export declare const numbers: 1 | 2 | 3[];
+export declare const letters: readonly "a" | "b" | "c"[];
+export declare const numbers: readonly 1 | 2 | 3[];

--- a/crates/crochet_dts/tests/integration_test.rs
+++ b/crates/crochet_dts/tests/integration_test.rs
@@ -665,7 +665,7 @@ fn new_expressions() {
 
     let t = ctx.lookup_value("array").unwrap();
     let result = format!("{}", t);
-    assert_eq!(result, "mut 1 | 2 | 3[]");
+    assert_eq!(result, "1 | 2 | 3[]");
 }
 
 #[test]
@@ -679,11 +679,11 @@ fn new_expressions_instantiation_check() {
 
     let t = ctx.lookup_value("numbers").unwrap();
     let result = format!("{}", t);
-    assert_eq!(result, "mut 1 | 2 | 3[]");
+    assert_eq!(result, "1 | 2 | 3[]");
 
     let t = ctx.lookup_value("letters").unwrap();
     let result = format!("{}", t);
-    assert_eq!(result, r#"mut "a" | "b" | "c"[]"#);
+    assert_eq!(result, r#""a" | "b" | "c"[]"#);
 }
 
 #[test]

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3085,7 +3085,7 @@ mod tests {
         let foo_num: mut Foo<number> = new Foo<number>();
         foo_num.set_msg(5);
         let foo_str = new Foo<string>();
-        foo_str.set_msg("hello");
+        let msg: string = foo_str.get_msg();
         "#;
 
         infer_prog(src);

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -3082,7 +3082,7 @@ mod tests {
             }
         }
 
-        let foo_num = new Foo<number>();
+        let foo_num: mut Foo<number> = new Foo<number>();
         foo_num.set_msg(5);
         let foo_str = new Foo<string>();
         foo_str.set_msg("hello");

--- a/crates/crochet_infer/src/unify.rs
+++ b/crates/crochet_infer/src/unify.rs
@@ -68,7 +68,7 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, V
         // is a literal, e.g. 1 + 2, but not something that calls a function or contains
         // variables.
         // NOTE: this is different from what a hypothetical `isConstExpr` would return
-        // which is similar, but call also contain:
+        // which is similar, but can also contain:
         // - binders that have been assigned const expressions
         // - pure function calls with args that are const expressions
         match &t1.provenance {
@@ -76,6 +76,7 @@ pub fn unify(t1: &mut Type, t2: &mut Type, ctx: &mut Context) -> Result<Subst, V
                 types::Provenance::Expr(e) => match e.kind {
                     ExprKind::Obj(_) => return Ok(Subst::new()),
                     ExprKind::Tuple(_) => return Ok(Subst::new()),
+                    ExprKind::New(_) => return Ok(Subst::new()),
                     _ => (),
                 },
                 types::Provenance::Pattern(_) => (),


### PR DESCRIPTION
In keeping with Crochet's "immutable by default" philosophy, this PR updates Crochet to infer `new` expressions as immutable.  We allow `new` expressions to be assigned to l-values that are type as immutable (similar to what we do for array and object literals), but all other immutable references may not be used as mutable ones.
