### PR TITLE
Switch back to using immutable references in unify() and infer_expr()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,7 @@ dependencies = [
  "crochet_ast",
  "crochet_parser",
  "defaultmap",
+ "im",
  "insta",
  "itertools",
 ]
@@ -570,6 +580,20 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "indexmap"
@@ -1032,6 +1056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1220,16 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "smallvec"

--- a/crates/crochet_infer/Cargo.toml
+++ b/crates/crochet_infer/Cargo.toml
@@ -11,6 +11,7 @@ crochet_ast = { version = "0.1.0", path = "../crochet_ast" }
 array_tool = "1.0.3"
 defaultmap = "0.5.0"
 itertools = "0.10.3"
+im = "15.1.0"
 
 [dev-dependencies]
 crochet_parser = { version = "0.1.0", path = "../crochet_parser" }

--- a/crates/crochet_infer/src/context.rs
+++ b/crates/crochet_infer/src/context.rs
@@ -36,6 +36,14 @@ pub struct Context {
     pub state: State,
 }
 
+// #[derive(Clone, Debug)]
+// pub struct Context {
+//     pub values: HashMap<String, Binding>,
+//     pub types: HashMap<String, Scheme>,
+//     pub is_async: bool,
+//     pub count: Cell<i32>,
+// }
+
 impl Default for Context {
     fn default() -> Self {
         Self {
@@ -66,8 +74,15 @@ impl Context {
 
     pub fn apply(&mut self, s: &Subst) {
         let current_scope = self.scopes.last_mut().unwrap();
-        for (_, b) in current_scope.values.iter_mut() {
-            b.apply(s);
+        for (k, b) in current_scope.values.clone() {
+            // Should we be apply substitions to types as well?
+            current_scope.values.insert(
+                k.to_owned(),
+                Binding {
+                    mutable: b.mutable,
+                    t: b.t.apply(s),
+                },
+            );
         }
     }
 

--- a/crates/crochet_infer/src/expand_type.rs
+++ b/crates/crochet_infer/src/expand_type.rs
@@ -214,7 +214,7 @@ fn expand_conditional_type(
         false_type,
     } = cond;
 
-    let mut check_type = check_type.clone();
+    let check_type = check_type.clone();
     let mut extends_type = extends_type.clone();
 
     let infer_types = find_infer_types(&mut extends_type);
@@ -226,11 +226,11 @@ fn expand_conditional_type(
 
     replace_infer_types(&mut extends_type, &type_param_map);
 
-    let t = match unify(&mut check_type, &mut extends_type, ctx) {
+    let t = match unify(&check_type, &extends_type, ctx) {
         Ok(s) => {
-            let mut true_type = replace_aliases_rec(true_type, &type_param_map);
-            true_type.apply(&s);
-            Box::from(true_type)
+            let true_type = replace_aliases_rec(true_type, &type_param_map);
+            let t = true_type.apply(&s);
+            Box::from(t)
         }
         Err(_) => false_type.to_owned(),
     };

--- a/crates/crochet_infer/src/infer.rs
+++ b/crates/crochet_infer/src/infer.rs
@@ -121,8 +121,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
                 ..
             } => match infer_type_ann(type_ann, ctx, type_params) {
                 Ok((s, t)) => {
-                    let mut t = t.clone();
-                    t.apply(&s);
+                    let t = t.apply(&s);
 
                     let empty_env = Env::default();
                     let scheme = generalize(&empty_env, &t);
@@ -149,8 +148,7 @@ pub fn infer_prog(prog: &mut Program, ctx: &mut Context) -> Result<Context, Vec<
             } => {
                 let (s, t) = infer_class(ctx, class)?;
 
-                let mut t = t.clone();
-                t.apply(&s);
+                let t = t.apply(&s);
 
                 // This follows the same pattern found in lib.es5.d.ts.
                 let name = ident.name.to_owned();

--- a/crates/crochet_infer/src/infer_type_ann.rs
+++ b/crates/crochet_infer/src/infer_type_ann.rs
@@ -326,7 +326,7 @@ fn infer_type_ann_rec(
                 // QUESTION: Do we need to apply `constraint_s` to `type_ann_t`?
                 type_ann.inferred_type = Some(type_ann_t.clone());
 
-                let mut t = Type::from(TypeKind::MappedType(TMappedType {
+                let t = Type::from(TypeKind::MappedType(TMappedType {
                     type_param: types::TypeParam {
                         name: type_param.name.name.to_owned(),
                         constraint: Some(Box::from(constraint_t)),
@@ -344,7 +344,7 @@ fn infer_type_ann_rec(
                 }));
 
                 let s = compose_subs(&type_ann_s, &constraint_s);
-                t.apply(&s); // I think we can skip this
+                let t = t.apply(&s); // I think we can skip this
 
                 Ok((s, t))
             } else {

--- a/crates/crochet_infer/src/lib.rs
+++ b/crates/crochet_infer/src/lib.rs
@@ -2174,6 +2174,7 @@ mod tests {
         infer_prog(src);
     }
 
+    // NOTE: This test relies on the proper functioning of Context#apply()
     #[test]
     fn infer_fn_based_on_multiple_different_calls() {
         let src = r#"let h = (f, x, y) => f(x) + f(y);"#;

--- a/crates/crochet_infer/src/scheme.rs
+++ b/crates/crochet_infer/src/scheme.rs
@@ -65,12 +65,8 @@ pub fn generalize(env: &Env, t: &Type) -> Scheme {
 
     let (sub, type_params) = get_sub_and_type_params(&tvars);
 
-    // TODO: Consider not cloning here once we have some tests in place
-    let mut t = t.clone();
-    t.apply(&sub);
-
     Scheme {
-        t: Box::from(t),
+        t: Box::from(t.apply(&sub)),
         type_params,
     }
 }

--- a/crates/crochet_infer/src/update.rs
+++ b/crates/crochet_infer/src/update.rs
@@ -6,9 +6,9 @@ use crate::substitutable::{Subst, Substitutable};
 pub fn update_pattern(pattern: &mut Pattern, s: &Subst) {
     // Since we process the node first, if `expr` is a leaf node we
     // ignore it in the match statement below.
-    if let Some(t) = &mut pattern.inferred_type {
+    if let Some(t) = &pattern.inferred_type {
         if let TypeKind::Var(_) = &t.kind {
-            t.apply(s)
+            pattern.inferred_type = Some(t.apply(s));
         }
     }
 
@@ -64,7 +64,7 @@ pub fn update_expr(expr: &mut Expr, s: &Subst) {
     // ignore it in the match statement below.
     if let Some(t) = &mut expr.inferred_type {
         if let TypeKind::Var(_) = &t.kind {
-            t.apply(s);
+            expr.inferred_type = Some(t.apply(s));
         }
     }
 
@@ -273,7 +273,7 @@ pub fn update_type_ann(type_ann: &mut TypeAnn, s: &Subst) {
     // ignore it in the match statement below.
     if let Some(t) = &mut type_ann.inferred_type {
         if let TypeKind::Var(_) = &t.kind {
-            t.apply(s);
+            type_ann.inferred_type = Some(t.apply(s));
         }
     }
 

--- a/crates/crochet_infer/src/util.rs
+++ b/crates/crochet_infer/src/util.rs
@@ -27,8 +27,7 @@ fn get_mapping(t: &Type) -> HashMap<i32, Type> {
 }
 
 pub fn close_over(s: &Subst, t: &Type, ctx: &Context) -> Type {
-    let mut t = t.clone();
-    t.apply(s);
+    let t = t.apply(s);
 
     let tvs = t.ftv();
 
@@ -63,7 +62,7 @@ pub fn close_over(s: &Subst, t: &Type, ctx: &Context) -> Type {
                     char_code += 1;
                 }
 
-                let mut t = Type::from(TypeKind::Lam(TLam {
+                let t = Type::from(TypeKind::Lam(TLam {
                     params: params.to_owned(),
                     ret: ret.to_owned(),
                     type_params: if type_params.is_empty() {
@@ -73,9 +72,7 @@ pub fn close_over(s: &Subst, t: &Type, ctx: &Context) -> Type {
                     },
                 }));
 
-                t.apply(&sub);
-
-                t
+                t.apply(&sub)
             }
             _ => {
                 panic!("We shouldn't have any free type variables when closing over non-lambdas")
@@ -443,8 +440,7 @@ pub fn compose_subs(s2: &Subst, s1: &Subst) -> Subst {
     let mut result: Subst = s1
         .iter()
         .map(|(tv, t)| {
-            let mut t = t.clone();
-            t.apply(s2);
+            let t = t.apply(s2);
             (*tv, t)
         })
         .collect();
@@ -467,8 +463,7 @@ fn compose_subs_with_context(s1: &Subst, s2: &Subst) -> Subst {
     let mut result: Subst = s2
         .iter()
         .map(|(tv, t)| {
-            let mut t = t.clone();
-            t.apply(s1);
+            let t = t.apply(s1);
             (*tv, t)
         })
         .collect();

--- a/crates/crochet_interop/src/parse.rs
+++ b/crates/crochet_interop/src/parse.rs
@@ -441,7 +441,7 @@ fn infer_method_sig(
         char_code += 1;
     }
 
-    let mut elem = types::TObjElem::Method(types::TMethod {
+    let elem = types::TObjElem::Method(types::TMethod {
         name: TPropKey::StringKey(name),
         params,
         ret: Box::from(ret),
@@ -456,9 +456,9 @@ fn infer_method_sig(
         is_mutating: obj_is_mutable,
     });
 
-    elem.apply(&sub);
+    let t = elem.apply(&sub);
 
-    Ok(elem)
+    Ok(t)
 }
 
 fn get_key_name(key: &Expr) -> Result<String, String> {
@@ -511,8 +511,8 @@ fn infer_callable(
     type_params: &Option<Box<TsTypeParamDecl>>,
     ctx: &Context,
 ) -> Result<TCallable, String> {
-    let mut params = infer_fn_params(params, ctx)?;
-    let mut ret = infer_ts_type_ann(type_ann, ctx)?;
+    let params = infer_fn_params(params, ctx)?;
+    let ret = infer_ts_type_ann(type_ann, ctx)?;
     let mut type_params = get_type_params(type_params, ctx)?;
 
     let mut tvars = params.ftv();
@@ -523,8 +523,8 @@ fn infer_callable(
         type_params.append(&mut more_type_params);
     }
 
-    params.apply(&sub);
-    ret.apply(&sub);
+    let params = params.apply(&sub);
+    let ret = ret.apply(&sub);
 
     Ok(TCallable {
         params,


### PR DESCRIPTION
I want to try using `im` for the hash maps in `Context`, but in order to do so, `.apply()` can't be mutating.