### PR TITLE
Stop using derivative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,6 @@ dependencies = [
 name = "crochet_ast"
 version = "0.1.0"
 dependencies = [
- "derivative",
  "itertools",
  "swc_atoms",
  "swc_common",
@@ -431,17 +430,6 @@ name = "defaultmap"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c4d4fbd66561c3acff86b297b024826505a715eb1b0984a78013b349d0e834"
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "diff"

--- a/crates/crochet_ast/Cargo.toml
+++ b/crates/crochet_ast/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derivative = "2.2.0"
 itertools = "0.10.3"
 # TODO: hide these behind a feature and then only use that feature in the codegen crate
 swc_atoms = "0.4.21"

--- a/crates/crochet_ast/src/types/binding.rs
+++ b/crates/crochet_ast/src/types/binding.rs
@@ -1,11 +1,9 @@
-use derivative::*;
 use std::fmt;
 
 // TODO: have a separate struct for BindingIdents in types so that
 // we don't have to create spans for things that don't need them.
 // TODO: add an `ident` field so that we can have separate spans
-#[derive(Derivative)]
-#[derivative(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BindingIdent {
     pub name: String,
     pub mutable: bool,

--- a/crates/crochet_ast/src/types/type.rs
+++ b/crates/crochet_ast/src/types/type.rs
@@ -1,5 +1,5 @@
-use derivative::*;
 use itertools::{join, Itertools};
+use std::cmp::Ordering;
 use std::fmt;
 
 use crate::types::keyword::TKeyword;
@@ -127,15 +127,35 @@ pub enum TypeKind {
     // Query, // use for typed holes
 }
 
-#[derive(Derivative)]
-#[derivative(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq)]
 pub struct Type {
     pub kind: TypeKind,
     pub mutable: bool,
-    #[derivative(PartialOrd = "ignore")]
-    #[derivative(Ord = "ignore")]
-    #[derivative(PartialEq = "ignore")] // we don't care about provenance when comparing types
     pub provenance: Option<Box<Provenance>>,
+}
+
+impl PartialOrd for Type {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Type {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let result = self.kind.cmp(&other.kind);
+
+        if result == Ordering::Equal {
+            self.mutable.cmp(&other.mutable)
+        } else {
+            result
+        }
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.mutable == other.mutable
+    }
 }
 
 impl From<TypeKind> for Type {

--- a/crates/crochet_ast/src/values/ident.rs
+++ b/crates/crochet_ast/src/values/ident.rs
@@ -1,4 +1,4 @@
-use derivative::*;
+use std::cmp::Ordering;
 use std::fmt;
 use swc_atoms::JsWord;
 use swc_common::{self, BytePos, SyntaxContext};
@@ -49,17 +49,30 @@ impl From<&BindingIdent> for swc_ecma_ast::Ident {
 // TODO: have a separate struct for BindingIdents in types so that
 // we don't have to create spans for things that don't need them.
 // TODO: add an `ident` field so that we can have separate spans
-#[derive(Derivative)]
-#[derivative(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BindingIdent {
     pub name: String,
     pub mutable: bool,
-    #[derivative(PartialOrd = "ignore")]
-    #[derivative(Ord = "ignore")]
     pub span: Span,
-    #[derivative(PartialOrd = "ignore")]
-    #[derivative(Ord = "ignore")]
     pub loc: SourceLocation,
+}
+
+impl PartialOrd for BindingIdent {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BindingIdent {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let result = self.name.cmp(&other.name);
+
+        if result == Ordering::Equal {
+            self.mutable.cmp(&other.mutable)
+        } else {
+            result
+        }
+    }
 }
 
 impl fmt::Display for BindingIdent {


### PR DESCRIPTION
We only use it in a couple of places and it's incompatible with `derive-visitor` which is arguably more useful.